### PR TITLE
v9 compatibility fix

### DIFF
--- a/css/emu.css
+++ b/css/emu.css
@@ -1,25 +1,236 @@
-body.-emu .dialog .tabs a, body.-emu .dialog .sheet-tabs a, body.-emu #sidebar .tabs a, body.-emu #sidebar .sheet-tabs a, body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .tabs a, body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .sheet-tabs a, body.-emu #module-management .list-filters a, body.-emu .dialog button,
+body.-emu .dialog .tabs a,
+body.-emu .dialog .sheet-tabs a,
+body.-emu #sidebar .tabs a,
+body.-emu #sidebar .sheet-tabs a,
+body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .tabs a,
+body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .sheet-tabs a,
+body.-emu #module-management .list-filters a,
+body.-emu .dialog button,
 body.-emu #sidebar button,
-body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) button, body.-emu #menu #menu-items li, body.-emu #sidebar #combat #combat-controls .combat-control,
-body.-emu .sidebar-popout #combat #combat-controls .combat-control, body.-emu .filepicker.window-app .display-modes .display-mode, body.-emu .journal-sheet.sheet.window-app .window-content .editor-edit, body.-emu #calendar-time-container .calendar--time-controls .advance-btn,
-body.-emu #calendar-weather-container .calendar--time-controls .advance-btn, body.-emu #sidebar #combat .add-temporary,
-body.-emu .sidebar-popout #combat .add-temporary, body.-emu .window-app[id*="ActiveEffects-"] .window-content > form li.filter-item, body.-emu #specials-config .fxmaster .directory-header a, body.-emu .moulinette-options li, body.-emu #moulinette.forge .filepicker .display-modes a, body.-emu #OneJournalShell.window-app .history-navigation a, body.-emu ul.command-menu li, body.-emu #token-action-hud button.tah-title-button,
-body.-emu #token-action-hud .tah-action button, body.-emu #sidebar .token-mold > label > span,
-body.-emu .sidebar-popout .token-mold > label > span, .-emu-layout body.-emu .sheet.active-effect-sheet .effects-header a, body.-emu .sheet.active-effect-sheet .-emu-layout .effects-header a, .-emu-layout body.-emu .sheet.roll-table-config .table-results .table-header a, body.-emu .sheet.roll-table-config .table-results .-emu-layout .table-header a, .-emu-layout body.-emu .dice-so-nice section.content .settings-list .sfxs-list .sfx-header a, body.-emu .dice-so-nice section.content .settings-list .sfxs-list .-emu-layout .sfx-header a, .-emu-layout body.-emu .window-app[id*="ActiveEffects-"] .window-content > form .dnd5e.sheet.item .effect-header a, body.-emu .window-app[id*="ActiveEffects-"] .window-content > form .dnd5e.sheet.item .-emu-layout .effect-header a, .-emu-layout body.-emu .sheet.active-effect-sheet .changes-list li a, body.-emu .sheet.active-effect-sheet .changes-list .-emu-layout li a, .-emu-layout body.-emu .sheet.roll-table-config .table-results .table-result a, body.-emu .sheet.roll-table-config .table-results .-emu-layout .table-result a, .-emu-layout body.-emu .dice-so-nice section.content .settings-list .sfxs-list .sfx a, body.-emu .dice-so-nice section.content .settings-list .sfxs-list .-emu-layout .sfx a, body.-emu .dialog .directory .directory-item.folder .folder-header .create-folder,
-body.-emu .dialog .directory .directory-item.folder .folder-header .create-entity,
-body.-emu #sidebar .directory .directory-item.folder .folder-header .create-folder,
-body.-emu #sidebar .directory .directory-item.folder .folder-header .create-entity,
-body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .directory .directory-item.folder .folder-header .create-folder,
-body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .directory .directory-item.folder .folder-header .create-entity, body.-emu #navigation #nav-toggle, .-emu-layout body.-emu .window-app .window-header > a, .-emu-layout body.-emu .window-app .window-header a.header-button, .-emu-layout body.-emu #sidebar #chat #chat-log .message .button.message-delete, .-emu-layout body.-emu .sidebar-popout #chat #chat-log .message .button.message-delete, .-emu-layout body.-emu #sidebar #chat #chat-controls .chat-control-icon .fa-dice-d20, .-emu-layout body.-emu .sidebar-popout #chat #chat-controls .chat-control-icon .fa-dice-d20, .-emu-layout body.-emu #sidebar #chat #chat-controls .control-buttons .button, .-emu-layout body.-emu .sidebar-popout #chat #chat-controls .control-buttons .button, body.-emu #sidebar #combat #combat-round .encounters a,
-body.-emu .sidebar-popout #combat #combat-round .encounters a, body.-emu #sidebar #combat #combat-tracker .combatant .combatant-control,
-body.-emu .sidebar-popout #combat #combat-tracker .combatant .combatant-control, body.-emu #sidebar #playlists .directory-list .playlist-header .sound-controls .sound-control,
-body.-emu #sidebar #playlists .directory-list .sound .sound-controls .sound-control,
-body.-emu .sidebar-popout #playlists .directory-list .playlist-header .sound-controls .sound-control,
-body.-emu .sidebar-popout #playlists .directory-list .sound .sound-controls .sound-control, body.-emu #sidebar #playlists #currently-playing .sound .sound-control,
-body.-emu .sidebar-popout #playlists #currently-playing .sound .sound-control, body.-emu .window-app[id*="chat-popout-"] .chat-message .chat-card .die-result-overlay-br button,
-body.-emu #sidebar #chat #chat-log .chat-message .chat-card .die-result-overlay-br button, body.-emu #dfcp-rt-buttons button, body.-emu .active-effect-sheet[id*="ActiveEffectsConfig-"] .effect-special-duration .effect-control, body.-emu #specials-config .fxmaster .special-effects .controls a, body.-emu div.permission-viewer a, .-emu-layout body.-emu #sidebar #chat #chat-log .message .button.polyglot-message-language, .-emu-layout body.-emu .sidebar-popout #chat #chat-log .message .button.polyglot-message-language, body.-emu #smalltime-app #displayContainer .arrow, body.-emu #token-action-hud #tah-reposition,
-body.-emu #token-action-hud #tah-categories, body.-emu #sidebar .token-mold > a,
-body.-emu .sidebar-popout .token-mold > a, body.-emu #sidebar .sidebar-tab .directory-header .header-control,
+body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) button,
+body.-emu #menu #menu-items li,
+body.-emu #sidebar #combat #combat-controls .combat-control,
+body.-emu .sidebar-popout #combat #combat-controls .combat-control,
+body.-emu .filepicker.window-app .display-modes .display-mode,
+body.-emu .journal-sheet.sheet.window-app .window-content .editor-edit,
+body.-emu #calendar-time-container .calendar--time-controls .advance-btn,
+body.-emu #calendar-weather-container .calendar--time-controls .advance-btn,
+body.-emu #sidebar #combat .add-temporary,
+body.-emu .sidebar-popout #combat .add-temporary,
+body.-emu
+  .window-app[id*="ActiveEffects-"]
+  .window-content
+  > form
+  li.filter-item,
+body.-emu #specials-config .fxmaster .directory-header a,
+body.-emu .moulinette-options li,
+body.-emu #moulinette.forge .filepicker .display-modes a,
+body.-emu #OneJournalShell.window-app .history-navigation a,
+body.-emu ul.command-menu li,
+body.-emu #token-action-hud button.tah-title-button,
+body.-emu #token-action-hud .tah-action button,
+body.-emu #sidebar .token-mold > label > span,
+body.-emu .sidebar-popout .token-mold > label > span,
+.-emu-layout body.-emu .sheet.active-effect-sheet .effects-header a,
+body.-emu .sheet.active-effect-sheet .-emu-layout .effects-header a,
+.-emu-layout body.-emu .sheet.roll-table-config .table-results .table-header a,
+body.-emu .sheet.roll-table-config .table-results .-emu-layout .table-header a,
+.-emu-layout
+  body.-emu
+  .dice-so-nice
+  section.content
+  .settings-list
+  .sfxs-list
+  .sfx-header
+  a,
+body.-emu
+  .dice-so-nice
+  section.content
+  .settings-list
+  .sfxs-list
+  .-emu-layout
+  .sfx-header
+  a,
+.-emu-layout
+  body.-emu
+  .window-app[id*="ActiveEffects-"]
+  .window-content
+  > form
+  .dnd5e.sheet.item
+  .effect-header
+  a,
+body.-emu
+  .window-app[id*="ActiveEffects-"]
+  .window-content
+  > form
+  .dnd5e.sheet.item
+  .-emu-layout
+  .effect-header
+  a,
+.-emu-layout body.-emu .sheet.active-effect-sheet .changes-list li a,
+body.-emu .sheet.active-effect-sheet .changes-list .-emu-layout li a,
+.-emu-layout body.-emu .sheet.roll-table-config .table-results .table-result a,
+body.-emu .sheet.roll-table-config .table-results .-emu-layout .table-result a,
+.-emu-layout
+  body.-emu
+  .dice-so-nice
+  section.content
+  .settings-list
+  .sfxs-list
+  .sfx
+  a,
+body.-emu
+  .dice-so-nice
+  section.content
+  .settings-list
+  .sfxs-list
+  .-emu-layout
+  .sfx
+  a,
+body.-emu
+  .dialog
+  .directory
+  .directory-item.folder
+  .folder-header
+  .create-folder,
+body.-emu
+  .dialog
+  .directory
+  .directory-item.folder
+  .folder-header
+  .create-entity,
+body.-emu
+  #sidebar
+  .directory
+  .directory-item.folder
+  .folder-header
+  .create-folder,
+body.-emu
+  #sidebar
+  .directory
+  .directory-item.folder
+  .folder-header
+  .create-entity,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .directory
+  .directory-item.folder
+  .folder-header
+  .create-folder,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .directory
+  .directory-item.folder
+  .folder-header
+  .create-entity,
+body.-emu #navigation #nav-toggle,
+.-emu-layout body.-emu .window-app .window-header > a,
+.-emu-layout body.-emu .window-app .window-header a.header-button,
+.-emu-layout body.-emu #sidebar #chat #chat-log .message .button.message-delete,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #chat
+  #chat-log
+  .message
+  .button.message-delete,
+.-emu-layout
+  body.-emu
+  #sidebar
+  #chat
+  #chat-controls
+  .chat-control-icon
+  .fa-dice-d20,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #chat
+  #chat-controls
+  .chat-control-icon
+  .fa-dice-d20,
+.-emu-layout body.-emu #sidebar #chat #chat-controls .control-buttons .button,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #chat
+  #chat-controls
+  .control-buttons
+  .button,
+body.-emu #sidebar #combat #combat-round .encounters a,
+body.-emu .sidebar-popout #combat #combat-round .encounters a,
+body.-emu #sidebar #combat #combat-tracker .combatant .combatant-control,
+body.-emu .sidebar-popout #combat #combat-tracker .combatant .combatant-control,
+body.-emu
+  #sidebar
+  #playlists
+  .directory-list
+  .playlist-header
+  .sound-controls
+  .sound-control,
+body.-emu
+  #sidebar
+  #playlists
+  .directory-list
+  .sound
+  .sound-controls
+  .sound-control,
+body.-emu
+  .sidebar-popout
+  #playlists
+  .directory-list
+  .playlist-header
+  .sound-controls
+  .sound-control,
+body.-emu
+  .sidebar-popout
+  #playlists
+  .directory-list
+  .sound
+  .sound-controls
+  .sound-control,
+body.-emu #sidebar #playlists #currently-playing .sound .sound-control,
+body.-emu .sidebar-popout #playlists #currently-playing .sound .sound-control,
+body.-emu
+  .window-app[id*="chat-popout-"]
+  .chat-message
+  .chat-card
+  .die-result-overlay-br
+  button,
+body.-emu
+  #sidebar
+  #chat
+  #chat-log
+  .chat-message
+  .chat-card
+  .die-result-overlay-br
+  button,
+body.-emu #dfcp-rt-buttons button,
+body.-emu
+  .active-effect-sheet[id*="ActiveEffectsConfig-"]
+  .effect-special-duration
+  .effect-control,
+body.-emu #specials-config .fxmaster .special-effects .controls a,
+body.-emu div.permission-viewer a,
+.-emu-layout
+  body.-emu
+  #sidebar
+  #chat
+  #chat-log
+  .message
+  .button.polyglot-message-language,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #chat
+  #chat-log
+  .message
+  .button.polyglot-message-language,
+body.-emu #smalltime-app #displayContainer .arrow,
+body.-emu #token-action-hud #tah-reposition,
+body.-emu #token-action-hud #tah-categories,
+body.-emu #sidebar .token-mold > a,
+body.-emu .sidebar-popout .token-mold > a,
+body.-emu #sidebar .sidebar-tab .directory-header .header-control,
 body.-emu .sidebar-popout .sidebar-tab .directory-header .header-control {
   background-image: var(--emu-image-background-controls, none);
   border: none;
@@ -27,157 +238,2726 @@ body.-emu .sidebar-popout .sidebar-tab .directory-header .header-control {
   box-shadow: none;
   color: rgba(var(--color-text-lightest), 1);
   text-shadow: none;
-  transition: background 0.3s cubic-bezier(0.075, 0.82, 0.165, 1), box-shadow 0.3s cubic-bezier(0.075, 0.82, 0.165, 1), color 0.3s cubic-bezier(0.075, 0.82, 0.165, 1); }
-  .-emu-layout body.-emu .dialog .tabs a, body.-emu .dialog .tabs .-emu-layout a, .-emu-layout body.-emu .dialog .sheet-tabs a, body.-emu .dialog .sheet-tabs .-emu-layout a, .-emu-layout body.-emu #sidebar .tabs a, body.-emu #sidebar .tabs .-emu-layout a, .-emu-layout body.-emu #sidebar .sheet-tabs a, body.-emu #sidebar .sheet-tabs .-emu-layout a, .-emu-layout body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .tabs a, body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .tabs .-emu-layout a, .-emu-layout body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .sheet-tabs a, body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .sheet-tabs .-emu-layout a, .-emu-layout body.-emu #module-management .list-filters a, body.-emu #module-management .list-filters .-emu-layout a, .-emu-layout body.-emu .dialog button, body.-emu .dialog .-emu-layout button,
-  .-emu-layout body.-emu #sidebar button, body.-emu #sidebar .-emu-layout button,
-  .-emu-layout body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) button, body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .-emu-layout button, .-emu-layout body.-emu #menu #menu-items li, body.-emu #menu #menu-items .-emu-layout li, .-emu-layout body.-emu #sidebar #combat #combat-controls .combat-control, body.-emu #sidebar #combat #combat-controls .-emu-layout .combat-control,
-  .-emu-layout body.-emu .sidebar-popout #combat #combat-controls .combat-control, body.-emu .sidebar-popout #combat #combat-controls .-emu-layout .combat-control, .-emu-layout body.-emu .filepicker.window-app .display-modes .display-mode, body.-emu .filepicker.window-app .display-modes .-emu-layout .display-mode, .-emu-layout body.-emu .journal-sheet.sheet.window-app .window-content .editor-edit, body.-emu .journal-sheet.sheet.window-app .window-content .-emu-layout .editor-edit, .-emu-layout body.-emu #calendar-time-container .calendar--time-controls .advance-btn, body.-emu #calendar-time-container .calendar--time-controls .-emu-layout .advance-btn,
-  .-emu-layout body.-emu #calendar-weather-container .calendar--time-controls .advance-btn, body.-emu #calendar-weather-container .calendar--time-controls .-emu-layout .advance-btn, .-emu-layout body.-emu #sidebar #combat .add-temporary, body.-emu #sidebar #combat .-emu-layout .add-temporary,
-  .-emu-layout body.-emu .sidebar-popout #combat .add-temporary, body.-emu .sidebar-popout #combat .-emu-layout .add-temporary, .-emu-layout body.-emu .window-app[id*="ActiveEffects-"] .window-content > form li.filter-item, body.-emu .window-app[id*="ActiveEffects-"] .window-content > form .-emu-layout li.filter-item, .-emu-layout body.-emu #specials-config .fxmaster .directory-header a, body.-emu #specials-config .fxmaster .directory-header .-emu-layout a, .-emu-layout body.-emu .moulinette-options li, body.-emu .moulinette-options .-emu-layout li, .-emu-layout body.-emu #moulinette.forge .filepicker .display-modes a, body.-emu #moulinette.forge .filepicker .display-modes .-emu-layout a, .-emu-layout body.-emu #OneJournalShell.window-app .history-navigation a, body.-emu #OneJournalShell.window-app .history-navigation .-emu-layout a, .-emu-layout body.-emu ul.command-menu li, body.-emu ul.command-menu .-emu-layout li, .-emu-layout body.-emu #token-action-hud button.tah-title-button, body.-emu #token-action-hud .-emu-layout button.tah-title-button,
-  .-emu-layout body.-emu #token-action-hud .tah-action button, body.-emu #token-action-hud .tah-action .-emu-layout button, .-emu-layout body.-emu #sidebar .token-mold > label > span, body.-emu #sidebar .-emu-layout .token-mold > label > span,
-  .-emu-layout body.-emu .sidebar-popout .token-mold > label > span, body.-emu .sidebar-popout .-emu-layout .token-mold > label > span, .-emu-layout body.-emu .sheet.active-effect-sheet .effects-header a, body.-emu .sheet.active-effect-sheet .-emu-layout .effects-header a, .-emu-layout body.-emu .sheet.roll-table-config .table-results .table-header a, body.-emu .sheet.roll-table-config .table-results .-emu-layout .table-header a, .-emu-layout body.-emu .dice-so-nice section.content .settings-list .sfxs-list .sfx-header a, body.-emu .dice-so-nice section.content .settings-list .sfxs-list .-emu-layout .sfx-header a, .-emu-layout body.-emu .window-app[id*="ActiveEffects-"] .window-content > form .dnd5e.sheet.item .effect-header a, body.-emu .window-app[id*="ActiveEffects-"] .window-content > form .dnd5e.sheet.item .-emu-layout .effect-header a, .-emu-layout body.-emu .sheet.active-effect-sheet .changes-list li a, body.-emu .sheet.active-effect-sheet .changes-list .-emu-layout li a, .-emu-layout body.-emu .sheet.roll-table-config .table-results .table-result a, body.-emu .sheet.roll-table-config .table-results .-emu-layout .table-result a, .-emu-layout body.-emu .dice-so-nice section.content .settings-list .sfxs-list .sfx a, body.-emu .dice-so-nice section.content .settings-list .sfxs-list .-emu-layout .sfx a, .-emu-layout body.-emu .dialog .directory .directory-item.folder .folder-header .create-folder, body.-emu .dialog .directory .directory-item.folder .folder-header .-emu-layout .create-folder,
-  .-emu-layout body.-emu .dialog .directory .directory-item.folder .folder-header .create-entity, body.-emu .dialog .directory .directory-item.folder .folder-header .-emu-layout .create-entity,
-  .-emu-layout body.-emu #sidebar .directory .directory-item.folder .folder-header .create-folder, body.-emu #sidebar .directory .directory-item.folder .folder-header .-emu-layout .create-folder,
-  .-emu-layout body.-emu #sidebar .directory .directory-item.folder .folder-header .create-entity, body.-emu #sidebar .directory .directory-item.folder .folder-header .-emu-layout .create-entity,
-  .-emu-layout body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .directory .directory-item.folder .folder-header .create-folder, body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .directory .directory-item.folder .folder-header .-emu-layout .create-folder,
-  .-emu-layout body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .directory .directory-item.folder .folder-header .create-entity, body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .directory .directory-item.folder .folder-header .-emu-layout .create-entity, .-emu-layout body.-emu #navigation #nav-toggle, body.-emu #navigation .-emu-layout #nav-toggle, .-emu-layout body.-emu .window-app .window-header > a, .-emu-layout body.-emu .window-app .window-header a.header-button, .-emu-layout body.-emu #sidebar #chat #chat-log .message .button.message-delete, .-emu-layout body.-emu .sidebar-popout #chat #chat-log .message .button.message-delete, .-emu-layout body.-emu #sidebar #chat #chat-controls .chat-control-icon .fa-dice-d20, .-emu-layout body.-emu .sidebar-popout #chat #chat-controls .chat-control-icon .fa-dice-d20, .-emu-layout body.-emu #sidebar #chat #chat-controls .control-buttons .button, .-emu-layout body.-emu .sidebar-popout #chat #chat-controls .control-buttons .button, .-emu-layout body.-emu #sidebar #combat #combat-round .encounters a, body.-emu #sidebar #combat #combat-round .encounters .-emu-layout a,
-  .-emu-layout body.-emu .sidebar-popout #combat #combat-round .encounters a, body.-emu .sidebar-popout #combat #combat-round .encounters .-emu-layout a, .-emu-layout body.-emu #sidebar #combat #combat-tracker .combatant .combatant-control, body.-emu #sidebar #combat #combat-tracker .combatant .-emu-layout .combatant-control,
-  .-emu-layout body.-emu .sidebar-popout #combat #combat-tracker .combatant .combatant-control, body.-emu .sidebar-popout #combat #combat-tracker .combatant .-emu-layout .combatant-control, .-emu-layout body.-emu #sidebar #playlists .directory-list .playlist-header .sound-controls .sound-control, body.-emu #sidebar #playlists .directory-list .playlist-header .sound-controls .-emu-layout .sound-control,
-  .-emu-layout body.-emu #sidebar #playlists .directory-list .sound .sound-controls .sound-control, body.-emu #sidebar #playlists .directory-list .sound .sound-controls .-emu-layout .sound-control,
-  .-emu-layout body.-emu .sidebar-popout #playlists .directory-list .playlist-header .sound-controls .sound-control, body.-emu .sidebar-popout #playlists .directory-list .playlist-header .sound-controls .-emu-layout .sound-control,
-  .-emu-layout body.-emu .sidebar-popout #playlists .directory-list .sound .sound-controls .sound-control, body.-emu .sidebar-popout #playlists .directory-list .sound .sound-controls .-emu-layout .sound-control, .-emu-layout body.-emu #sidebar #playlists #currently-playing .sound .sound-control, body.-emu #sidebar #playlists #currently-playing .sound .-emu-layout .sound-control,
-  .-emu-layout body.-emu .sidebar-popout #playlists #currently-playing .sound .sound-control, body.-emu .sidebar-popout #playlists #currently-playing .sound .-emu-layout .sound-control, .-emu-layout body.-emu .window-app[id*="chat-popout-"] .chat-message .chat-card .die-result-overlay-br button, body.-emu .window-app[id*="chat-popout-"] .chat-message .chat-card .die-result-overlay-br .-emu-layout button,
-  .-emu-layout body.-emu #sidebar #chat #chat-log .chat-message .chat-card .die-result-overlay-br button, body.-emu #sidebar #chat #chat-log .chat-message .chat-card .die-result-overlay-br .-emu-layout button, .-emu-layout body.-emu #dfcp-rt-buttons button, body.-emu #dfcp-rt-buttons .-emu-layout button, .-emu-layout body.-emu .active-effect-sheet[id*="ActiveEffectsConfig-"] .effect-special-duration .effect-control, body.-emu .active-effect-sheet[id*="ActiveEffectsConfig-"] .effect-special-duration .-emu-layout .effect-control, .-emu-layout body.-emu #specials-config .fxmaster .special-effects .controls a, body.-emu #specials-config .fxmaster .special-effects .controls .-emu-layout a, .-emu-layout body.-emu div.permission-viewer a, body.-emu div.permission-viewer .-emu-layout a, .-emu-layout body.-emu #sidebar #chat #chat-log .message .button.polyglot-message-language, .-emu-layout body.-emu .sidebar-popout #chat #chat-log .message .button.polyglot-message-language, .-emu-layout body.-emu #smalltime-app #displayContainer .arrow, body.-emu #smalltime-app #displayContainer .-emu-layout .arrow, .-emu-layout body.-emu #token-action-hud #tah-reposition, body.-emu #token-action-hud .-emu-layout #tah-reposition,
-  .-emu-layout body.-emu #token-action-hud #tah-categories, body.-emu #token-action-hud .-emu-layout #tah-categories, .-emu-layout body.-emu #sidebar .token-mold > a, body.-emu #sidebar .-emu-layout .token-mold > a,
-  .-emu-layout body.-emu .sidebar-popout .token-mold > a, body.-emu .sidebar-popout .-emu-layout .token-mold > a, .-emu-layout body.-emu #sidebar .sidebar-tab .directory-header .header-control, body.-emu #sidebar .sidebar-tab .directory-header .-emu-layout .header-control,
-  .-emu-layout body.-emu .sidebar-popout .sidebar-tab .directory-header .header-control, body.-emu .sidebar-popout .sidebar-tab .directory-header .-emu-layout .header-control {
-    align-items: center;
-    cursor: pointer;
-    display: inline-flex;
-    font-size: var(--emu-font-size-lg);
-    font-family: inherit;
-    height: initial;
-    justify-content: center;
-    line-height: 1;
-    margin: 0;
-    padding: var(--emu-space-sm);
-    position: relative; }
-    .-emu-layout body.-emu .dialog .tabs a > i, body.-emu .dialog .tabs .-emu-layout a > i, .-emu-layout body.-emu .dialog .sheet-tabs a > i, body.-emu .dialog .sheet-tabs .-emu-layout a > i, .-emu-layout body.-emu #sidebar .tabs a > i, body.-emu #sidebar .tabs .-emu-layout a > i, .-emu-layout body.-emu #sidebar .sheet-tabs a > i, body.-emu #sidebar .sheet-tabs .-emu-layout a > i, .-emu-layout body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .tabs a > i, body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .tabs .-emu-layout a > i, .-emu-layout body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .sheet-tabs a > i, body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .sheet-tabs .-emu-layout a > i, .-emu-layout body.-emu #module-management .list-filters a > i, body.-emu #module-management .list-filters .-emu-layout a > i, .-emu-layout body.-emu .dialog button > i, body.-emu .dialog .-emu-layout button > i, .-emu-layout body.-emu #sidebar button > i, body.-emu #sidebar .-emu-layout button > i, .-emu-layout body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) button > i, body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .-emu-layout button > i, .-emu-layout body.-emu #menu #menu-items li > i, body.-emu #menu #menu-items .-emu-layout li > i, .-emu-layout body.-emu #sidebar #combat #combat-controls .combat-control > i, body.-emu #sidebar #combat #combat-controls .-emu-layout .combat-control > i, .-emu-layout body.-emu .sidebar-popout #combat #combat-controls .combat-control > i, body.-emu .sidebar-popout #combat #combat-controls .-emu-layout .combat-control > i, .-emu-layout body.-emu .filepicker.window-app .display-modes .display-mode > i, body.-emu .filepicker.window-app .display-modes .-emu-layout .display-mode > i, .-emu-layout body.-emu .journal-sheet.sheet.window-app .window-content .editor-edit > i, body.-emu .journal-sheet.sheet.window-app .window-content .-emu-layout .editor-edit > i, .-emu-layout body.-emu #calendar-time-container .calendar--time-controls .advance-btn > i, body.-emu #calendar-time-container .calendar--time-controls .-emu-layout .advance-btn > i, .-emu-layout body.-emu #calendar-weather-container .calendar--time-controls .advance-btn > i, body.-emu #calendar-weather-container .calendar--time-controls .-emu-layout .advance-btn > i, .-emu-layout body.-emu #sidebar #combat .add-temporary > i, body.-emu #sidebar #combat .-emu-layout .add-temporary > i, .-emu-layout body.-emu .sidebar-popout #combat .add-temporary > i, body.-emu .sidebar-popout #combat .-emu-layout .add-temporary > i, .-emu-layout body.-emu .window-app[id*="ActiveEffects-"] .window-content > form li.filter-item > i, body.-emu .window-app[id*="ActiveEffects-"] .window-content > form .-emu-layout li.filter-item > i, .-emu-layout body.-emu #specials-config .fxmaster .directory-header a > i, body.-emu #specials-config .fxmaster .directory-header .-emu-layout a > i, .-emu-layout body.-emu .moulinette-options li > i, body.-emu .moulinette-options .-emu-layout li > i, .-emu-layout body.-emu #moulinette.forge .filepicker .display-modes a > i, body.-emu #moulinette.forge .filepicker .display-modes .-emu-layout a > i, .-emu-layout body.-emu #OneJournalShell.window-app .history-navigation a > i, body.-emu #OneJournalShell.window-app .history-navigation .-emu-layout a > i, .-emu-layout body.-emu ul.command-menu li > i, body.-emu ul.command-menu .-emu-layout li > i, .-emu-layout body.-emu #token-action-hud button.tah-title-button > i, body.-emu #token-action-hud .-emu-layout button.tah-title-button > i, .-emu-layout body.-emu #token-action-hud .tah-action button > i, body.-emu #token-action-hud .tah-action .-emu-layout button > i, .-emu-layout body.-emu #sidebar .token-mold > label > span > i, body.-emu #sidebar .-emu-layout .token-mold > label > span > i, .-emu-layout body.-emu .sidebar-popout .token-mold > label > span > i, body.-emu .sidebar-popout .-emu-layout .token-mold > label > span > i, .-emu-layout body.-emu .sheet.active-effect-sheet .effects-header a > i, body.-emu .sheet.active-effect-sheet .-emu-layout .effects-header a > i, .-emu-layout body.-emu .sheet.roll-table-config .table-results .table-header a > i, body.-emu .sheet.roll-table-config .table-results .-emu-layout .table-header a > i, .-emu-layout body.-emu .dice-so-nice section.content .settings-list .sfxs-list .sfx-header a > i, body.-emu .dice-so-nice section.content .settings-list .sfxs-list .-emu-layout .sfx-header a > i, .-emu-layout body.-emu .window-app[id*="ActiveEffects-"] .window-content > form .dnd5e.sheet.item .effect-header a > i, body.-emu .window-app[id*="ActiveEffects-"] .window-content > form .dnd5e.sheet.item .-emu-layout .effect-header a > i, .-emu-layout body.-emu .sheet.active-effect-sheet .changes-list li a > i, body.-emu .sheet.active-effect-sheet .changes-list .-emu-layout li a > i, .-emu-layout body.-emu .sheet.roll-table-config .table-results .table-result a > i, body.-emu .sheet.roll-table-config .table-results .-emu-layout .table-result a > i, .-emu-layout body.-emu .dice-so-nice section.content .settings-list .sfxs-list .sfx a > i, body.-emu .dice-so-nice section.content .settings-list .sfxs-list .-emu-layout .sfx a > i, .-emu-layout body.-emu .dialog .directory .directory-item.folder .folder-header .create-folder > i, body.-emu .dialog .directory .directory-item.folder .folder-header .-emu-layout .create-folder > i, .-emu-layout body.-emu .dialog .directory .directory-item.folder .folder-header .create-entity > i, body.-emu .dialog .directory .directory-item.folder .folder-header .-emu-layout .create-entity > i, .-emu-layout body.-emu #sidebar .directory .directory-item.folder .folder-header .create-folder > i, body.-emu #sidebar .directory .directory-item.folder .folder-header .-emu-layout .create-folder > i, .-emu-layout body.-emu #sidebar .directory .directory-item.folder .folder-header .create-entity > i, body.-emu #sidebar .directory .directory-item.folder .folder-header .-emu-layout .create-entity > i, .-emu-layout body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .directory .directory-item.folder .folder-header .create-folder > i, body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .directory .directory-item.folder .folder-header .-emu-layout .create-folder > i, .-emu-layout body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .directory .directory-item.folder .folder-header .create-entity > i, body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .directory .directory-item.folder .folder-header .-emu-layout .create-entity > i, .-emu-layout body.-emu #navigation #nav-toggle > i, body.-emu #navigation .-emu-layout #nav-toggle > i, .-emu-layout body.-emu .window-app .window-header > a > i, .-emu-layout body.-emu .window-app .window-header a.header-button > i, .-emu-layout body.-emu #sidebar #chat #chat-log .message .button.message-delete > i, .-emu-layout body.-emu .sidebar-popout #chat #chat-log .message .button.message-delete > i, .-emu-layout body.-emu #sidebar #chat #chat-controls .chat-control-icon .fa-dice-d20 > i, .-emu-layout body.-emu .sidebar-popout #chat #chat-controls .chat-control-icon .fa-dice-d20 > i, .-emu-layout body.-emu #sidebar #chat #chat-controls .control-buttons .button > i, .-emu-layout body.-emu .sidebar-popout #chat #chat-controls .control-buttons .button > i, .-emu-layout body.-emu #sidebar #combat #combat-round .encounters a > i, body.-emu #sidebar #combat #combat-round .encounters .-emu-layout a > i, .-emu-layout body.-emu .sidebar-popout #combat #combat-round .encounters a > i, body.-emu .sidebar-popout #combat #combat-round .encounters .-emu-layout a > i, .-emu-layout body.-emu #sidebar #combat #combat-tracker .combatant .combatant-control > i, body.-emu #sidebar #combat #combat-tracker .combatant .-emu-layout .combatant-control > i, .-emu-layout body.-emu .sidebar-popout #combat #combat-tracker .combatant .combatant-control > i, body.-emu .sidebar-popout #combat #combat-tracker .combatant .-emu-layout .combatant-control > i, .-emu-layout body.-emu #sidebar #playlists .directory-list .playlist-header .sound-controls .sound-control > i, body.-emu #sidebar #playlists .directory-list .playlist-header .sound-controls .-emu-layout .sound-control > i, .-emu-layout body.-emu #sidebar #playlists .directory-list .sound .sound-controls .sound-control > i, body.-emu #sidebar #playlists .directory-list .sound .sound-controls .-emu-layout .sound-control > i, .-emu-layout body.-emu .sidebar-popout #playlists .directory-list .playlist-header .sound-controls .sound-control > i, body.-emu .sidebar-popout #playlists .directory-list .playlist-header .sound-controls .-emu-layout .sound-control > i, .-emu-layout body.-emu .sidebar-popout #playlists .directory-list .sound .sound-controls .sound-control > i, body.-emu .sidebar-popout #playlists .directory-list .sound .sound-controls .-emu-layout .sound-control > i, .-emu-layout body.-emu #sidebar #playlists #currently-playing .sound .sound-control > i, body.-emu #sidebar #playlists #currently-playing .sound .-emu-layout .sound-control > i, .-emu-layout body.-emu .sidebar-popout #playlists #currently-playing .sound .sound-control > i, body.-emu .sidebar-popout #playlists #currently-playing .sound .-emu-layout .sound-control > i, .-emu-layout body.-emu .window-app[id*="chat-popout-"] .chat-message .chat-card .die-result-overlay-br button > i, body.-emu .window-app[id*="chat-popout-"] .chat-message .chat-card .die-result-overlay-br .-emu-layout button > i, .-emu-layout body.-emu #sidebar #chat #chat-log .chat-message .chat-card .die-result-overlay-br button > i, body.-emu #sidebar #chat #chat-log .chat-message .chat-card .die-result-overlay-br .-emu-layout button > i, .-emu-layout body.-emu #dfcp-rt-buttons button > i, body.-emu #dfcp-rt-buttons .-emu-layout button > i, .-emu-layout body.-emu .active-effect-sheet[id*="ActiveEffectsConfig-"] .effect-special-duration .effect-control > i, body.-emu .active-effect-sheet[id*="ActiveEffectsConfig-"] .effect-special-duration .-emu-layout .effect-control > i, .-emu-layout body.-emu #specials-config .fxmaster .special-effects .controls a > i, body.-emu #specials-config .fxmaster .special-effects .controls .-emu-layout a > i, .-emu-layout body.-emu div.permission-viewer a > i, body.-emu div.permission-viewer .-emu-layout a > i, .-emu-layout body.-emu #sidebar #chat #chat-log .message .button.polyglot-message-language > i, .-emu-layout body.-emu .sidebar-popout #chat #chat-log .message .button.polyglot-message-language > i, .-emu-layout body.-emu #smalltime-app #displayContainer .arrow > i, body.-emu #smalltime-app #displayContainer .-emu-layout .arrow > i, .-emu-layout body.-emu #token-action-hud #tah-reposition > i, body.-emu #token-action-hud .-emu-layout #tah-reposition > i, .-emu-layout body.-emu #token-action-hud #tah-categories > i, body.-emu #token-action-hud .-emu-layout #tah-categories > i, .-emu-layout body.-emu #sidebar .token-mold > a > i, body.-emu #sidebar .-emu-layout .token-mold > a > i, .-emu-layout body.-emu .sidebar-popout .token-mold > a > i, body.-emu .sidebar-popout .-emu-layout .token-mold > a > i, .-emu-layout body.-emu #sidebar .sidebar-tab .directory-header .header-control > i, body.-emu #sidebar .sidebar-tab .directory-header .-emu-layout .header-control > i, .-emu-layout body.-emu .sidebar-popout .sidebar-tab .directory-header .header-control > i, body.-emu .sidebar-popout .sidebar-tab .directory-header .-emu-layout .header-control > i {
-      -webkit-margin-end: var(--emu-space-sm);
-              margin-inline-end: var(--emu-space-sm); }
-  body.-emu .dialog .tabs a:hover, body.-emu .dialog .sheet-tabs a:hover, body.-emu #sidebar .tabs a:hover, body.-emu #sidebar .sheet-tabs a:hover, body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .tabs a:hover, body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .sheet-tabs a:hover, body.-emu #module-management .list-filters a:hover, body.-emu .dialog button:hover,
-  body.-emu #sidebar button:hover,
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) button:hover, body.-emu #menu #menu-items li:hover, body.-emu #sidebar #combat #combat-controls .combat-control:hover,
-  body.-emu .sidebar-popout #combat #combat-controls .combat-control:hover, body.-emu .filepicker.window-app .display-modes .display-mode:hover, body.-emu .journal-sheet.sheet.window-app .window-content .editor-edit:hover, body.-emu #calendar-time-container .calendar--time-controls .advance-btn:hover,
-  body.-emu #calendar-weather-container .calendar--time-controls .advance-btn:hover, body.-emu #sidebar #combat .add-temporary:hover,
-  body.-emu .sidebar-popout #combat .add-temporary:hover, body.-emu .window-app[id*="ActiveEffects-"] .window-content > form li.filter-item:hover, body.-emu #specials-config .fxmaster .directory-header a:hover, body.-emu .moulinette-options li:hover, body.-emu #moulinette.forge .filepicker .display-modes a:hover, body.-emu #OneJournalShell.window-app .history-navigation a:hover, body.-emu ul.command-menu li:hover, body.-emu #token-action-hud button.tah-title-button:hover,
-  body.-emu #token-action-hud .tah-action button:hover, body.-emu #sidebar .token-mold > label > span:hover,
-  body.-emu .sidebar-popout .token-mold > label > span:hover, .-emu-layout body.-emu .sheet.active-effect-sheet .effects-header a:hover, body.-emu .sheet.active-effect-sheet .-emu-layout .effects-header a:hover, .-emu-layout body.-emu .sheet.roll-table-config .table-results .table-header a:hover, body.-emu .sheet.roll-table-config .table-results .-emu-layout .table-header a:hover, .-emu-layout body.-emu .dice-so-nice section.content .settings-list .sfxs-list .sfx-header a:hover, body.-emu .dice-so-nice section.content .settings-list .sfxs-list .-emu-layout .sfx-header a:hover, .-emu-layout body.-emu .window-app[id*="ActiveEffects-"] .window-content > form .dnd5e.sheet.item .effect-header a:hover, body.-emu .window-app[id*="ActiveEffects-"] .window-content > form .dnd5e.sheet.item .-emu-layout .effect-header a:hover, .-emu-layout body.-emu .sheet.active-effect-sheet .changes-list li a:hover, body.-emu .sheet.active-effect-sheet .changes-list .-emu-layout li a:hover, .-emu-layout body.-emu .sheet.roll-table-config .table-results .table-result a:hover, body.-emu .sheet.roll-table-config .table-results .-emu-layout .table-result a:hover, .-emu-layout body.-emu .dice-so-nice section.content .settings-list .sfxs-list .sfx a:hover, body.-emu .dice-so-nice section.content .settings-list .sfxs-list .-emu-layout .sfx a:hover, body.-emu .dialog .directory .directory-item.folder .folder-header .create-folder:hover,
-  body.-emu .dialog .directory .directory-item.folder .folder-header .create-entity:hover,
-  body.-emu #sidebar .directory .directory-item.folder .folder-header .create-folder:hover,
-  body.-emu #sidebar .directory .directory-item.folder .folder-header .create-entity:hover,
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .directory .directory-item.folder .folder-header .create-folder:hover,
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .directory .directory-item.folder .folder-header .create-entity:hover, body.-emu #navigation #nav-toggle:hover, .-emu-layout body.-emu .window-app .window-header > a:hover, .-emu-layout body.-emu .window-app .window-header a.header-button:hover, .-emu-layout body.-emu #sidebar #chat #chat-log .message .button.message-delete:hover, .-emu-layout body.-emu .sidebar-popout #chat #chat-log .message .button.message-delete:hover, .-emu-layout body.-emu #sidebar #chat #chat-controls .chat-control-icon .fa-dice-d20:hover, .-emu-layout body.-emu .sidebar-popout #chat #chat-controls .chat-control-icon .fa-dice-d20:hover, .-emu-layout body.-emu #sidebar #chat #chat-controls .control-buttons .button:hover, .-emu-layout body.-emu .sidebar-popout #chat #chat-controls .control-buttons .button:hover, body.-emu #sidebar #combat #combat-round .encounters a:hover,
-  body.-emu .sidebar-popout #combat #combat-round .encounters a:hover, body.-emu #sidebar #combat #combat-tracker .combatant .combatant-control:hover,
-  body.-emu .sidebar-popout #combat #combat-tracker .combatant .combatant-control:hover, body.-emu #sidebar #playlists .directory-list .playlist-header .sound-controls .sound-control:hover,
-  body.-emu #sidebar #playlists .directory-list .sound .sound-controls .sound-control:hover,
-  body.-emu .sidebar-popout #playlists .directory-list .playlist-header .sound-controls .sound-control:hover,
-  body.-emu .sidebar-popout #playlists .directory-list .sound .sound-controls .sound-control:hover, body.-emu #sidebar #playlists #currently-playing .sound .sound-control:hover,
-  body.-emu .sidebar-popout #playlists #currently-playing .sound .sound-control:hover, body.-emu .window-app[id*="chat-popout-"] .chat-message .chat-card .die-result-overlay-br button:hover,
-  body.-emu #sidebar #chat #chat-log .chat-message .chat-card .die-result-overlay-br button:hover, body.-emu #dfcp-rt-buttons button:hover, body.-emu .active-effect-sheet[id*="ActiveEffectsConfig-"] .effect-special-duration .effect-control:hover, body.-emu #specials-config .fxmaster .special-effects .controls a:hover, body.-emu div.permission-viewer a:hover, .-emu-layout body.-emu #sidebar #chat #chat-log .message .button.polyglot-message-language:hover, .-emu-layout body.-emu .sidebar-popout #chat #chat-log .message .button.polyglot-message-language:hover, body.-emu #smalltime-app #displayContainer .arrow:hover, body.-emu #token-action-hud #tah-reposition:hover,
-  body.-emu #token-action-hud #tah-categories:hover, body.-emu #sidebar .token-mold > a:hover,
-  body.-emu .sidebar-popout .token-mold > a:hover, body.-emu #sidebar .sidebar-tab .directory-header .header-control:hover,
-  body.-emu .sidebar-popout .sidebar-tab .directory-header .header-control:hover {
-    background-color: rgba(var(--color-primary), 1);
-    background-image: none;
-    color: rgba(var(--color-text-lightest), 1); }
-  body.-emu .dialog .tabs a:disabled, body.-emu .dialog .sheet-tabs a:disabled, body.-emu #sidebar .tabs a:disabled, body.-emu #sidebar .sheet-tabs a:disabled, body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .tabs a:disabled, body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .sheet-tabs a:disabled, body.-emu #module-management .list-filters a:disabled, body.-emu .dialog button:disabled,
-  body.-emu #sidebar button:disabled,
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) button:disabled, body.-emu #menu #menu-items li:disabled, body.-emu #sidebar #combat #combat-controls .combat-control:disabled,
-  body.-emu .sidebar-popout #combat #combat-controls .combat-control:disabled, body.-emu .filepicker.window-app .display-modes .display-mode:disabled, body.-emu .journal-sheet.sheet.window-app .window-content .editor-edit:disabled, body.-emu #calendar-time-container .calendar--time-controls .advance-btn:disabled,
-  body.-emu #calendar-weather-container .calendar--time-controls .advance-btn:disabled, body.-emu #sidebar #combat .add-temporary:disabled,
-  body.-emu .sidebar-popout #combat .add-temporary:disabled, body.-emu .window-app[id*="ActiveEffects-"] .window-content > form li.filter-item:disabled, body.-emu #specials-config .fxmaster .directory-header a:disabled, body.-emu .moulinette-options li:disabled, body.-emu #moulinette.forge .filepicker .display-modes a:disabled, body.-emu #OneJournalShell.window-app .history-navigation a:disabled, body.-emu ul.command-menu li:disabled, body.-emu #token-action-hud button.tah-title-button:disabled,
-  body.-emu #token-action-hud .tah-action button:disabled, body.-emu #sidebar .token-mold > label > span:disabled,
-  body.-emu .sidebar-popout .token-mold > label > span:disabled, .-emu-layout body.-emu .sheet.active-effect-sheet .effects-header a:disabled, body.-emu .sheet.active-effect-sheet .-emu-layout .effects-header a:disabled, .-emu-layout body.-emu .sheet.roll-table-config .table-results .table-header a:disabled, body.-emu .sheet.roll-table-config .table-results .-emu-layout .table-header a:disabled, .-emu-layout body.-emu .dice-so-nice section.content .settings-list .sfxs-list .sfx-header a:disabled, body.-emu .dice-so-nice section.content .settings-list .sfxs-list .-emu-layout .sfx-header a:disabled, .-emu-layout body.-emu .window-app[id*="ActiveEffects-"] .window-content > form .dnd5e.sheet.item .effect-header a:disabled, body.-emu .window-app[id*="ActiveEffects-"] .window-content > form .dnd5e.sheet.item .-emu-layout .effect-header a:disabled, .-emu-layout body.-emu .sheet.active-effect-sheet .changes-list li a:disabled, body.-emu .sheet.active-effect-sheet .changes-list .-emu-layout li a:disabled, .-emu-layout body.-emu .sheet.roll-table-config .table-results .table-result a:disabled, body.-emu .sheet.roll-table-config .table-results .-emu-layout .table-result a:disabled, .-emu-layout body.-emu .dice-so-nice section.content .settings-list .sfxs-list .sfx a:disabled, body.-emu .dice-so-nice section.content .settings-list .sfxs-list .-emu-layout .sfx a:disabled, body.-emu .dialog .directory .directory-item.folder .folder-header .create-folder:disabled,
-  body.-emu .dialog .directory .directory-item.folder .folder-header .create-entity:disabled,
-  body.-emu #sidebar .directory .directory-item.folder .folder-header .create-folder:disabled,
-  body.-emu #sidebar .directory .directory-item.folder .folder-header .create-entity:disabled,
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .directory .directory-item.folder .folder-header .create-folder:disabled,
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .directory .directory-item.folder .folder-header .create-entity:disabled, body.-emu #navigation #nav-toggle:disabled, .-emu-layout body.-emu .window-app .window-header > a:disabled, .-emu-layout body.-emu .window-app .window-header a.header-button:disabled, .-emu-layout body.-emu #sidebar #chat #chat-log .message .button.message-delete:disabled, .-emu-layout body.-emu .sidebar-popout #chat #chat-log .message .button.message-delete:disabled, .-emu-layout body.-emu #sidebar #chat #chat-controls .chat-control-icon .fa-dice-d20:disabled, .-emu-layout body.-emu .sidebar-popout #chat #chat-controls .chat-control-icon .fa-dice-d20:disabled, .-emu-layout body.-emu #sidebar #chat #chat-controls .control-buttons .button:disabled, .-emu-layout body.-emu .sidebar-popout #chat #chat-controls .control-buttons .button:disabled, body.-emu #sidebar #combat #combat-round .encounters a:disabled,
-  body.-emu .sidebar-popout #combat #combat-round .encounters a:disabled, body.-emu #sidebar #combat #combat-tracker .combatant .combatant-control:disabled,
-  body.-emu .sidebar-popout #combat #combat-tracker .combatant .combatant-control:disabled, body.-emu #sidebar #playlists .directory-list .playlist-header .sound-controls .sound-control:disabled,
-  body.-emu #sidebar #playlists .directory-list .sound .sound-controls .sound-control:disabled,
-  body.-emu .sidebar-popout #playlists .directory-list .playlist-header .sound-controls .sound-control:disabled,
-  body.-emu .sidebar-popout #playlists .directory-list .sound .sound-controls .sound-control:disabled, body.-emu #sidebar #playlists #currently-playing .sound .sound-control:disabled,
-  body.-emu .sidebar-popout #playlists #currently-playing .sound .sound-control:disabled, body.-emu .window-app[id*="chat-popout-"] .chat-message .chat-card .die-result-overlay-br button:disabled,
-  body.-emu #sidebar #chat #chat-log .chat-message .chat-card .die-result-overlay-br button:disabled, body.-emu #dfcp-rt-buttons button:disabled, body.-emu .active-effect-sheet[id*="ActiveEffectsConfig-"] .effect-special-duration .effect-control:disabled, body.-emu #specials-config .fxmaster .special-effects .controls a:disabled, body.-emu div.permission-viewer a:disabled, .-emu-layout body.-emu #sidebar #chat #chat-log .message .button.polyglot-message-language:disabled, .-emu-layout body.-emu .sidebar-popout #chat #chat-log .message .button.polyglot-message-language:disabled, body.-emu #smalltime-app #displayContainer .arrow:disabled, body.-emu #token-action-hud #tah-reposition:disabled,
-  body.-emu #token-action-hud #tah-categories:disabled, body.-emu #sidebar .token-mold > a:disabled,
-  body.-emu .sidebar-popout .token-mold > a:disabled, body.-emu #sidebar .sidebar-tab .directory-header .header-control:disabled,
-  body.-emu .sidebar-popout .sidebar-tab .directory-header .header-control:disabled {
-    opacity: 0.5;
-    pointer-events: none; }
+  transition: background 0.3s cubic-bezier(0.075, 0.82, 0.165, 1),
+    box-shadow 0.3s cubic-bezier(0.075, 0.82, 0.165, 1),
+    color 0.3s cubic-bezier(0.075, 0.82, 0.165, 1);
+}
+.-emu-layout body.-emu .dialog .tabs a,
+body.-emu .dialog .tabs .-emu-layout a,
+.-emu-layout body.-emu .dialog .sheet-tabs a,
+body.-emu .dialog .sheet-tabs .-emu-layout a,
+.-emu-layout body.-emu #sidebar .tabs a,
+body.-emu #sidebar .tabs .-emu-layout a,
+.-emu-layout body.-emu #sidebar .sheet-tabs a,
+body.-emu #sidebar .sheet-tabs .-emu-layout a,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .tabs
+  a,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .tabs
+  .-emu-layout
+  a,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .sheet-tabs
+  a,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .sheet-tabs
+  .-emu-layout
+  a,
+.-emu-layout body.-emu #module-management .list-filters a,
+body.-emu #module-management .list-filters .-emu-layout a,
+.-emu-layout body.-emu .dialog button,
+body.-emu .dialog .-emu-layout button,
+.-emu-layout body.-emu #sidebar button,
+body.-emu #sidebar .-emu-layout button,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  button,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .-emu-layout
+  button,
+.-emu-layout body.-emu #menu #menu-items li,
+body.-emu #menu #menu-items .-emu-layout li,
+.-emu-layout body.-emu #sidebar #combat #combat-controls .combat-control,
+body.-emu #sidebar #combat #combat-controls .-emu-layout .combat-control,
+.-emu-layout body.-emu .sidebar-popout #combat #combat-controls .combat-control,
+body.-emu .sidebar-popout #combat #combat-controls .-emu-layout .combat-control,
+.-emu-layout body.-emu .filepicker.window-app .display-modes .display-mode,
+body.-emu .filepicker.window-app .display-modes .-emu-layout .display-mode,
+.-emu-layout
+  body.-emu
+  .journal-sheet.sheet.window-app
+  .window-content
+  .editor-edit,
+body.-emu
+  .journal-sheet.sheet.window-app
+  .window-content
+  .-emu-layout
+  .editor-edit,
+.-emu-layout
+  body.-emu
+  #calendar-time-container
+  .calendar--time-controls
+  .advance-btn,
+body.-emu
+  #calendar-time-container
+  .calendar--time-controls
+  .-emu-layout
+  .advance-btn,
+.-emu-layout
+  body.-emu
+  #calendar-weather-container
+  .calendar--time-controls
+  .advance-btn,
+body.-emu
+  #calendar-weather-container
+  .calendar--time-controls
+  .-emu-layout
+  .advance-btn,
+.-emu-layout body.-emu #sidebar #combat .add-temporary,
+body.-emu #sidebar #combat .-emu-layout .add-temporary,
+.-emu-layout body.-emu .sidebar-popout #combat .add-temporary,
+body.-emu .sidebar-popout #combat .-emu-layout .add-temporary,
+.-emu-layout
+  body.-emu
+  .window-app[id*="ActiveEffects-"]
+  .window-content
+  > form
+  li.filter-item,
+body.-emu
+  .window-app[id*="ActiveEffects-"]
+  .window-content
+  > form
+  .-emu-layout
+  li.filter-item,
+.-emu-layout body.-emu #specials-config .fxmaster .directory-header a,
+body.-emu #specials-config .fxmaster .directory-header .-emu-layout a,
+.-emu-layout body.-emu .moulinette-options li,
+body.-emu .moulinette-options .-emu-layout li,
+.-emu-layout body.-emu #moulinette.forge .filepicker .display-modes a,
+body.-emu #moulinette.forge .filepicker .display-modes .-emu-layout a,
+.-emu-layout body.-emu #OneJournalShell.window-app .history-navigation a,
+body.-emu #OneJournalShell.window-app .history-navigation .-emu-layout a,
+.-emu-layout body.-emu ul.command-menu li,
+body.-emu ul.command-menu .-emu-layout li,
+.-emu-layout body.-emu #token-action-hud button.tah-title-button,
+body.-emu #token-action-hud .-emu-layout button.tah-title-button,
+.-emu-layout body.-emu #token-action-hud .tah-action button,
+body.-emu #token-action-hud .tah-action .-emu-layout button,
+.-emu-layout body.-emu #sidebar .token-mold > label > span,
+body.-emu #sidebar .-emu-layout .token-mold > label > span,
+.-emu-layout body.-emu .sidebar-popout .token-mold > label > span,
+body.-emu .sidebar-popout .-emu-layout .token-mold > label > span,
+.-emu-layout body.-emu .sheet.active-effect-sheet .effects-header a,
+body.-emu .sheet.active-effect-sheet .-emu-layout .effects-header a,
+.-emu-layout body.-emu .sheet.roll-table-config .table-results .table-header a,
+body.-emu .sheet.roll-table-config .table-results .-emu-layout .table-header a,
+.-emu-layout
+  body.-emu
+  .dice-so-nice
+  section.content
+  .settings-list
+  .sfxs-list
+  .sfx-header
+  a,
+body.-emu
+  .dice-so-nice
+  section.content
+  .settings-list
+  .sfxs-list
+  .-emu-layout
+  .sfx-header
+  a,
+.-emu-layout
+  body.-emu
+  .window-app[id*="ActiveEffects-"]
+  .window-content
+  > form
+  .dnd5e.sheet.item
+  .effect-header
+  a,
+body.-emu
+  .window-app[id*="ActiveEffects-"]
+  .window-content
+  > form
+  .dnd5e.sheet.item
+  .-emu-layout
+  .effect-header
+  a,
+.-emu-layout body.-emu .sheet.active-effect-sheet .changes-list li a,
+body.-emu .sheet.active-effect-sheet .changes-list .-emu-layout li a,
+.-emu-layout body.-emu .sheet.roll-table-config .table-results .table-result a,
+body.-emu .sheet.roll-table-config .table-results .-emu-layout .table-result a,
+.-emu-layout
+  body.-emu
+  .dice-so-nice
+  section.content
+  .settings-list
+  .sfxs-list
+  .sfx
+  a,
+body.-emu
+  .dice-so-nice
+  section.content
+  .settings-list
+  .sfxs-list
+  .-emu-layout
+  .sfx
+  a,
+.-emu-layout
+  body.-emu
+  .dialog
+  .directory
+  .directory-item.folder
+  .folder-header
+  .create-folder,
+body.-emu
+  .dialog
+  .directory
+  .directory-item.folder
+  .folder-header
+  .-emu-layout
+  .create-folder,
+.-emu-layout
+  body.-emu
+  .dialog
+  .directory
+  .directory-item.folder
+  .folder-header
+  .create-entity,
+body.-emu
+  .dialog
+  .directory
+  .directory-item.folder
+  .folder-header
+  .-emu-layout
+  .create-entity,
+.-emu-layout
+  body.-emu
+  #sidebar
+  .directory
+  .directory-item.folder
+  .folder-header
+  .create-folder,
+body.-emu
+  #sidebar
+  .directory
+  .directory-item.folder
+  .folder-header
+  .-emu-layout
+  .create-folder,
+.-emu-layout
+  body.-emu
+  #sidebar
+  .directory
+  .directory-item.folder
+  .folder-header
+  .create-entity,
+body.-emu
+  #sidebar
+  .directory
+  .directory-item.folder
+  .folder-header
+  .-emu-layout
+  .create-entity,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .directory
+  .directory-item.folder
+  .folder-header
+  .create-folder,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .directory
+  .directory-item.folder
+  .folder-header
+  .-emu-layout
+  .create-folder,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .directory
+  .directory-item.folder
+  .folder-header
+  .create-entity,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .directory
+  .directory-item.folder
+  .folder-header
+  .-emu-layout
+  .create-entity,
+.-emu-layout body.-emu #navigation #nav-toggle,
+body.-emu #navigation .-emu-layout #nav-toggle,
+.-emu-layout body.-emu .window-app .window-header > a,
+.-emu-layout body.-emu .window-app .window-header a.header-button,
+.-emu-layout body.-emu #sidebar #chat #chat-log .message .button.message-delete,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #chat
+  #chat-log
+  .message
+  .button.message-delete,
+.-emu-layout
+  body.-emu
+  #sidebar
+  #chat
+  #chat-controls
+  .chat-control-icon
+  .fa-dice-d20,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #chat
+  #chat-controls
+  .chat-control-icon
+  .fa-dice-d20,
+.-emu-layout body.-emu #sidebar #chat #chat-controls .control-buttons .button,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #chat
+  #chat-controls
+  .control-buttons
+  .button,
+.-emu-layout body.-emu #sidebar #combat #combat-round .encounters a,
+body.-emu #sidebar #combat #combat-round .encounters .-emu-layout a,
+.-emu-layout body.-emu .sidebar-popout #combat #combat-round .encounters a,
+body.-emu .sidebar-popout #combat #combat-round .encounters .-emu-layout a,
+.-emu-layout
+  body.-emu
+  #sidebar
+  #combat
+  #combat-tracker
+  .combatant
+  .combatant-control,
+body.-emu
+  #sidebar
+  #combat
+  #combat-tracker
+  .combatant
+  .-emu-layout
+  .combatant-control,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #combat
+  #combat-tracker
+  .combatant
+  .combatant-control,
+body.-emu
+  .sidebar-popout
+  #combat
+  #combat-tracker
+  .combatant
+  .-emu-layout
+  .combatant-control,
+.-emu-layout
+  body.-emu
+  #sidebar
+  #playlists
+  .directory-list
+  .playlist-header
+  .sound-controls
+  .sound-control,
+body.-emu
+  #sidebar
+  #playlists
+  .directory-list
+  .playlist-header
+  .sound-controls
+  .-emu-layout
+  .sound-control,
+.-emu-layout
+  body.-emu
+  #sidebar
+  #playlists
+  .directory-list
+  .sound
+  .sound-controls
+  .sound-control,
+body.-emu
+  #sidebar
+  #playlists
+  .directory-list
+  .sound
+  .sound-controls
+  .-emu-layout
+  .sound-control,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #playlists
+  .directory-list
+  .playlist-header
+  .sound-controls
+  .sound-control,
+body.-emu
+  .sidebar-popout
+  #playlists
+  .directory-list
+  .playlist-header
+  .sound-controls
+  .-emu-layout
+  .sound-control,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #playlists
+  .directory-list
+  .sound
+  .sound-controls
+  .sound-control,
+body.-emu
+  .sidebar-popout
+  #playlists
+  .directory-list
+  .sound
+  .sound-controls
+  .-emu-layout
+  .sound-control,
+.-emu-layout
+  body.-emu
+  #sidebar
+  #playlists
+  #currently-playing
+  .sound
+  .sound-control,
+body.-emu
+  #sidebar
+  #playlists
+  #currently-playing
+  .sound
+  .-emu-layout
+  .sound-control,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #playlists
+  #currently-playing
+  .sound
+  .sound-control,
+body.-emu
+  .sidebar-popout
+  #playlists
+  #currently-playing
+  .sound
+  .-emu-layout
+  .sound-control,
+.-emu-layout
+  body.-emu
+  .window-app[id*="chat-popout-"]
+  .chat-message
+  .chat-card
+  .die-result-overlay-br
+  button,
+body.-emu
+  .window-app[id*="chat-popout-"]
+  .chat-message
+  .chat-card
+  .die-result-overlay-br
+  .-emu-layout
+  button,
+.-emu-layout
+  body.-emu
+  #sidebar
+  #chat
+  #chat-log
+  .chat-message
+  .chat-card
+  .die-result-overlay-br
+  button,
+body.-emu
+  #sidebar
+  #chat
+  #chat-log
+  .chat-message
+  .chat-card
+  .die-result-overlay-br
+  .-emu-layout
+  button,
+.-emu-layout body.-emu #dfcp-rt-buttons button,
+body.-emu #dfcp-rt-buttons .-emu-layout button,
+.-emu-layout
+  body.-emu
+  .active-effect-sheet[id*="ActiveEffectsConfig-"]
+  .effect-special-duration
+  .effect-control,
+body.-emu
+  .active-effect-sheet[id*="ActiveEffectsConfig-"]
+  .effect-special-duration
+  .-emu-layout
+  .effect-control,
+.-emu-layout body.-emu #specials-config .fxmaster .special-effects .controls a,
+body.-emu #specials-config .fxmaster .special-effects .controls .-emu-layout a,
+.-emu-layout body.-emu div.permission-viewer a,
+body.-emu div.permission-viewer .-emu-layout a,
+.-emu-layout
+  body.-emu
+  #sidebar
+  #chat
+  #chat-log
+  .message
+  .button.polyglot-message-language,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #chat
+  #chat-log
+  .message
+  .button.polyglot-message-language,
+.-emu-layout body.-emu #smalltime-app #displayContainer .arrow,
+body.-emu #smalltime-app #displayContainer .-emu-layout .arrow,
+.-emu-layout body.-emu #token-action-hud #tah-reposition,
+body.-emu #token-action-hud .-emu-layout #tah-reposition,
+.-emu-layout body.-emu #token-action-hud #tah-categories,
+body.-emu #token-action-hud .-emu-layout #tah-categories,
+.-emu-layout body.-emu #sidebar .token-mold > a,
+body.-emu #sidebar .-emu-layout .token-mold > a,
+.-emu-layout body.-emu .sidebar-popout .token-mold > a,
+body.-emu .sidebar-popout .-emu-layout .token-mold > a,
+.-emu-layout body.-emu #sidebar .sidebar-tab .directory-header .header-control,
+body.-emu #sidebar .sidebar-tab .directory-header .-emu-layout .header-control,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  .sidebar-tab
+  .directory-header
+  .header-control,
+body.-emu
+  .sidebar-popout
+  .sidebar-tab
+  .directory-header
+  .-emu-layout
+  .header-control {
+  align-items: center;
+  cursor: pointer;
+  display: inline-flex;
+  font-size: var(--emu-font-size-lg);
+  font-family: inherit;
+  height: initial;
+  justify-content: center;
+  line-height: 1;
+  margin: 0;
+  padding: var(--emu-space-sm);
+  position: relative;
+}
+.-emu-layout body.-emu .dialog .tabs a > i,
+body.-emu .dialog .tabs .-emu-layout a > i,
+.-emu-layout body.-emu .dialog .sheet-tabs a > i,
+body.-emu .dialog .sheet-tabs .-emu-layout a > i,
+.-emu-layout body.-emu #sidebar .tabs a > i,
+body.-emu #sidebar .tabs .-emu-layout a > i,
+.-emu-layout body.-emu #sidebar .sheet-tabs a > i,
+body.-emu #sidebar .sheet-tabs .-emu-layout a > i,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .tabs
+  a
+  > i,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .tabs
+  .-emu-layout
+  a
+  > i,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .sheet-tabs
+  a
+  > i,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .sheet-tabs
+  .-emu-layout
+  a
+  > i,
+.-emu-layout body.-emu #module-management .list-filters a > i,
+body.-emu #module-management .list-filters .-emu-layout a > i,
+.-emu-layout body.-emu .dialog button > i,
+body.-emu .dialog .-emu-layout button > i,
+.-emu-layout body.-emu #sidebar button > i,
+body.-emu #sidebar .-emu-layout button > i,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  button
+  > i,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .-emu-layout
+  button
+  > i,
+.-emu-layout body.-emu #menu #menu-items li > i,
+body.-emu #menu #menu-items .-emu-layout li > i,
+.-emu-layout body.-emu #sidebar #combat #combat-controls .combat-control > i,
+body.-emu #sidebar #combat #combat-controls .-emu-layout .combat-control > i,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #combat
+  #combat-controls
+  .combat-control
+  > i,
+body.-emu
+  .sidebar-popout
+  #combat
+  #combat-controls
+  .-emu-layout
+  .combat-control
+  > i,
+.-emu-layout body.-emu .filepicker.window-app .display-modes .display-mode > i,
+body.-emu .filepicker.window-app .display-modes .-emu-layout .display-mode > i,
+.-emu-layout
+  body.-emu
+  .journal-sheet.sheet.window-app
+  .window-content
+  .editor-edit
+  > i,
+body.-emu
+  .journal-sheet.sheet.window-app
+  .window-content
+  .-emu-layout
+  .editor-edit
+  > i,
+.-emu-layout
+  body.-emu
+  #calendar-time-container
+  .calendar--time-controls
+  .advance-btn
+  > i,
+body.-emu
+  #calendar-time-container
+  .calendar--time-controls
+  .-emu-layout
+  .advance-btn
+  > i,
+.-emu-layout
+  body.-emu
+  #calendar-weather-container
+  .calendar--time-controls
+  .advance-btn
+  > i,
+body.-emu
+  #calendar-weather-container
+  .calendar--time-controls
+  .-emu-layout
+  .advance-btn
+  > i,
+.-emu-layout body.-emu #sidebar #combat .add-temporary > i,
+body.-emu #sidebar #combat .-emu-layout .add-temporary > i,
+.-emu-layout body.-emu .sidebar-popout #combat .add-temporary > i,
+body.-emu .sidebar-popout #combat .-emu-layout .add-temporary > i,
+.-emu-layout
+  body.-emu
+  .window-app[id*="ActiveEffects-"]
+  .window-content
+  > form
+  li.filter-item
+  > i,
+body.-emu
+  .window-app[id*="ActiveEffects-"]
+  .window-content
+  > form
+  .-emu-layout
+  li.filter-item
+  > i,
+.-emu-layout body.-emu #specials-config .fxmaster .directory-header a > i,
+body.-emu #specials-config .fxmaster .directory-header .-emu-layout a > i,
+.-emu-layout body.-emu .moulinette-options li > i,
+body.-emu .moulinette-options .-emu-layout li > i,
+.-emu-layout body.-emu #moulinette.forge .filepicker .display-modes a > i,
+body.-emu #moulinette.forge .filepicker .display-modes .-emu-layout a > i,
+.-emu-layout body.-emu #OneJournalShell.window-app .history-navigation a > i,
+body.-emu #OneJournalShell.window-app .history-navigation .-emu-layout a > i,
+.-emu-layout body.-emu ul.command-menu li > i,
+body.-emu ul.command-menu .-emu-layout li > i,
+.-emu-layout body.-emu #token-action-hud button.tah-title-button > i,
+body.-emu #token-action-hud .-emu-layout button.tah-title-button > i,
+.-emu-layout body.-emu #token-action-hud .tah-action button > i,
+body.-emu #token-action-hud .tah-action .-emu-layout button > i,
+.-emu-layout body.-emu #sidebar .token-mold > label > span > i,
+body.-emu #sidebar .-emu-layout .token-mold > label > span > i,
+.-emu-layout body.-emu .sidebar-popout .token-mold > label > span > i,
+body.-emu .sidebar-popout .-emu-layout .token-mold > label > span > i,
+.-emu-layout body.-emu .sheet.active-effect-sheet .effects-header a > i,
+body.-emu .sheet.active-effect-sheet .-emu-layout .effects-header a > i,
+.-emu-layout
+  body.-emu
+  .sheet.roll-table-config
+  .table-results
+  .table-header
+  a
+  > i,
+body.-emu
+  .sheet.roll-table-config
+  .table-results
+  .-emu-layout
+  .table-header
+  a
+  > i,
+.-emu-layout
+  body.-emu
+  .dice-so-nice
+  section.content
+  .settings-list
+  .sfxs-list
+  .sfx-header
+  a
+  > i,
+body.-emu
+  .dice-so-nice
+  section.content
+  .settings-list
+  .sfxs-list
+  .-emu-layout
+  .sfx-header
+  a
+  > i,
+.-emu-layout
+  body.-emu
+  .window-app[id*="ActiveEffects-"]
+  .window-content
+  > form
+  .dnd5e.sheet.item
+  .effect-header
+  a
+  > i,
+body.-emu
+  .window-app[id*="ActiveEffects-"]
+  .window-content
+  > form
+  .dnd5e.sheet.item
+  .-emu-layout
+  .effect-header
+  a
+  > i,
+.-emu-layout body.-emu .sheet.active-effect-sheet .changes-list li a > i,
+body.-emu .sheet.active-effect-sheet .changes-list .-emu-layout li a > i,
+.-emu-layout
+  body.-emu
+  .sheet.roll-table-config
+  .table-results
+  .table-result
+  a
+  > i,
+body.-emu
+  .sheet.roll-table-config
+  .table-results
+  .-emu-layout
+  .table-result
+  a
+  > i,
+.-emu-layout
+  body.-emu
+  .dice-so-nice
+  section.content
+  .settings-list
+  .sfxs-list
+  .sfx
+  a
+  > i,
+body.-emu
+  .dice-so-nice
+  section.content
+  .settings-list
+  .sfxs-list
+  .-emu-layout
+  .sfx
+  a
+  > i,
+.-emu-layout
+  body.-emu
+  .dialog
+  .directory
+  .directory-item.folder
+  .folder-header
+  .create-folder
+  > i,
+body.-emu
+  .dialog
+  .directory
+  .directory-item.folder
+  .folder-header
+  .-emu-layout
+  .create-folder
+  > i,
+.-emu-layout
+  body.-emu
+  .dialog
+  .directory
+  .directory-item.folder
+  .folder-header
+  .create-entity
+  > i,
+body.-emu
+  .dialog
+  .directory
+  .directory-item.folder
+  .folder-header
+  .-emu-layout
+  .create-entity
+  > i,
+.-emu-layout
+  body.-emu
+  #sidebar
+  .directory
+  .directory-item.folder
+  .folder-header
+  .create-folder
+  > i,
+body.-emu
+  #sidebar
+  .directory
+  .directory-item.folder
+  .folder-header
+  .-emu-layout
+  .create-folder
+  > i,
+.-emu-layout
+  body.-emu
+  #sidebar
+  .directory
+  .directory-item.folder
+  .folder-header
+  .create-entity
+  > i,
+body.-emu
+  #sidebar
+  .directory
+  .directory-item.folder
+  .folder-header
+  .-emu-layout
+  .create-entity
+  > i,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .directory
+  .directory-item.folder
+  .folder-header
+  .create-folder
+  > i,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .directory
+  .directory-item.folder
+  .folder-header
+  .-emu-layout
+  .create-folder
+  > i,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .directory
+  .directory-item.folder
+  .folder-header
+  .create-entity
+  > i,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .directory
+  .directory-item.folder
+  .folder-header
+  .-emu-layout
+  .create-entity
+  > i,
+.-emu-layout body.-emu #navigation #nav-toggle > i,
+body.-emu #navigation .-emu-layout #nav-toggle > i,
+.-emu-layout body.-emu .window-app .window-header > a > i,
+.-emu-layout body.-emu .window-app .window-header a.header-button > i,
+.-emu-layout
+  body.-emu
+  #sidebar
+  #chat
+  #chat-log
+  .message
+  .button.message-delete
+  > i,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #chat
+  #chat-log
+  .message
+  .button.message-delete
+  > i,
+.-emu-layout
+  body.-emu
+  #sidebar
+  #chat
+  #chat-controls
+  .chat-control-icon
+  .fa-dice-d20
+  > i,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #chat
+  #chat-controls
+  .chat-control-icon
+  .fa-dice-d20
+  > i,
+.-emu-layout
+  body.-emu
+  #sidebar
+  #chat
+  #chat-controls
+  .control-buttons
+  .button
+  > i,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #chat
+  #chat-controls
+  .control-buttons
+  .button
+  > i,
+.-emu-layout body.-emu #sidebar #combat #combat-round .encounters a > i,
+body.-emu #sidebar #combat #combat-round .encounters .-emu-layout a > i,
+.-emu-layout body.-emu .sidebar-popout #combat #combat-round .encounters a > i,
+body.-emu .sidebar-popout #combat #combat-round .encounters .-emu-layout a > i,
+.-emu-layout
+  body.-emu
+  #sidebar
+  #combat
+  #combat-tracker
+  .combatant
+  .combatant-control
+  > i,
+body.-emu
+  #sidebar
+  #combat
+  #combat-tracker
+  .combatant
+  .-emu-layout
+  .combatant-control
+  > i,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #combat
+  #combat-tracker
+  .combatant
+  .combatant-control
+  > i,
+body.-emu
+  .sidebar-popout
+  #combat
+  #combat-tracker
+  .combatant
+  .-emu-layout
+  .combatant-control
+  > i,
+.-emu-layout
+  body.-emu
+  #sidebar
+  #playlists
+  .directory-list
+  .playlist-header
+  .sound-controls
+  .sound-control
+  > i,
+body.-emu
+  #sidebar
+  #playlists
+  .directory-list
+  .playlist-header
+  .sound-controls
+  .-emu-layout
+  .sound-control
+  > i,
+.-emu-layout
+  body.-emu
+  #sidebar
+  #playlists
+  .directory-list
+  .sound
+  .sound-controls
+  .sound-control
+  > i,
+body.-emu
+  #sidebar
+  #playlists
+  .directory-list
+  .sound
+  .sound-controls
+  .-emu-layout
+  .sound-control
+  > i,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #playlists
+  .directory-list
+  .playlist-header
+  .sound-controls
+  .sound-control
+  > i,
+body.-emu
+  .sidebar-popout
+  #playlists
+  .directory-list
+  .playlist-header
+  .sound-controls
+  .-emu-layout
+  .sound-control
+  > i,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #playlists
+  .directory-list
+  .sound
+  .sound-controls
+  .sound-control
+  > i,
+body.-emu
+  .sidebar-popout
+  #playlists
+  .directory-list
+  .sound
+  .sound-controls
+  .-emu-layout
+  .sound-control
+  > i,
+.-emu-layout
+  body.-emu
+  #sidebar
+  #playlists
+  #currently-playing
+  .sound
+  .sound-control
+  > i,
+body.-emu
+  #sidebar
+  #playlists
+  #currently-playing
+  .sound
+  .-emu-layout
+  .sound-control
+  > i,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #playlists
+  #currently-playing
+  .sound
+  .sound-control
+  > i,
+body.-emu
+  .sidebar-popout
+  #playlists
+  #currently-playing
+  .sound
+  .-emu-layout
+  .sound-control
+  > i,
+.-emu-layout
+  body.-emu
+  .window-app[id*="chat-popout-"]
+  .chat-message
+  .chat-card
+  .die-result-overlay-br
+  button
+  > i,
+body.-emu
+  .window-app[id*="chat-popout-"]
+  .chat-message
+  .chat-card
+  .die-result-overlay-br
+  .-emu-layout
+  button
+  > i,
+.-emu-layout
+  body.-emu
+  #sidebar
+  #chat
+  #chat-log
+  .chat-message
+  .chat-card
+  .die-result-overlay-br
+  button
+  > i,
+body.-emu
+  #sidebar
+  #chat
+  #chat-log
+  .chat-message
+  .chat-card
+  .die-result-overlay-br
+  .-emu-layout
+  button
+  > i,
+.-emu-layout body.-emu #dfcp-rt-buttons button > i,
+body.-emu #dfcp-rt-buttons .-emu-layout button > i,
+.-emu-layout
+  body.-emu
+  .active-effect-sheet[id*="ActiveEffectsConfig-"]
+  .effect-special-duration
+  .effect-control
+  > i,
+body.-emu
+  .active-effect-sheet[id*="ActiveEffectsConfig-"]
+  .effect-special-duration
+  .-emu-layout
+  .effect-control
+  > i,
+.-emu-layout
+  body.-emu
+  #specials-config
+  .fxmaster
+  .special-effects
+  .controls
+  a
+  > i,
+body.-emu
+  #specials-config
+  .fxmaster
+  .special-effects
+  .controls
+  .-emu-layout
+  a
+  > i,
+.-emu-layout body.-emu div.permission-viewer a > i,
+body.-emu div.permission-viewer .-emu-layout a > i,
+.-emu-layout
+  body.-emu
+  #sidebar
+  #chat
+  #chat-log
+  .message
+  .button.polyglot-message-language
+  > i,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #chat
+  #chat-log
+  .message
+  .button.polyglot-message-language
+  > i,
+.-emu-layout body.-emu #smalltime-app #displayContainer .arrow > i,
+body.-emu #smalltime-app #displayContainer .-emu-layout .arrow > i,
+.-emu-layout body.-emu #token-action-hud #tah-reposition > i,
+body.-emu #token-action-hud .-emu-layout #tah-reposition > i,
+.-emu-layout body.-emu #token-action-hud #tah-categories > i,
+body.-emu #token-action-hud .-emu-layout #tah-categories > i,
+.-emu-layout body.-emu #sidebar .token-mold > a > i,
+body.-emu #sidebar .-emu-layout .token-mold > a > i,
+.-emu-layout body.-emu .sidebar-popout .token-mold > a > i,
+body.-emu .sidebar-popout .-emu-layout .token-mold > a > i,
+.-emu-layout
+  body.-emu
+  #sidebar
+  .sidebar-tab
+  .directory-header
+  .header-control
+  > i,
+body.-emu
+  #sidebar
+  .sidebar-tab
+  .directory-header
+  .-emu-layout
+  .header-control
+  > i,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  .sidebar-tab
+  .directory-header
+  .header-control
+  > i,
+body.-emu
+  .sidebar-popout
+  .sidebar-tab
+  .directory-header
+  .-emu-layout
+  .header-control
+  > i {
+  -webkit-margin-end: var(--emu-space-sm);
+  margin-inline-end: var(--emu-space-sm);
+}
+body.-emu .dialog .tabs a:hover,
+body.-emu .dialog .sheet-tabs a:hover,
+body.-emu #sidebar .tabs a:hover,
+body.-emu #sidebar .sheet-tabs a:hover,
+body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .tabs a:hover,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .sheet-tabs
+  a:hover,
+body.-emu #module-management .list-filters a:hover,
+body.-emu .dialog button:hover,
+body.-emu #sidebar button:hover,
+body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) button:hover,
+body.-emu #menu #menu-items li:hover,
+body.-emu #sidebar #combat #combat-controls .combat-control:hover,
+body.-emu .sidebar-popout #combat #combat-controls .combat-control:hover,
+body.-emu .filepicker.window-app .display-modes .display-mode:hover,
+body.-emu .journal-sheet.sheet.window-app .window-content .editor-edit:hover,
+body.-emu #calendar-time-container .calendar--time-controls .advance-btn:hover,
+body.-emu
+  #calendar-weather-container
+  .calendar--time-controls
+  .advance-btn:hover,
+body.-emu #sidebar #combat .add-temporary:hover,
+body.-emu .sidebar-popout #combat .add-temporary:hover,
+body.-emu
+  .window-app[id*="ActiveEffects-"]
+  .window-content
+  > form
+  li.filter-item:hover,
+body.-emu #specials-config .fxmaster .directory-header a:hover,
+body.-emu .moulinette-options li:hover,
+body.-emu #moulinette.forge .filepicker .display-modes a:hover,
+body.-emu #OneJournalShell.window-app .history-navigation a:hover,
+body.-emu ul.command-menu li:hover,
+body.-emu #token-action-hud button.tah-title-button:hover,
+body.-emu #token-action-hud .tah-action button:hover,
+body.-emu #sidebar .token-mold > label > span:hover,
+body.-emu .sidebar-popout .token-mold > label > span:hover,
+.-emu-layout body.-emu .sheet.active-effect-sheet .effects-header a:hover,
+body.-emu .sheet.active-effect-sheet .-emu-layout .effects-header a:hover,
+.-emu-layout
+  body.-emu
+  .sheet.roll-table-config
+  .table-results
+  .table-header
+  a:hover,
+body.-emu
+  .sheet.roll-table-config
+  .table-results
+  .-emu-layout
+  .table-header
+  a:hover,
+.-emu-layout
+  body.-emu
+  .dice-so-nice
+  section.content
+  .settings-list
+  .sfxs-list
+  .sfx-header
+  a:hover,
+body.-emu
+  .dice-so-nice
+  section.content
+  .settings-list
+  .sfxs-list
+  .-emu-layout
+  .sfx-header
+  a:hover,
+.-emu-layout
+  body.-emu
+  .window-app[id*="ActiveEffects-"]
+  .window-content
+  > form
+  .dnd5e.sheet.item
+  .effect-header
+  a:hover,
+body.-emu
+  .window-app[id*="ActiveEffects-"]
+  .window-content
+  > form
+  .dnd5e.sheet.item
+  .-emu-layout
+  .effect-header
+  a:hover,
+.-emu-layout body.-emu .sheet.active-effect-sheet .changes-list li a:hover,
+body.-emu .sheet.active-effect-sheet .changes-list .-emu-layout li a:hover,
+.-emu-layout
+  body.-emu
+  .sheet.roll-table-config
+  .table-results
+  .table-result
+  a:hover,
+body.-emu
+  .sheet.roll-table-config
+  .table-results
+  .-emu-layout
+  .table-result
+  a:hover,
+.-emu-layout
+  body.-emu
+  .dice-so-nice
+  section.content
+  .settings-list
+  .sfxs-list
+  .sfx
+  a:hover,
+body.-emu
+  .dice-so-nice
+  section.content
+  .settings-list
+  .sfxs-list
+  .-emu-layout
+  .sfx
+  a:hover,
+body.-emu
+  .dialog
+  .directory
+  .directory-item.folder
+  .folder-header
+  .create-folder:hover,
+body.-emu
+  .dialog
+  .directory
+  .directory-item.folder
+  .folder-header
+  .create-entity:hover,
+body.-emu
+  #sidebar
+  .directory
+  .directory-item.folder
+  .folder-header
+  .create-folder:hover,
+body.-emu
+  #sidebar
+  .directory
+  .directory-item.folder
+  .folder-header
+  .create-entity:hover,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .directory
+  .directory-item.folder
+  .folder-header
+  .create-folder:hover,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .directory
+  .directory-item.folder
+  .folder-header
+  .create-entity:hover,
+body.-emu #navigation #nav-toggle:hover,
+.-emu-layout body.-emu .window-app .window-header > a:hover,
+.-emu-layout body.-emu .window-app .window-header a.header-button:hover,
+.-emu-layout
+  body.-emu
+  #sidebar
+  #chat
+  #chat-log
+  .message
+  .button.message-delete:hover,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #chat
+  #chat-log
+  .message
+  .button.message-delete:hover,
+.-emu-layout
+  body.-emu
+  #sidebar
+  #chat
+  #chat-controls
+  .chat-control-icon
+  .fa-dice-d20:hover,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #chat
+  #chat-controls
+  .chat-control-icon
+  .fa-dice-d20:hover,
+.-emu-layout
+  body.-emu
+  #sidebar
+  #chat
+  #chat-controls
+  .control-buttons
+  .button:hover,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #chat
+  #chat-controls
+  .control-buttons
+  .button:hover,
+body.-emu #sidebar #combat #combat-round .encounters a:hover,
+body.-emu .sidebar-popout #combat #combat-round .encounters a:hover,
+body.-emu #sidebar #combat #combat-tracker .combatant .combatant-control:hover,
+body.-emu
+  .sidebar-popout
+  #combat
+  #combat-tracker
+  .combatant
+  .combatant-control:hover,
+body.-emu
+  #sidebar
+  #playlists
+  .directory-list
+  .playlist-header
+  .sound-controls
+  .sound-control:hover,
+body.-emu
+  #sidebar
+  #playlists
+  .directory-list
+  .sound
+  .sound-controls
+  .sound-control:hover,
+body.-emu
+  .sidebar-popout
+  #playlists
+  .directory-list
+  .playlist-header
+  .sound-controls
+  .sound-control:hover,
+body.-emu
+  .sidebar-popout
+  #playlists
+  .directory-list
+  .sound
+  .sound-controls
+  .sound-control:hover,
+body.-emu #sidebar #playlists #currently-playing .sound .sound-control:hover,
+body.-emu
+  .sidebar-popout
+  #playlists
+  #currently-playing
+  .sound
+  .sound-control:hover,
+body.-emu
+  .window-app[id*="chat-popout-"]
+  .chat-message
+  .chat-card
+  .die-result-overlay-br
+  button:hover,
+body.-emu
+  #sidebar
+  #chat
+  #chat-log
+  .chat-message
+  .chat-card
+  .die-result-overlay-br
+  button:hover,
+body.-emu #dfcp-rt-buttons button:hover,
+body.-emu
+  .active-effect-sheet[id*="ActiveEffectsConfig-"]
+  .effect-special-duration
+  .effect-control:hover,
+body.-emu #specials-config .fxmaster .special-effects .controls a:hover,
+body.-emu div.permission-viewer a:hover,
+.-emu-layout
+  body.-emu
+  #sidebar
+  #chat
+  #chat-log
+  .message
+  .button.polyglot-message-language:hover,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #chat
+  #chat-log
+  .message
+  .button.polyglot-message-language:hover,
+body.-emu #smalltime-app #displayContainer .arrow:hover,
+body.-emu #token-action-hud #tah-reposition:hover,
+body.-emu #token-action-hud #tah-categories:hover,
+body.-emu #sidebar .token-mold > a:hover,
+body.-emu .sidebar-popout .token-mold > a:hover,
+body.-emu #sidebar .sidebar-tab .directory-header .header-control:hover,
+body.-emu .sidebar-popout .sidebar-tab .directory-header .header-control:hover {
+  background-color: rgba(var(--color-primary), 1);
+  background-image: none;
+  color: rgba(var(--color-text-lightest), 1);
+}
+body.-emu .dialog .tabs a:disabled,
+body.-emu .dialog .sheet-tabs a:disabled,
+body.-emu #sidebar .tabs a:disabled,
+body.-emu #sidebar .sheet-tabs a:disabled,
+body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .tabs a:disabled,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .sheet-tabs
+  a:disabled,
+body.-emu #module-management .list-filters a:disabled,
+body.-emu .dialog button:disabled,
+body.-emu #sidebar button:disabled,
+body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) button:disabled,
+body.-emu #menu #menu-items li:disabled,
+body.-emu #sidebar #combat #combat-controls .combat-control:disabled,
+body.-emu .sidebar-popout #combat #combat-controls .combat-control:disabled,
+body.-emu .filepicker.window-app .display-modes .display-mode:disabled,
+body.-emu .journal-sheet.sheet.window-app .window-content .editor-edit:disabled,
+body.-emu
+  #calendar-time-container
+  .calendar--time-controls
+  .advance-btn:disabled,
+body.-emu
+  #calendar-weather-container
+  .calendar--time-controls
+  .advance-btn:disabled,
+body.-emu #sidebar #combat .add-temporary:disabled,
+body.-emu .sidebar-popout #combat .add-temporary:disabled,
+body.-emu
+  .window-app[id*="ActiveEffects-"]
+  .window-content
+  > form
+  li.filter-item:disabled,
+body.-emu #specials-config .fxmaster .directory-header a:disabled,
+body.-emu .moulinette-options li:disabled,
+body.-emu #moulinette.forge .filepicker .display-modes a:disabled,
+body.-emu #OneJournalShell.window-app .history-navigation a:disabled,
+body.-emu ul.command-menu li:disabled,
+body.-emu #token-action-hud button.tah-title-button:disabled,
+body.-emu #token-action-hud .tah-action button:disabled,
+body.-emu #sidebar .token-mold > label > span:disabled,
+body.-emu .sidebar-popout .token-mold > label > span:disabled,
+.-emu-layout body.-emu .sheet.active-effect-sheet .effects-header a:disabled,
+body.-emu .sheet.active-effect-sheet .-emu-layout .effects-header a:disabled,
+.-emu-layout
+  body.-emu
+  .sheet.roll-table-config
+  .table-results
+  .table-header
+  a:disabled,
+body.-emu
+  .sheet.roll-table-config
+  .table-results
+  .-emu-layout
+  .table-header
+  a:disabled,
+.-emu-layout
+  body.-emu
+  .dice-so-nice
+  section.content
+  .settings-list
+  .sfxs-list
+  .sfx-header
+  a:disabled,
+body.-emu
+  .dice-so-nice
+  section.content
+  .settings-list
+  .sfxs-list
+  .-emu-layout
+  .sfx-header
+  a:disabled,
+.-emu-layout
+  body.-emu
+  .window-app[id*="ActiveEffects-"]
+  .window-content
+  > form
+  .dnd5e.sheet.item
+  .effect-header
+  a:disabled,
+body.-emu
+  .window-app[id*="ActiveEffects-"]
+  .window-content
+  > form
+  .dnd5e.sheet.item
+  .-emu-layout
+  .effect-header
+  a:disabled,
+.-emu-layout body.-emu .sheet.active-effect-sheet .changes-list li a:disabled,
+body.-emu .sheet.active-effect-sheet .changes-list .-emu-layout li a:disabled,
+.-emu-layout
+  body.-emu
+  .sheet.roll-table-config
+  .table-results
+  .table-result
+  a:disabled,
+body.-emu
+  .sheet.roll-table-config
+  .table-results
+  .-emu-layout
+  .table-result
+  a:disabled,
+.-emu-layout
+  body.-emu
+  .dice-so-nice
+  section.content
+  .settings-list
+  .sfxs-list
+  .sfx
+  a:disabled,
+body.-emu
+  .dice-so-nice
+  section.content
+  .settings-list
+  .sfxs-list
+  .-emu-layout
+  .sfx
+  a:disabled,
+body.-emu
+  .dialog
+  .directory
+  .directory-item.folder
+  .folder-header
+  .create-folder:disabled,
+body.-emu
+  .dialog
+  .directory
+  .directory-item.folder
+  .folder-header
+  .create-entity:disabled,
+body.-emu
+  #sidebar
+  .directory
+  .directory-item.folder
+  .folder-header
+  .create-folder:disabled,
+body.-emu
+  #sidebar
+  .directory
+  .directory-item.folder
+  .folder-header
+  .create-entity:disabled,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .directory
+  .directory-item.folder
+  .folder-header
+  .create-folder:disabled,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .directory
+  .directory-item.folder
+  .folder-header
+  .create-entity:disabled,
+body.-emu #navigation #nav-toggle:disabled,
+.-emu-layout body.-emu .window-app .window-header > a:disabled,
+.-emu-layout body.-emu .window-app .window-header a.header-button:disabled,
+.-emu-layout
+  body.-emu
+  #sidebar
+  #chat
+  #chat-log
+  .message
+  .button.message-delete:disabled,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #chat
+  #chat-log
+  .message
+  .button.message-delete:disabled,
+.-emu-layout
+  body.-emu
+  #sidebar
+  #chat
+  #chat-controls
+  .chat-control-icon
+  .fa-dice-d20:disabled,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #chat
+  #chat-controls
+  .chat-control-icon
+  .fa-dice-d20:disabled,
+.-emu-layout
+  body.-emu
+  #sidebar
+  #chat
+  #chat-controls
+  .control-buttons
+  .button:disabled,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #chat
+  #chat-controls
+  .control-buttons
+  .button:disabled,
+body.-emu #sidebar #combat #combat-round .encounters a:disabled,
+body.-emu .sidebar-popout #combat #combat-round .encounters a:disabled,
+body.-emu
+  #sidebar
+  #combat
+  #combat-tracker
+  .combatant
+  .combatant-control:disabled,
+body.-emu
+  .sidebar-popout
+  #combat
+  #combat-tracker
+  .combatant
+  .combatant-control:disabled,
+body.-emu
+  #sidebar
+  #playlists
+  .directory-list
+  .playlist-header
+  .sound-controls
+  .sound-control:disabled,
+body.-emu
+  #sidebar
+  #playlists
+  .directory-list
+  .sound
+  .sound-controls
+  .sound-control:disabled,
+body.-emu
+  .sidebar-popout
+  #playlists
+  .directory-list
+  .playlist-header
+  .sound-controls
+  .sound-control:disabled,
+body.-emu
+  .sidebar-popout
+  #playlists
+  .directory-list
+  .sound
+  .sound-controls
+  .sound-control:disabled,
+body.-emu #sidebar #playlists #currently-playing .sound .sound-control:disabled,
+body.-emu
+  .sidebar-popout
+  #playlists
+  #currently-playing
+  .sound
+  .sound-control:disabled,
+body.-emu
+  .window-app[id*="chat-popout-"]
+  .chat-message
+  .chat-card
+  .die-result-overlay-br
+  button:disabled,
+body.-emu
+  #sidebar
+  #chat
+  #chat-log
+  .chat-message
+  .chat-card
+  .die-result-overlay-br
+  button:disabled,
+body.-emu #dfcp-rt-buttons button:disabled,
+body.-emu
+  .active-effect-sheet[id*="ActiveEffectsConfig-"]
+  .effect-special-duration
+  .effect-control:disabled,
+body.-emu #specials-config .fxmaster .special-effects .controls a:disabled,
+body.-emu div.permission-viewer a:disabled,
+.-emu-layout
+  body.-emu
+  #sidebar
+  #chat
+  #chat-log
+  .message
+  .button.polyglot-message-language:disabled,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #chat
+  #chat-log
+  .message
+  .button.polyglot-message-language:disabled,
+body.-emu #smalltime-app #displayContainer .arrow:disabled,
+body.-emu #token-action-hud #tah-reposition:disabled,
+body.-emu #token-action-hud #tah-categories:disabled,
+body.-emu #sidebar .token-mold > a:disabled,
+body.-emu .sidebar-popout .token-mold > a:disabled,
+body.-emu #sidebar .sidebar-tab .directory-header .header-control:disabled,
+body.-emu
+  .sidebar-popout
+  .sidebar-tab
+  .directory-header
+  .header-control:disabled {
+  opacity: 0.5;
+  pointer-events: none;
+}
 
-body.-emu .dialog .tabs a, body.-emu .dialog .sheet-tabs a, body.-emu #sidebar .tabs a, body.-emu #sidebar .sheet-tabs a, body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .tabs a, body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .sheet-tabs a, body.-emu #module-management .list-filters a, body.-emu .dialog button,
+body.-emu .dialog .tabs a,
+body.-emu .dialog .sheet-tabs a,
+body.-emu #sidebar .tabs a,
+body.-emu #sidebar .sheet-tabs a,
+body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .tabs a,
+body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .sheet-tabs a,
+body.-emu #module-management .list-filters a,
+body.-emu .dialog button,
 body.-emu #sidebar button,
-body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) button, body.-emu #menu #menu-items li, body.-emu #sidebar #combat #combat-controls .combat-control,
-body.-emu .sidebar-popout #combat #combat-controls .combat-control, body.-emu .filepicker.window-app .display-modes .display-mode, body.-emu .journal-sheet.sheet.window-app .window-content .editor-edit, body.-emu #calendar-time-container .calendar--time-controls .advance-btn,
-body.-emu #calendar-weather-container .calendar--time-controls .advance-btn, body.-emu #sidebar #combat .add-temporary,
-body.-emu .sidebar-popout #combat .add-temporary, body.-emu .window-app[id*="ActiveEffects-"] .window-content > form li.filter-item, body.-emu #specials-config .fxmaster .directory-header a, body.-emu .moulinette-options li, body.-emu #moulinette.forge .filepicker .display-modes a, body.-emu #OneJournalShell.window-app .history-navigation a, body.-emu ul.command-menu li, body.-emu #token-action-hud button.tah-title-button,
-body.-emu #token-action-hud .tah-action button, body.-emu #sidebar .token-mold > label > span,
+body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) button,
+body.-emu #menu #menu-items li,
+body.-emu #sidebar #combat #combat-controls .combat-control,
+body.-emu .sidebar-popout #combat #combat-controls .combat-control,
+body.-emu .filepicker.window-app .display-modes .display-mode,
+body.-emu .journal-sheet.sheet.window-app .window-content .editor-edit,
+body.-emu #calendar-time-container .calendar--time-controls .advance-btn,
+body.-emu #calendar-weather-container .calendar--time-controls .advance-btn,
+body.-emu #sidebar #combat .add-temporary,
+body.-emu .sidebar-popout #combat .add-temporary,
+body.-emu
+  .window-app[id*="ActiveEffects-"]
+  .window-content
+  > form
+  li.filter-item,
+body.-emu #specials-config .fxmaster .directory-header a,
+body.-emu .moulinette-options li,
+body.-emu #moulinette.forge .filepicker .display-modes a,
+body.-emu #OneJournalShell.window-app .history-navigation a,
+body.-emu ul.command-menu li,
+body.-emu #token-action-hud button.tah-title-button,
+body.-emu #token-action-hud .tah-action button,
+body.-emu #sidebar .token-mold > label > span,
 body.-emu .sidebar-popout .token-mold > label > span {
-  background-color: rgba(var(--color-background-button), var(--emu-background-opacity-button-primary, 1)); }
+  background-color: rgba(
+    var(--color-background-button),
+    var(--emu-background-opacity-button-primary, 1)
+  );
+}
 
 body.-emu .dialog .dialog-buttons .dialog-button {
-  background-color: rgba(var(--color-background-button), var(--emu-background-opacity-button-primary, 1));
+  background-color: rgba(
+    var(--color-background-button),
+    var(--emu-background-opacity-button-primary, 1)
+  );
   background-image: var(--emu-image-background-controls, none);
-  border: none; }
-  .-emu-layout body.-emu .dialog .dialog-buttons .dialog-button, body.-emu .dialog .dialog-buttons .-emu-layout .dialog-button {
-    margin: 0; }
-  body.-emu .dialog .dialog-buttons .dialog-button:hover {
-    background-color: rgba(var(--color-primary), 1);
-    background-image: none;
-    color: rgba(var(--color-text-lightest), 1); }
-  .-emu-layout body.-emu .dialog .dialog-buttons .dialog-button + button, body.-emu .dialog .dialog-buttons .-emu-layout .dialog-button + button {
-    -webkit-margin-start: var(--emu-space-base);
-            margin-inline-start: var(--emu-space-base); }
+  border: none;
+}
+.-emu-layout body.-emu .dialog .dialog-buttons .dialog-button,
+body.-emu .dialog .dialog-buttons .-emu-layout .dialog-button {
+  margin: 0;
+}
+body.-emu .dialog .dialog-buttons .dialog-button:hover {
+  background-color: rgba(var(--color-primary), 1);
+  background-image: none;
+  color: rgba(var(--color-text-lightest), 1);
+}
+.-emu-layout body.-emu .dialog .dialog-buttons .dialog-button + button,
+body.-emu .dialog .dialog-buttons .-emu-layout .dialog-button + button {
+  -webkit-margin-start: var(--emu-space-base);
+  margin-inline-start: var(--emu-space-base);
+}
 
-.-emu-layout body.-emu .sheet.active-effect-sheet .effects-header a, body.-emu .sheet.active-effect-sheet .-emu-layout .effects-header a, .-emu-layout body.-emu .sheet.roll-table-config .table-results .table-header a, body.-emu .sheet.roll-table-config .table-results .-emu-layout .table-header a, .-emu-layout body.-emu .dice-so-nice section.content .settings-list .sfxs-list .sfx-header a, body.-emu .dice-so-nice section.content .settings-list .sfxs-list .-emu-layout .sfx-header a, .-emu-layout body.-emu .window-app[id*="ActiveEffects-"] .window-content > form .dnd5e.sheet.item .effect-header a, body.-emu .window-app[id*="ActiveEffects-"] .window-content > form .dnd5e.sheet.item .-emu-layout .effect-header a, .-emu-layout body.-emu .sheet.active-effect-sheet .changes-list li a, body.-emu .sheet.active-effect-sheet .changes-list .-emu-layout li a, .-emu-layout body.-emu .sheet.roll-table-config .table-results .table-result a, body.-emu .sheet.roll-table-config .table-results .-emu-layout .table-result a, .-emu-layout body.-emu .dice-so-nice section.content .settings-list .sfxs-list .sfx a, body.-emu .dice-so-nice section.content .settings-list .sfxs-list .-emu-layout .sfx a, .-emu-layout body.-emu .dialog .directory .directory-item.folder .folder-header .create-folder, body.-emu .dialog .directory .directory-item.folder .folder-header .-emu-layout .create-folder,
-.-emu-layout body.-emu .dialog .directory .directory-item.folder .folder-header .create-entity, body.-emu .dialog .directory .directory-item.folder .folder-header .-emu-layout .create-entity,
-.-emu-layout body.-emu #sidebar .directory .directory-item.folder .folder-header .create-folder, body.-emu #sidebar .directory .directory-item.folder .folder-header .-emu-layout .create-folder,
-.-emu-layout body.-emu #sidebar .directory .directory-item.folder .folder-header .create-entity, body.-emu #sidebar .directory .directory-item.folder .folder-header .-emu-layout .create-entity,
-.-emu-layout body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .directory .directory-item.folder .folder-header .create-folder, body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .directory .directory-item.folder .folder-header .-emu-layout .create-folder,
-.-emu-layout body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .directory .directory-item.folder .folder-header .create-entity, body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .directory .directory-item.folder .folder-header .-emu-layout .create-entity, .-emu-layout body.-emu #navigation #nav-toggle, body.-emu #navigation .-emu-layout #nav-toggle, .-emu-layout body.-emu .window-app .window-header > a, .-emu-layout body.-emu .window-app .window-header a.header-button, .-emu-layout body.-emu #sidebar #chat #chat-log .message .button.message-delete, .-emu-layout body.-emu .sidebar-popout #chat #chat-log .message .button.message-delete, .-emu-layout body.-emu #sidebar #chat #chat-controls .chat-control-icon .fa-dice-d20, .-emu-layout body.-emu .sidebar-popout #chat #chat-controls .chat-control-icon .fa-dice-d20, .-emu-layout body.-emu #sidebar #chat #chat-controls .control-buttons .button, .-emu-layout body.-emu .sidebar-popout #chat #chat-controls .control-buttons .button, .-emu-layout body.-emu #sidebar #combat #combat-round .encounters a, body.-emu #sidebar #combat #combat-round .encounters .-emu-layout a,
-.-emu-layout body.-emu .sidebar-popout #combat #combat-round .encounters a, body.-emu .sidebar-popout #combat #combat-round .encounters .-emu-layout a, .-emu-layout body.-emu #sidebar #combat #combat-tracker .combatant .combatant-control, body.-emu #sidebar #combat #combat-tracker .combatant .-emu-layout .combatant-control,
-.-emu-layout body.-emu .sidebar-popout #combat #combat-tracker .combatant .combatant-control, body.-emu .sidebar-popout #combat #combat-tracker .combatant .-emu-layout .combatant-control, .-emu-layout body.-emu #sidebar #playlists .directory-list .playlist-header .sound-controls .sound-control, body.-emu #sidebar #playlists .directory-list .playlist-header .sound-controls .-emu-layout .sound-control,
-.-emu-layout body.-emu #sidebar #playlists .directory-list .sound .sound-controls .sound-control, body.-emu #sidebar #playlists .directory-list .sound .sound-controls .-emu-layout .sound-control,
-.-emu-layout body.-emu .sidebar-popout #playlists .directory-list .playlist-header .sound-controls .sound-control, body.-emu .sidebar-popout #playlists .directory-list .playlist-header .sound-controls .-emu-layout .sound-control,
-.-emu-layout body.-emu .sidebar-popout #playlists .directory-list .sound .sound-controls .sound-control, body.-emu .sidebar-popout #playlists .directory-list .sound .sound-controls .-emu-layout .sound-control, .-emu-layout body.-emu #sidebar #playlists #currently-playing .sound .sound-control, body.-emu #sidebar #playlists #currently-playing .sound .-emu-layout .sound-control,
-.-emu-layout body.-emu .sidebar-popout #playlists #currently-playing .sound .sound-control, body.-emu .sidebar-popout #playlists #currently-playing .sound .-emu-layout .sound-control, .-emu-layout body.-emu .window-app[id*="chat-popout-"] .chat-message .chat-card .die-result-overlay-br button, body.-emu .window-app[id*="chat-popout-"] .chat-message .chat-card .die-result-overlay-br .-emu-layout button,
-.-emu-layout body.-emu #sidebar #chat #chat-log .chat-message .chat-card .die-result-overlay-br button, body.-emu #sidebar #chat #chat-log .chat-message .chat-card .die-result-overlay-br .-emu-layout button, .-emu-layout body.-emu #dfcp-rt-buttons button, body.-emu #dfcp-rt-buttons .-emu-layout button, .-emu-layout body.-emu .active-effect-sheet[id*="ActiveEffectsConfig-"] .effect-special-duration .effect-control, body.-emu .active-effect-sheet[id*="ActiveEffectsConfig-"] .effect-special-duration .-emu-layout .effect-control, .-emu-layout body.-emu #specials-config .fxmaster .special-effects .controls a, body.-emu #specials-config .fxmaster .special-effects .controls .-emu-layout a, .-emu-layout body.-emu div.permission-viewer a, body.-emu div.permission-viewer .-emu-layout a, .-emu-layout body.-emu #sidebar #chat #chat-log .message .button.polyglot-message-language, .-emu-layout body.-emu .sidebar-popout #chat #chat-log .message .button.polyglot-message-language, .-emu-layout body.-emu #smalltime-app #displayContainer .arrow, body.-emu #smalltime-app #displayContainer .-emu-layout .arrow, .-emu-layout body.-emu #token-action-hud #tah-reposition, body.-emu #token-action-hud .-emu-layout #tah-reposition,
-.-emu-layout body.-emu #token-action-hud #tah-categories, body.-emu #token-action-hud .-emu-layout #tah-categories, .-emu-layout body.-emu #sidebar .token-mold > a, body.-emu #sidebar .-emu-layout .token-mold > a,
-.-emu-layout body.-emu .sidebar-popout .token-mold > a, body.-emu .sidebar-popout .-emu-layout .token-mold > a {
+.-emu-layout body.-emu .sheet.active-effect-sheet .effects-header a,
+body.-emu .sheet.active-effect-sheet .-emu-layout .effects-header a,
+.-emu-layout body.-emu .sheet.roll-table-config .table-results .table-header a,
+body.-emu .sheet.roll-table-config .table-results .-emu-layout .table-header a,
+.-emu-layout
+  body.-emu
+  .dice-so-nice
+  section.content
+  .settings-list
+  .sfxs-list
+  .sfx-header
+  a,
+body.-emu
+  .dice-so-nice
+  section.content
+  .settings-list
+  .sfxs-list
+  .-emu-layout
+  .sfx-header
+  a,
+.-emu-layout
+  body.-emu
+  .window-app[id*="ActiveEffects-"]
+  .window-content
+  > form
+  .dnd5e.sheet.item
+  .effect-header
+  a,
+body.-emu
+  .window-app[id*="ActiveEffects-"]
+  .window-content
+  > form
+  .dnd5e.sheet.item
+  .-emu-layout
+  .effect-header
+  a,
+.-emu-layout body.-emu .sheet.active-effect-sheet .changes-list li a,
+body.-emu .sheet.active-effect-sheet .changes-list .-emu-layout li a,
+.-emu-layout body.-emu .sheet.roll-table-config .table-results .table-result a,
+body.-emu .sheet.roll-table-config .table-results .-emu-layout .table-result a,
+.-emu-layout
+  body.-emu
+  .dice-so-nice
+  section.content
+  .settings-list
+  .sfxs-list
+  .sfx
+  a,
+body.-emu
+  .dice-so-nice
+  section.content
+  .settings-list
+  .sfxs-list
+  .-emu-layout
+  .sfx
+  a,
+.-emu-layout
+  body.-emu
+  .dialog
+  .directory
+  .directory-item.folder
+  .folder-header
+  .create-folder,
+body.-emu
+  .dialog
+  .directory
+  .directory-item.folder
+  .folder-header
+  .-emu-layout
+  .create-folder,
+.-emu-layout
+  body.-emu
+  .dialog
+  .directory
+  .directory-item.folder
+  .folder-header
+  .create-entity,
+body.-emu
+  .dialog
+  .directory
+  .directory-item.folder
+  .folder-header
+  .-emu-layout
+  .create-entity,
+.-emu-layout
+  body.-emu
+  #sidebar
+  .directory
+  .directory-item.folder
+  .folder-header
+  .create-folder,
+body.-emu
+  #sidebar
+  .directory
+  .directory-item.folder
+  .folder-header
+  .-emu-layout
+  .create-folder,
+.-emu-layout
+  body.-emu
+  #sidebar
+  .directory
+  .directory-item.folder
+  .folder-header
+  .create-entity,
+body.-emu
+  #sidebar
+  .directory
+  .directory-item.folder
+  .folder-header
+  .-emu-layout
+  .create-entity,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .directory
+  .directory-item.folder
+  .folder-header
+  .create-folder,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .directory
+  .directory-item.folder
+  .folder-header
+  .-emu-layout
+  .create-folder,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .directory
+  .directory-item.folder
+  .folder-header
+  .create-entity,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .directory
+  .directory-item.folder
+  .folder-header
+  .-emu-layout
+  .create-entity,
+.-emu-layout body.-emu #navigation #nav-toggle,
+body.-emu #navigation .-emu-layout #nav-toggle,
+.-emu-layout body.-emu .window-app .window-header > a,
+.-emu-layout body.-emu .window-app .window-header a.header-button,
+.-emu-layout body.-emu #sidebar #chat #chat-log .message .button.message-delete,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #chat
+  #chat-log
+  .message
+  .button.message-delete,
+.-emu-layout
+  body.-emu
+  #sidebar
+  #chat
+  #chat-controls
+  .chat-control-icon
+  .fa-dice-d20,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #chat
+  #chat-controls
+  .chat-control-icon
+  .fa-dice-d20,
+.-emu-layout body.-emu #sidebar #chat #chat-controls .control-buttons .button,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #chat
+  #chat-controls
+  .control-buttons
+  .button,
+.-emu-layout body.-emu #sidebar #combat #combat-round .encounters a,
+body.-emu #sidebar #combat #combat-round .encounters .-emu-layout a,
+.-emu-layout body.-emu .sidebar-popout #combat #combat-round .encounters a,
+body.-emu .sidebar-popout #combat #combat-round .encounters .-emu-layout a,
+.-emu-layout
+  body.-emu
+  #sidebar
+  #combat
+  #combat-tracker
+  .combatant
+  .combatant-control,
+body.-emu
+  #sidebar
+  #combat
+  #combat-tracker
+  .combatant
+  .-emu-layout
+  .combatant-control,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #combat
+  #combat-tracker
+  .combatant
+  .combatant-control,
+body.-emu
+  .sidebar-popout
+  #combat
+  #combat-tracker
+  .combatant
+  .-emu-layout
+  .combatant-control,
+.-emu-layout
+  body.-emu
+  #sidebar
+  #playlists
+  .directory-list
+  .playlist-header
+  .sound-controls
+  .sound-control,
+body.-emu
+  #sidebar
+  #playlists
+  .directory-list
+  .playlist-header
+  .sound-controls
+  .-emu-layout
+  .sound-control,
+.-emu-layout
+  body.-emu
+  #sidebar
+  #playlists
+  .directory-list
+  .sound
+  .sound-controls
+  .sound-control,
+body.-emu
+  #sidebar
+  #playlists
+  .directory-list
+  .sound
+  .sound-controls
+  .-emu-layout
+  .sound-control,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #playlists
+  .directory-list
+  .playlist-header
+  .sound-controls
+  .sound-control,
+body.-emu
+  .sidebar-popout
+  #playlists
+  .directory-list
+  .playlist-header
+  .sound-controls
+  .-emu-layout
+  .sound-control,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #playlists
+  .directory-list
+  .sound
+  .sound-controls
+  .sound-control,
+body.-emu
+  .sidebar-popout
+  #playlists
+  .directory-list
+  .sound
+  .sound-controls
+  .-emu-layout
+  .sound-control,
+.-emu-layout
+  body.-emu
+  #sidebar
+  #playlists
+  #currently-playing
+  .sound
+  .sound-control,
+body.-emu
+  #sidebar
+  #playlists
+  #currently-playing
+  .sound
+  .-emu-layout
+  .sound-control,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #playlists
+  #currently-playing
+  .sound
+  .sound-control,
+body.-emu
+  .sidebar-popout
+  #playlists
+  #currently-playing
+  .sound
+  .-emu-layout
+  .sound-control,
+.-emu-layout
+  body.-emu
+  .window-app[id*="chat-popout-"]
+  .chat-message
+  .chat-card
+  .die-result-overlay-br
+  button,
+body.-emu
+  .window-app[id*="chat-popout-"]
+  .chat-message
+  .chat-card
+  .die-result-overlay-br
+  .-emu-layout
+  button,
+.-emu-layout
+  body.-emu
+  #sidebar
+  #chat
+  #chat-log
+  .chat-message
+  .chat-card
+  .die-result-overlay-br
+  button,
+body.-emu
+  #sidebar
+  #chat
+  #chat-log
+  .chat-message
+  .chat-card
+  .die-result-overlay-br
+  .-emu-layout
+  button,
+.-emu-layout body.-emu #dfcp-rt-buttons button,
+body.-emu #dfcp-rt-buttons .-emu-layout button,
+.-emu-layout
+  body.-emu
+  .active-effect-sheet[id*="ActiveEffectsConfig-"]
+  .effect-special-duration
+  .effect-control,
+body.-emu
+  .active-effect-sheet[id*="ActiveEffectsConfig-"]
+  .effect-special-duration
+  .-emu-layout
+  .effect-control,
+.-emu-layout body.-emu #specials-config .fxmaster .special-effects .controls a,
+body.-emu #specials-config .fxmaster .special-effects .controls .-emu-layout a,
+.-emu-layout body.-emu div.permission-viewer a,
+body.-emu div.permission-viewer .-emu-layout a,
+.-emu-layout
+  body.-emu
+  #sidebar
+  #chat
+  #chat-log
+  .message
+  .button.polyglot-message-language,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #chat
+  #chat-log
+  .message
+  .button.polyglot-message-language,
+.-emu-layout body.-emu #smalltime-app #displayContainer .arrow,
+body.-emu #smalltime-app #displayContainer .-emu-layout .arrow,
+.-emu-layout body.-emu #token-action-hud #tah-reposition,
+body.-emu #token-action-hud .-emu-layout #tah-reposition,
+.-emu-layout body.-emu #token-action-hud #tah-categories,
+body.-emu #token-action-hud .-emu-layout #tah-categories,
+.-emu-layout body.-emu #sidebar .token-mold > a,
+body.-emu #sidebar .-emu-layout .token-mold > a,
+.-emu-layout body.-emu .sidebar-popout .token-mold > a,
+body.-emu .sidebar-popout .-emu-layout .token-mold > a {
   width: var(--emu-space-button-sm);
   height: var(--emu-space-button-sm);
   flex: 0 0 auto;
   font-size: var(--emu-font-size-sm);
   -webkit-margin-start: var(--emu-space-xs);
-          margin-inline-start: var(--emu-space-xs);
-  padding: 0; }
-  .-emu-layout body.-emu .sheet.active-effect-sheet .effects-header a > i, body.-emu .sheet.active-effect-sheet .-emu-layout .effects-header a > i, .-emu-layout body.-emu .sheet.roll-table-config .table-results .table-header a > i, body.-emu .sheet.roll-table-config .table-results .-emu-layout .table-header a > i, .-emu-layout body.-emu .dice-so-nice section.content .settings-list .sfxs-list .sfx-header a > i, body.-emu .dice-so-nice section.content .settings-list .sfxs-list .-emu-layout .sfx-header a > i, .-emu-layout body.-emu .window-app[id*="ActiveEffects-"] .window-content > form .dnd5e.sheet.item .effect-header a > i, body.-emu .window-app[id*="ActiveEffects-"] .window-content > form .dnd5e.sheet.item .-emu-layout .effect-header a > i, .-emu-layout body.-emu .sheet.active-effect-sheet .changes-list li a > i, body.-emu .sheet.active-effect-sheet .changes-list .-emu-layout li a > i, .-emu-layout body.-emu .sheet.roll-table-config .table-results .table-result a > i, body.-emu .sheet.roll-table-config .table-results .-emu-layout .table-result a > i, .-emu-layout body.-emu .dice-so-nice section.content .settings-list .sfxs-list .sfx a > i, body.-emu .dice-so-nice section.content .settings-list .sfxs-list .-emu-layout .sfx a > i, .-emu-layout body.-emu .dialog .directory .directory-item.folder .folder-header .create-folder > i, body.-emu .dialog .directory .directory-item.folder .folder-header .-emu-layout .create-folder > i, .-emu-layout body.-emu .dialog .directory .directory-item.folder .folder-header .create-entity > i, body.-emu .dialog .directory .directory-item.folder .folder-header .-emu-layout .create-entity > i, .-emu-layout body.-emu #sidebar .directory .directory-item.folder .folder-header .create-folder > i, body.-emu #sidebar .directory .directory-item.folder .folder-header .-emu-layout .create-folder > i, .-emu-layout body.-emu #sidebar .directory .directory-item.folder .folder-header .create-entity > i, body.-emu #sidebar .directory .directory-item.folder .folder-header .-emu-layout .create-entity > i, .-emu-layout body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .directory .directory-item.folder .folder-header .create-folder > i, body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .directory .directory-item.folder .folder-header .-emu-layout .create-folder > i, .-emu-layout body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .directory .directory-item.folder .folder-header .create-entity > i, body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .directory .directory-item.folder .folder-header .-emu-layout .create-entity > i, .-emu-layout body.-emu #navigation #nav-toggle > i, body.-emu #navigation .-emu-layout #nav-toggle > i, .-emu-layout body.-emu .window-app .window-header > a > i, .-emu-layout body.-emu .window-app .window-header a.header-button > i, .-emu-layout body.-emu #sidebar #chat #chat-log .message .button.message-delete > i, .-emu-layout body.-emu .sidebar-popout #chat #chat-log .message .button.message-delete > i, .-emu-layout body.-emu #sidebar #chat #chat-controls .chat-control-icon .fa-dice-d20 > i, .-emu-layout body.-emu .sidebar-popout #chat #chat-controls .chat-control-icon .fa-dice-d20 > i, .-emu-layout body.-emu #sidebar #chat #chat-controls .control-buttons .button > i, .-emu-layout body.-emu .sidebar-popout #chat #chat-controls .control-buttons .button > i, .-emu-layout body.-emu #sidebar #combat #combat-round .encounters a > i, body.-emu #sidebar #combat #combat-round .encounters .-emu-layout a > i, .-emu-layout body.-emu .sidebar-popout #combat #combat-round .encounters a > i, body.-emu .sidebar-popout #combat #combat-round .encounters .-emu-layout a > i, .-emu-layout body.-emu #sidebar #combat #combat-tracker .combatant .combatant-control > i, body.-emu #sidebar #combat #combat-tracker .combatant .-emu-layout .combatant-control > i, .-emu-layout body.-emu .sidebar-popout #combat #combat-tracker .combatant .combatant-control > i, body.-emu .sidebar-popout #combat #combat-tracker .combatant .-emu-layout .combatant-control > i, .-emu-layout body.-emu #sidebar #playlists .directory-list .playlist-header .sound-controls .sound-control > i, body.-emu #sidebar #playlists .directory-list .playlist-header .sound-controls .-emu-layout .sound-control > i, .-emu-layout body.-emu #sidebar #playlists .directory-list .sound .sound-controls .sound-control > i, body.-emu #sidebar #playlists .directory-list .sound .sound-controls .-emu-layout .sound-control > i, .-emu-layout body.-emu .sidebar-popout #playlists .directory-list .playlist-header .sound-controls .sound-control > i, body.-emu .sidebar-popout #playlists .directory-list .playlist-header .sound-controls .-emu-layout .sound-control > i, .-emu-layout body.-emu .sidebar-popout #playlists .directory-list .sound .sound-controls .sound-control > i, body.-emu .sidebar-popout #playlists .directory-list .sound .sound-controls .-emu-layout .sound-control > i, .-emu-layout body.-emu #sidebar #playlists #currently-playing .sound .sound-control > i, body.-emu #sidebar #playlists #currently-playing .sound .-emu-layout .sound-control > i, .-emu-layout body.-emu .sidebar-popout #playlists #currently-playing .sound .sound-control > i, body.-emu .sidebar-popout #playlists #currently-playing .sound .-emu-layout .sound-control > i, .-emu-layout body.-emu .window-app[id*="chat-popout-"] .chat-message .chat-card .die-result-overlay-br button > i, body.-emu .window-app[id*="chat-popout-"] .chat-message .chat-card .die-result-overlay-br .-emu-layout button > i, .-emu-layout body.-emu #sidebar #chat #chat-log .chat-message .chat-card .die-result-overlay-br button > i, body.-emu #sidebar #chat #chat-log .chat-message .chat-card .die-result-overlay-br .-emu-layout button > i, .-emu-layout body.-emu #dfcp-rt-buttons button > i, body.-emu #dfcp-rt-buttons .-emu-layout button > i, .-emu-layout body.-emu .active-effect-sheet[id*="ActiveEffectsConfig-"] .effect-special-duration .effect-control > i, body.-emu .active-effect-sheet[id*="ActiveEffectsConfig-"] .effect-special-duration .-emu-layout .effect-control > i, .-emu-layout body.-emu #specials-config .fxmaster .special-effects .controls a > i, body.-emu #specials-config .fxmaster .special-effects .controls .-emu-layout a > i, .-emu-layout body.-emu div.permission-viewer a > i, body.-emu div.permission-viewer .-emu-layout a > i, .-emu-layout body.-emu #sidebar #chat #chat-log .message .button.polyglot-message-language > i, .-emu-layout body.-emu .sidebar-popout #chat #chat-log .message .button.polyglot-message-language > i, .-emu-layout body.-emu #smalltime-app #displayContainer .arrow > i, body.-emu #smalltime-app #displayContainer .-emu-layout .arrow > i, .-emu-layout body.-emu #token-action-hud #tah-reposition > i, body.-emu #token-action-hud .-emu-layout #tah-reposition > i, .-emu-layout body.-emu #token-action-hud #tah-categories > i, body.-emu #token-action-hud .-emu-layout #tah-categories > i, .-emu-layout body.-emu #sidebar .token-mold > a > i, body.-emu #sidebar .-emu-layout .token-mold > a > i, .-emu-layout body.-emu .sidebar-popout .token-mold > a > i, body.-emu .sidebar-popout .-emu-layout .token-mold > a > i {
-    margin: 0; }
+  margin-inline-start: var(--emu-space-xs);
+  padding: 0;
+}
+.-emu-layout body.-emu .sheet.active-effect-sheet .effects-header a > i,
+body.-emu .sheet.active-effect-sheet .-emu-layout .effects-header a > i,
+.-emu-layout
+  body.-emu
+  .sheet.roll-table-config
+  .table-results
+  .table-header
+  a
+  > i,
+body.-emu
+  .sheet.roll-table-config
+  .table-results
+  .-emu-layout
+  .table-header
+  a
+  > i,
+.-emu-layout
+  body.-emu
+  .dice-so-nice
+  section.content
+  .settings-list
+  .sfxs-list
+  .sfx-header
+  a
+  > i,
+body.-emu
+  .dice-so-nice
+  section.content
+  .settings-list
+  .sfxs-list
+  .-emu-layout
+  .sfx-header
+  a
+  > i,
+.-emu-layout
+  body.-emu
+  .window-app[id*="ActiveEffects-"]
+  .window-content
+  > form
+  .dnd5e.sheet.item
+  .effect-header
+  a
+  > i,
+body.-emu
+  .window-app[id*="ActiveEffects-"]
+  .window-content
+  > form
+  .dnd5e.sheet.item
+  .-emu-layout
+  .effect-header
+  a
+  > i,
+.-emu-layout body.-emu .sheet.active-effect-sheet .changes-list li a > i,
+body.-emu .sheet.active-effect-sheet .changes-list .-emu-layout li a > i,
+.-emu-layout
+  body.-emu
+  .sheet.roll-table-config
+  .table-results
+  .table-result
+  a
+  > i,
+body.-emu
+  .sheet.roll-table-config
+  .table-results
+  .-emu-layout
+  .table-result
+  a
+  > i,
+.-emu-layout
+  body.-emu
+  .dice-so-nice
+  section.content
+  .settings-list
+  .sfxs-list
+  .sfx
+  a
+  > i,
+body.-emu
+  .dice-so-nice
+  section.content
+  .settings-list
+  .sfxs-list
+  .-emu-layout
+  .sfx
+  a
+  > i,
+.-emu-layout
+  body.-emu
+  .dialog
+  .directory
+  .directory-item.folder
+  .folder-header
+  .create-folder
+  > i,
+body.-emu
+  .dialog
+  .directory
+  .directory-item.folder
+  .folder-header
+  .-emu-layout
+  .create-folder
+  > i,
+.-emu-layout
+  body.-emu
+  .dialog
+  .directory
+  .directory-item.folder
+  .folder-header
+  .create-entity
+  > i,
+body.-emu
+  .dialog
+  .directory
+  .directory-item.folder
+  .folder-header
+  .-emu-layout
+  .create-entity
+  > i,
+.-emu-layout
+  body.-emu
+  #sidebar
+  .directory
+  .directory-item.folder
+  .folder-header
+  .create-folder
+  > i,
+body.-emu
+  #sidebar
+  .directory
+  .directory-item.folder
+  .folder-header
+  .-emu-layout
+  .create-folder
+  > i,
+.-emu-layout
+  body.-emu
+  #sidebar
+  .directory
+  .directory-item.folder
+  .folder-header
+  .create-entity
+  > i,
+body.-emu
+  #sidebar
+  .directory
+  .directory-item.folder
+  .folder-header
+  .-emu-layout
+  .create-entity
+  > i,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .directory
+  .directory-item.folder
+  .folder-header
+  .create-folder
+  > i,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .directory
+  .directory-item.folder
+  .folder-header
+  .-emu-layout
+  .create-folder
+  > i,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .directory
+  .directory-item.folder
+  .folder-header
+  .create-entity
+  > i,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .directory
+  .directory-item.folder
+  .folder-header
+  .-emu-layout
+  .create-entity
+  > i,
+.-emu-layout body.-emu #navigation #nav-toggle > i,
+body.-emu #navigation .-emu-layout #nav-toggle > i,
+.-emu-layout body.-emu .window-app .window-header > a > i,
+.-emu-layout body.-emu .window-app .window-header a.header-button > i,
+.-emu-layout
+  body.-emu
+  #sidebar
+  #chat
+  #chat-log
+  .message
+  .button.message-delete
+  > i,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #chat
+  #chat-log
+  .message
+  .button.message-delete
+  > i,
+.-emu-layout
+  body.-emu
+  #sidebar
+  #chat
+  #chat-controls
+  .chat-control-icon
+  .fa-dice-d20
+  > i,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #chat
+  #chat-controls
+  .chat-control-icon
+  .fa-dice-d20
+  > i,
+.-emu-layout
+  body.-emu
+  #sidebar
+  #chat
+  #chat-controls
+  .control-buttons
+  .button
+  > i,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #chat
+  #chat-controls
+  .control-buttons
+  .button
+  > i,
+.-emu-layout body.-emu #sidebar #combat #combat-round .encounters a > i,
+body.-emu #sidebar #combat #combat-round .encounters .-emu-layout a > i,
+.-emu-layout body.-emu .sidebar-popout #combat #combat-round .encounters a > i,
+body.-emu .sidebar-popout #combat #combat-round .encounters .-emu-layout a > i,
+.-emu-layout
+  body.-emu
+  #sidebar
+  #combat
+  #combat-tracker
+  .combatant
+  .combatant-control
+  > i,
+body.-emu
+  #sidebar
+  #combat
+  #combat-tracker
+  .combatant
+  .-emu-layout
+  .combatant-control
+  > i,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #combat
+  #combat-tracker
+  .combatant
+  .combatant-control
+  > i,
+body.-emu
+  .sidebar-popout
+  #combat
+  #combat-tracker
+  .combatant
+  .-emu-layout
+  .combatant-control
+  > i,
+.-emu-layout
+  body.-emu
+  #sidebar
+  #playlists
+  .directory-list
+  .playlist-header
+  .sound-controls
+  .sound-control
+  > i,
+body.-emu
+  #sidebar
+  #playlists
+  .directory-list
+  .playlist-header
+  .sound-controls
+  .-emu-layout
+  .sound-control
+  > i,
+.-emu-layout
+  body.-emu
+  #sidebar
+  #playlists
+  .directory-list
+  .sound
+  .sound-controls
+  .sound-control
+  > i,
+body.-emu
+  #sidebar
+  #playlists
+  .directory-list
+  .sound
+  .sound-controls
+  .-emu-layout
+  .sound-control
+  > i,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #playlists
+  .directory-list
+  .playlist-header
+  .sound-controls
+  .sound-control
+  > i,
+body.-emu
+  .sidebar-popout
+  #playlists
+  .directory-list
+  .playlist-header
+  .sound-controls
+  .-emu-layout
+  .sound-control
+  > i,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #playlists
+  .directory-list
+  .sound
+  .sound-controls
+  .sound-control
+  > i,
+body.-emu
+  .sidebar-popout
+  #playlists
+  .directory-list
+  .sound
+  .sound-controls
+  .-emu-layout
+  .sound-control
+  > i,
+.-emu-layout
+  body.-emu
+  #sidebar
+  #playlists
+  #currently-playing
+  .sound
+  .sound-control
+  > i,
+body.-emu
+  #sidebar
+  #playlists
+  #currently-playing
+  .sound
+  .-emu-layout
+  .sound-control
+  > i,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #playlists
+  #currently-playing
+  .sound
+  .sound-control
+  > i,
+body.-emu
+  .sidebar-popout
+  #playlists
+  #currently-playing
+  .sound
+  .-emu-layout
+  .sound-control
+  > i,
+.-emu-layout
+  body.-emu
+  .window-app[id*="chat-popout-"]
+  .chat-message
+  .chat-card
+  .die-result-overlay-br
+  button
+  > i,
+body.-emu
+  .window-app[id*="chat-popout-"]
+  .chat-message
+  .chat-card
+  .die-result-overlay-br
+  .-emu-layout
+  button
+  > i,
+.-emu-layout
+  body.-emu
+  #sidebar
+  #chat
+  #chat-log
+  .chat-message
+  .chat-card
+  .die-result-overlay-br
+  button
+  > i,
+body.-emu
+  #sidebar
+  #chat
+  #chat-log
+  .chat-message
+  .chat-card
+  .die-result-overlay-br
+  .-emu-layout
+  button
+  > i,
+.-emu-layout body.-emu #dfcp-rt-buttons button > i,
+body.-emu #dfcp-rt-buttons .-emu-layout button > i,
+.-emu-layout
+  body.-emu
+  .active-effect-sheet[id*="ActiveEffectsConfig-"]
+  .effect-special-duration
+  .effect-control
+  > i,
+body.-emu
+  .active-effect-sheet[id*="ActiveEffectsConfig-"]
+  .effect-special-duration
+  .-emu-layout
+  .effect-control
+  > i,
+.-emu-layout
+  body.-emu
+  #specials-config
+  .fxmaster
+  .special-effects
+  .controls
+  a
+  > i,
+body.-emu
+  #specials-config
+  .fxmaster
+  .special-effects
+  .controls
+  .-emu-layout
+  a
+  > i,
+.-emu-layout body.-emu div.permission-viewer a > i,
+body.-emu div.permission-viewer .-emu-layout a > i,
+.-emu-layout
+  body.-emu
+  #sidebar
+  #chat
+  #chat-log
+  .message
+  .button.polyglot-message-language
+  > i,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #chat
+  #chat-log
+  .message
+  .button.polyglot-message-language
+  > i,
+.-emu-layout body.-emu #smalltime-app #displayContainer .arrow > i,
+body.-emu #smalltime-app #displayContainer .-emu-layout .arrow > i,
+.-emu-layout body.-emu #token-action-hud #tah-reposition > i,
+body.-emu #token-action-hud .-emu-layout #tah-reposition > i,
+.-emu-layout body.-emu #token-action-hud #tah-categories > i,
+body.-emu #token-action-hud .-emu-layout #tah-categories > i,
+.-emu-layout body.-emu #sidebar .token-mold > a > i,
+body.-emu #sidebar .-emu-layout .token-mold > a > i,
+.-emu-layout body.-emu .sidebar-popout .token-mold > a > i,
+body.-emu .sidebar-popout .-emu-layout .token-mold > a > i {
+  margin: 0;
+}
 
-body.-emu .sheet.active-effect-sheet .effects-header a, body.-emu .sheet.roll-table-config .table-results .table-header a, body.-emu .dice-so-nice section.content .settings-list .sfxs-list .sfx-header a, body.-emu .window-app[id*="ActiveEffects-"] .window-content > form .dnd5e.sheet.item .effect-header a, body.-emu .sheet.active-effect-sheet .changes-list li a, body.-emu .sheet.roll-table-config .table-results .table-result a, body.-emu .dice-so-nice section.content .settings-list .sfxs-list .sfx a, body.-emu #sidebar #chat #chat-log .message .button.message-delete,
-body.-emu .sidebar-popout #chat #chat-log .message .button.message-delete, body.-emu #sidebar #chat #chat-controls .chat-control-icon .fa-dice-d20,
-body.-emu .sidebar-popout #chat #chat-controls .chat-control-icon .fa-dice-d20, body.-emu #sidebar #chat #chat-controls .control-buttons .button,
-body.-emu .sidebar-popout #chat #chat-controls .control-buttons .button, body.-emu #sidebar #chat #chat-log .message .button.polyglot-message-language,
-body.-emu .sidebar-popout #chat #chat-log .message .button.polyglot-message-language {
-  text-shadow: none; }
-  body.-emu .sheet.active-effect-sheet .effects-header a:hover, body.-emu .sheet.roll-table-config .table-results .table-header a:hover, body.-emu .dice-so-nice section.content .settings-list .sfxs-list .sfx-header a:hover, body.-emu .window-app[id*="ActiveEffects-"] .window-content > form .dnd5e.sheet.item .effect-header a:hover, body.-emu .sheet.active-effect-sheet .changes-list li a:hover, body.-emu .sheet.roll-table-config .table-results .table-result a:hover, body.-emu .dice-so-nice section.content .settings-list .sfxs-list .sfx a:hover, body.-emu #sidebar #chat #chat-log .message .button.message-delete:hover,
-  body.-emu .sidebar-popout #chat #chat-log .message .button.message-delete:hover, body.-emu #sidebar #chat #chat-controls .chat-control-icon .fa-dice-d20:hover,
-  body.-emu .sidebar-popout #chat #chat-controls .chat-control-icon .fa-dice-d20:hover, body.-emu #sidebar #chat #chat-controls .control-buttons .button:hover,
-  body.-emu .sidebar-popout #chat #chat-controls .control-buttons .button:hover, body.-emu #sidebar #chat #chat-log .message .button.polyglot-message-language:hover,
-  body.-emu .sidebar-popout #chat #chat-log .message .button.polyglot-message-language:hover {
-    color: rgba(var(--color-primary), 1); }
+body.-emu .sheet.active-effect-sheet .effects-header a,
+body.-emu .sheet.roll-table-config .table-results .table-header a,
+body.-emu .dice-so-nice section.content .settings-list .sfxs-list .sfx-header a,
+body.-emu
+  .window-app[id*="ActiveEffects-"]
+  .window-content
+  > form
+  .dnd5e.sheet.item
+  .effect-header
+  a,
+body.-emu .sheet.active-effect-sheet .changes-list li a,
+body.-emu .sheet.roll-table-config .table-results .table-result a,
+body.-emu .dice-so-nice section.content .settings-list .sfxs-list .sfx a,
+body.-emu #sidebar #chat #chat-log .message .button.message-delete,
+body.-emu .sidebar-popout #chat #chat-log .message .button.message-delete,
+body.-emu #sidebar #chat #chat-controls .chat-control-icon .fa-dice-d20,
+body.-emu .sidebar-popout #chat #chat-controls .chat-control-icon .fa-dice-d20,
+body.-emu #sidebar #chat #chat-controls .control-buttons .button,
+body.-emu .sidebar-popout #chat #chat-controls .control-buttons .button,
+body.-emu #sidebar #chat #chat-log .message .button.polyglot-message-language,
+body.-emu
+  .sidebar-popout
+  #chat
+  #chat-log
+  .message
+  .button.polyglot-message-language {
+  text-shadow: none;
+}
+body.-emu .sheet.active-effect-sheet .effects-header a:hover,
+body.-emu .sheet.roll-table-config .table-results .table-header a:hover,
+body.-emu
+  .dice-so-nice
+  section.content
+  .settings-list
+  .sfxs-list
+  .sfx-header
+  a:hover,
+body.-emu
+  .window-app[id*="ActiveEffects-"]
+  .window-content
+  > form
+  .dnd5e.sheet.item
+  .effect-header
+  a:hover,
+body.-emu .sheet.active-effect-sheet .changes-list li a:hover,
+body.-emu .sheet.roll-table-config .table-results .table-result a:hover,
+body.-emu .dice-so-nice section.content .settings-list .sfxs-list .sfx a:hover,
+body.-emu #sidebar #chat #chat-log .message .button.message-delete:hover,
+body.-emu .sidebar-popout #chat #chat-log .message .button.message-delete:hover,
+body.-emu #sidebar #chat #chat-controls .chat-control-icon .fa-dice-d20:hover,
+body.-emu
+  .sidebar-popout
+  #chat
+  #chat-controls
+  .chat-control-icon
+  .fa-dice-d20:hover,
+body.-emu #sidebar #chat #chat-controls .control-buttons .button:hover,
+body.-emu .sidebar-popout #chat #chat-controls .control-buttons .button:hover,
+body.-emu
+  #sidebar
+  #chat
+  #chat-log
+  .message
+  .button.polyglot-message-language:hover,
+body.-emu
+  .sidebar-popout
+  #chat
+  #chat-log
+  .message
+  .button.polyglot-message-language:hover {
+  color: rgba(var(--color-primary), 1);
+}
 
 body.-emu .dialog input[type="text"],
 body.-emu .dialog input[type="number"],
@@ -192,112 +2972,296 @@ body.-emu #sidebar input[type="time"],
 body.-emu #sidebar input[type="password"],
 body.-emu #sidebar input[type="datetime-local"],
 body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) input[type="text"],
-body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) input[type="number"],
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  input[type="number"],
 body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) input[type="date"],
 body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) input[type="time"],
-body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) input[type="password"],
-body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) input[type="datetime-local"], body.-emu #hud input[type="text"], body.-emu #sidebar #chat section.dice-tray input.dice-tray__input,
-body.-emu .sidebar-popout #chat section.dice-tray input.dice-tray__input, body.-emu #client-settings.window-app.form .window-content #config-tabs div.tab[data-tab="modules"] #searchField #searchInput {
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  input[type="password"],
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  input[type="datetime-local"],
+body.-emu #hud input[type="text"],
+body.-emu #sidebar #chat section.dice-tray input.dice-tray__input,
+body.-emu .sidebar-popout #chat section.dice-tray input.dice-tray__input,
+body.-emu
+  #client-settings.window-app.form
+  .window-content
+  #config-tabs
+  div.tab[data-tab="modules"]
+  #searchField
+  #searchInput {
   background: transparent;
   border: rgba(var(--color-border-lighter), 1) 1px solid;
   border-radius: var(--emu-border-radius-forms, 0);
   box-shadow: none;
   color: rgba(var(--color-text), 1);
-  transition: box-shadow 0.3s cubic-bezier(0.075, 0.82, 0.165, 1); }
-  .-emu-layout body.-emu .dialog input[type="text"], body.-emu .dialog .-emu-layout input[type="text"],
-  .-emu-layout body.-emu .dialog input[type="number"], body.-emu .dialog .-emu-layout input[type="number"],
-  .-emu-layout body.-emu .dialog input[type="date"], body.-emu .dialog .-emu-layout input[type="date"],
-  .-emu-layout body.-emu .dialog input[type="time"], body.-emu .dialog .-emu-layout input[type="time"],
-  .-emu-layout body.-emu .dialog input[type="password"], body.-emu .dialog .-emu-layout input[type="password"],
-  .-emu-layout body.-emu .dialog input[type="datetime-local"], body.-emu .dialog .-emu-layout input[type="datetime-local"],
-  .-emu-layout body.-emu #sidebar input[type="text"], body.-emu #sidebar .-emu-layout input[type="text"],
-  .-emu-layout body.-emu #sidebar input[type="number"], body.-emu #sidebar .-emu-layout input[type="number"],
-  .-emu-layout body.-emu #sidebar input[type="date"], body.-emu #sidebar .-emu-layout input[type="date"],
-  .-emu-layout body.-emu #sidebar input[type="time"], body.-emu #sidebar .-emu-layout input[type="time"],
-  .-emu-layout body.-emu #sidebar input[type="password"], body.-emu #sidebar .-emu-layout input[type="password"],
-  .-emu-layout body.-emu #sidebar input[type="datetime-local"], body.-emu #sidebar .-emu-layout input[type="datetime-local"],
-  .-emu-layout body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) input[type="text"], body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .-emu-layout input[type="text"],
-  .-emu-layout body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) input[type="number"], body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .-emu-layout input[type="number"],
-  .-emu-layout body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) input[type="date"], body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .-emu-layout input[type="date"],
-  .-emu-layout body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) input[type="time"], body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .-emu-layout input[type="time"],
-  .-emu-layout body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) input[type="password"], body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .-emu-layout input[type="password"],
-  .-emu-layout body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) input[type="datetime-local"], body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .-emu-layout input[type="datetime-local"], .-emu-layout body.-emu #hud input[type="text"], body.-emu #hud .-emu-layout input[type="text"], .-emu-layout body.-emu #sidebar #chat section.dice-tray input.dice-tray__input, body.-emu #sidebar #chat section.dice-tray .-emu-layout input.dice-tray__input,
-  .-emu-layout body.-emu .sidebar-popout #chat section.dice-tray input.dice-tray__input, body.-emu .sidebar-popout #chat section.dice-tray .-emu-layout input.dice-tray__input, .-emu-layout body.-emu #client-settings.window-app.form .window-content #config-tabs div.tab[data-tab="modules"] #searchField #searchInput, body.-emu #client-settings.window-app.form .window-content #config-tabs div.tab[data-tab="modules"] #searchField .-emu-layout #searchInput {
-    width: 100%;
-    height: var(--emu-space-button);
-    font-family: inherit;
-    font-size: inherit;
-    font-weight: normal;
-    line-height: 1;
-    margin: 0;
-    min-width: var(--emu-space-xl);
-    padding: 0 var(--emu-space-sm);
-    position: relative;
-    -webkit-user-select: text;
-       -moz-user-select: text;
-        -ms-user-select: text;
-            user-select: text; }
-  body.-emu .dialog input[type="text"]::-moz-placeholder,
-  body.-emu .dialog input[type="number"]::-moz-placeholder,
-  body.-emu .dialog input[type="date"]::-moz-placeholder,
-  body.-emu .dialog input[type="time"]::-moz-placeholder,
-  body.-emu .dialog input[type="password"]::-moz-placeholder,
-  body.-emu .dialog input[type="datetime-local"]::-moz-placeholder,
-  body.-emu #sidebar input[type="text"]::-moz-placeholder,
-  body.-emu #sidebar input[type="number"]::-moz-placeholder,
-  body.-emu #sidebar input[type="date"]::-moz-placeholder,
-  body.-emu #sidebar input[type="time"]::-moz-placeholder,
-  body.-emu #sidebar input[type="password"]::-moz-placeholder,
-  body.-emu #sidebar input[type="datetime-local"]::-moz-placeholder,
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) input[type="text"]::-moz-placeholder,
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) input[type="number"]::-moz-placeholder,
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) input[type="date"]::-moz-placeholder,
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) input[type="time"]::-moz-placeholder,
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) input[type="password"]::-moz-placeholder,
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) input[type="datetime-local"]::-moz-placeholder, body.-emu #hud input[type="text"]::-moz-placeholder, body.-emu #sidebar #chat section.dice-tray input.dice-tray__input::-moz-placeholder,
-  body.-emu .sidebar-popout #chat section.dice-tray input.dice-tray__input::-moz-placeholder, body.-emu #client-settings.window-app.form .window-content #config-tabs div.tab[data-tab="modules"] #searchField #searchInput::-moz-placeholder {
-    color: rgba(var(--color-text), 0.5); }
-  body.-emu .dialog input[type="text"]::placeholder,
-  body.-emu .dialog input[type="number"]::placeholder,
-  body.-emu .dialog input[type="date"]::placeholder,
-  body.-emu .dialog input[type="time"]::placeholder,
-  body.-emu .dialog input[type="password"]::placeholder,
-  body.-emu .dialog input[type="datetime-local"]::placeholder,
-  body.-emu #sidebar input[type="text"]::placeholder,
-  body.-emu #sidebar input[type="number"]::placeholder,
-  body.-emu #sidebar input[type="date"]::placeholder,
-  body.-emu #sidebar input[type="time"]::placeholder,
-  body.-emu #sidebar input[type="password"]::placeholder,
-  body.-emu #sidebar input[type="datetime-local"]::placeholder,
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) input[type="text"]::placeholder,
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) input[type="number"]::placeholder,
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) input[type="date"]::placeholder,
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) input[type="time"]::placeholder,
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) input[type="password"]::placeholder,
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) input[type="datetime-local"]::placeholder, body.-emu #hud input[type="text"]::placeholder, body.-emu #sidebar #chat section.dice-tray input.dice-tray__input::placeholder,
-  body.-emu .sidebar-popout #chat section.dice-tray input.dice-tray__input::placeholder, body.-emu #client-settings.window-app.form .window-content #config-tabs div.tab[data-tab="modules"] #searchField #searchInput::placeholder {
-    color: rgba(var(--color-text), 0.5); }
-  body.-emu .dialog input:disabled[type="text"],
-  body.-emu .dialog input:disabled[type="number"],
-  body.-emu .dialog input:disabled[type="date"],
-  body.-emu .dialog input:disabled[type="time"],
-  body.-emu .dialog input:disabled[type="password"],
-  body.-emu .dialog input:disabled[type="datetime-local"],
-  body.-emu #sidebar input:disabled[type="text"],
-  body.-emu #sidebar input:disabled[type="number"],
-  body.-emu #sidebar input:disabled[type="date"],
-  body.-emu #sidebar input:disabled[type="time"],
-  body.-emu #sidebar input:disabled[type="password"],
-  body.-emu #sidebar input:disabled[type="datetime-local"],
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) input:disabled[type="text"],
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) input:disabled[type="number"],
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) input:disabled[type="date"],
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) input:disabled[type="time"],
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) input:disabled[type="password"],
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) input:disabled[type="datetime-local"], body.-emu #hud input:disabled[type="text"], body.-emu #sidebar #chat section.dice-tray input.dice-tray__input:disabled,
-  body.-emu .sidebar-popout #chat section.dice-tray input.dice-tray__input:disabled, body.-emu #client-settings.window-app.form .window-content #config-tabs div.tab[data-tab="modules"] #searchField #searchInput:disabled {
-    opacity: 0.5;
-    pointer-events: none; }
+  transition: box-shadow 0.3s cubic-bezier(0.075, 0.82, 0.165, 1);
+}
+.-emu-layout body.-emu .dialog input[type="text"],
+body.-emu .dialog .-emu-layout input[type="text"],
+.-emu-layout body.-emu .dialog input[type="number"],
+body.-emu .dialog .-emu-layout input[type="number"],
+.-emu-layout body.-emu .dialog input[type="date"],
+body.-emu .dialog .-emu-layout input[type="date"],
+.-emu-layout body.-emu .dialog input[type="time"],
+body.-emu .dialog .-emu-layout input[type="time"],
+.-emu-layout body.-emu .dialog input[type="password"],
+body.-emu .dialog .-emu-layout input[type="password"],
+.-emu-layout body.-emu .dialog input[type="datetime-local"],
+body.-emu .dialog .-emu-layout input[type="datetime-local"],
+.-emu-layout body.-emu #sidebar input[type="text"],
+body.-emu #sidebar .-emu-layout input[type="text"],
+.-emu-layout body.-emu #sidebar input[type="number"],
+body.-emu #sidebar .-emu-layout input[type="number"],
+.-emu-layout body.-emu #sidebar input[type="date"],
+body.-emu #sidebar .-emu-layout input[type="date"],
+.-emu-layout body.-emu #sidebar input[type="time"],
+body.-emu #sidebar .-emu-layout input[type="time"],
+.-emu-layout body.-emu #sidebar input[type="password"],
+body.-emu #sidebar .-emu-layout input[type="password"],
+.-emu-layout body.-emu #sidebar input[type="datetime-local"],
+body.-emu #sidebar .-emu-layout input[type="datetime-local"],
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  input[type="text"],
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .-emu-layout
+  input[type="text"],
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  input[type="number"],
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .-emu-layout
+  input[type="number"],
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  input[type="date"],
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .-emu-layout
+  input[type="date"],
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  input[type="time"],
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .-emu-layout
+  input[type="time"],
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  input[type="password"],
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .-emu-layout
+  input[type="password"],
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  input[type="datetime-local"],
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .-emu-layout
+  input[type="datetime-local"],
+.-emu-layout body.-emu #hud input[type="text"],
+body.-emu #hud .-emu-layout input[type="text"],
+.-emu-layout body.-emu #sidebar #chat section.dice-tray input.dice-tray__input,
+body.-emu #sidebar #chat section.dice-tray .-emu-layout input.dice-tray__input,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #chat
+  section.dice-tray
+  input.dice-tray__input,
+body.-emu
+  .sidebar-popout
+  #chat
+  section.dice-tray
+  .-emu-layout
+  input.dice-tray__input,
+.-emu-layout
+  body.-emu
+  #client-settings.window-app.form
+  .window-content
+  #config-tabs
+  div.tab[data-tab="modules"]
+  #searchField
+  #searchInput,
+body.-emu
+  #client-settings.window-app.form
+  .window-content
+  #config-tabs
+  div.tab[data-tab="modules"]
+  #searchField
+  .-emu-layout
+  #searchInput {
+  width: 100%;
+  height: var(--emu-space-button);
+  font-family: inherit;
+  font-size: inherit;
+  font-weight: normal;
+  line-height: 1;
+  margin: 0;
+  min-width: var(--emu-space-xl);
+  padding: 0 var(--emu-space-sm);
+  position: relative;
+  -webkit-user-select: text;
+  -moz-user-select: text;
+  -ms-user-select: text;
+  user-select: text;
+}
+body.-emu .dialog input[type="text"]::-moz-placeholder,
+body.-emu .dialog input[type="number"]::-moz-placeholder,
+body.-emu .dialog input[type="date"]::-moz-placeholder,
+body.-emu .dialog input[type="time"]::-moz-placeholder,
+body.-emu .dialog input[type="password"]::-moz-placeholder,
+body.-emu .dialog input[type="datetime-local"]::-moz-placeholder,
+body.-emu #sidebar input[type="text"]::-moz-placeholder,
+body.-emu #sidebar input[type="number"]::-moz-placeholder,
+body.-emu #sidebar input[type="date"]::-moz-placeholder,
+body.-emu #sidebar input[type="time"]::-moz-placeholder,
+body.-emu #sidebar input[type="password"]::-moz-placeholder,
+body.-emu #sidebar input[type="datetime-local"]::-moz-placeholder,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  input[type="text"]::-moz-placeholder,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  input[type="number"]::-moz-placeholder,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  input[type="date"]::-moz-placeholder,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  input[type="time"]::-moz-placeholder,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  input[type="password"]::-moz-placeholder,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  input[type="datetime-local"]::-moz-placeholder,
+body.-emu #hud input[type="text"]::-moz-placeholder,
+body.-emu
+  #sidebar
+  #chat
+  section.dice-tray
+  input.dice-tray__input::-moz-placeholder,
+body.-emu
+  .sidebar-popout
+  #chat
+  section.dice-tray
+  input.dice-tray__input::-moz-placeholder,
+body.-emu
+  #client-settings.window-app.form
+  .window-content
+  #config-tabs
+  div.tab[data-tab="modules"]
+  #searchField
+  #searchInput::-moz-placeholder {
+  color: rgba(var(--color-text), 0.5);
+}
+body.-emu .dialog input[type="text"]::placeholder,
+body.-emu .dialog input[type="number"]::placeholder,
+body.-emu .dialog input[type="date"]::placeholder,
+body.-emu .dialog input[type="time"]::placeholder,
+body.-emu .dialog input[type="password"]::placeholder,
+body.-emu .dialog input[type="datetime-local"]::placeholder,
+body.-emu #sidebar input[type="text"]::placeholder,
+body.-emu #sidebar input[type="number"]::placeholder,
+body.-emu #sidebar input[type="date"]::placeholder,
+body.-emu #sidebar input[type="time"]::placeholder,
+body.-emu #sidebar input[type="password"]::placeholder,
+body.-emu #sidebar input[type="datetime-local"]::placeholder,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  input[type="text"]::placeholder,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  input[type="number"]::placeholder,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  input[type="date"]::placeholder,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  input[type="time"]::placeholder,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  input[type="password"]::placeholder,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  input[type="datetime-local"]::placeholder,
+body.-emu #hud input[type="text"]::placeholder,
+body.-emu #sidebar #chat section.dice-tray input.dice-tray__input::placeholder,
+body.-emu
+  .sidebar-popout
+  #chat
+  section.dice-tray
+  input.dice-tray__input::placeholder,
+body.-emu
+  #client-settings.window-app.form
+  .window-content
+  #config-tabs
+  div.tab[data-tab="modules"]
+  #searchField
+  #searchInput::placeholder {
+  color: rgba(var(--color-text), 0.5);
+}
+body.-emu .dialog input:disabled[type="text"],
+body.-emu .dialog input:disabled[type="number"],
+body.-emu .dialog input:disabled[type="date"],
+body.-emu .dialog input:disabled[type="time"],
+body.-emu .dialog input:disabled[type="password"],
+body.-emu .dialog input:disabled[type="datetime-local"],
+body.-emu #sidebar input:disabled[type="text"],
+body.-emu #sidebar input:disabled[type="number"],
+body.-emu #sidebar input:disabled[type="date"],
+body.-emu #sidebar input:disabled[type="time"],
+body.-emu #sidebar input:disabled[type="password"],
+body.-emu #sidebar input:disabled[type="datetime-local"],
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  input:disabled[type="text"],
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  input:disabled[type="number"],
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  input:disabled[type="date"],
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  input:disabled[type="time"],
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  input:disabled[type="password"],
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  input:disabled[type="datetime-local"],
+body.-emu #hud input:disabled[type="text"],
+body.-emu #sidebar #chat section.dice-tray input.dice-tray__input:disabled,
+body.-emu
+  .sidebar-popout
+  #chat
+  section.dice-tray
+  input.dice-tray__input:disabled,
+body.-emu
+  #client-settings.window-app.form
+  .window-content
+  #config-tabs
+  div.tab[data-tab="modules"]
+  #searchField
+  #searchInput:disabled {
+  opacity: 0.5;
+  pointer-events: none;
+}
 
 body.-emu .dialog select,
 body.-emu #sidebar select,
@@ -306,211 +3270,463 @@ body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) select {
   border: rgba(var(--color-border-lighter), 1) 1px solid;
   border-radius: var(--emu-border-radius-forms, 0);
   color: rgba(var(--color-text), 1);
-  transition: box-shadow 0.3s cubic-bezier(0.075, 0.82, 0.165, 1); }
-  .-emu-layout body.-emu .dialog select, body.-emu .dialog .-emu-layout select,
-  .-emu-layout body.-emu #sidebar select, body.-emu #sidebar .-emu-layout select,
-  .-emu-layout body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) select, body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .-emu-layout select {
-    cursor: pointer;
-    font-family: inherit;
-    font-size: inherit;
-    height: var(--emu-space-button);
-    margin: 0;
-    padding: 0 var(--emu-space-sm);
-    position: relative;
-    text-overflow: ellipsis; }
-    .-emu-layout body.-emu .dialog select[multiple], body.-emu .dialog .-emu-layout select[multiple],
-    .-emu-layout body.-emu #sidebar select[multiple], body.-emu #sidebar .-emu-layout select[multiple],
-    .-emu-layout body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) select[multiple], body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .-emu-layout select[multiple] {
-      height: auto;
-      padding: var(--emu-space-sm); }
-  body.-emu .dialog select:disabled,
-  body.-emu #sidebar select:disabled,
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) select:disabled {
-    opacity: 0.5;
-    pointer-events: none; }
-  body.-emu .dialog select optgroup, body.-emu #sidebar select optgroup, body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) select optgroup,
-  body.-emu .dialog select option,
-  body.-emu #sidebar select option,
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) select option {
-    background-color: rgba(var(--color-background-lightest), 1);
-    color: rgba(var(--color-text), 1); }
+  transition: box-shadow 0.3s cubic-bezier(0.075, 0.82, 0.165, 1);
+}
+.-emu-layout body.-emu .dialog select,
+body.-emu .dialog .-emu-layout select,
+.-emu-layout body.-emu #sidebar select,
+body.-emu #sidebar .-emu-layout select,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  select,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .-emu-layout
+  select {
+  cursor: pointer;
+  font-family: inherit;
+  font-size: inherit;
+  height: var(--emu-space-button);
+  margin: 0;
+  padding: 0 var(--emu-space-sm);
+  position: relative;
+  text-overflow: ellipsis;
+}
+.-emu-layout body.-emu .dialog select[multiple],
+body.-emu .dialog .-emu-layout select[multiple],
+.-emu-layout body.-emu #sidebar select[multiple],
+body.-emu #sidebar .-emu-layout select[multiple],
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  select[multiple],
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .-emu-layout
+  select[multiple] {
+  height: auto;
+  padding: var(--emu-space-sm);
+}
+body.-emu .dialog select:disabled,
+body.-emu #sidebar select:disabled,
+body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) select:disabled {
+  opacity: 0.5;
+  pointer-events: none;
+}
+body.-emu .dialog select optgroup,
+body.-emu #sidebar select optgroup,
+body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) select optgroup,
+body.-emu .dialog select option,
+body.-emu #sidebar select option,
+body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) select option {
+  background-color: rgba(var(--color-background-lightest), 1);
+  color: rgba(var(--color-text), 1);
+}
 
 body.-emu .dialog input[type="checkbox"],
 body.-emu #sidebar input[type="checkbox"],
-body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) input[type="checkbox"], body.-emu #client-settings.window-app.form .window-content #config-tabs .module-settings-wrapper div.form-group input[type="checkbox"], body.-emu #module-management .package-title input[type="checkbox"] {
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  input[type="checkbox"],
+body.-emu
+  #client-settings.window-app.form
+  .window-content
+  #config-tabs
+  .module-settings-wrapper
+  div.form-group
+  input[type="checkbox"],
+body.-emu #module-management .package-title input[type="checkbox"] {
   background: transparent;
   border: rgba(var(--color-border-lighter), 1) 1px solid;
   border-radius: var(--emu-border-radius-forms, 0);
   box-shadow: none;
   color: rgba(var(--color-text), 1);
-  transition: box-shadow 0.3s cubic-bezier(0.075, 0.82, 0.165, 1); }
-  .-emu-layout body.-emu .dialog input[type="checkbox"], body.-emu .dialog .-emu-layout input[type="checkbox"],
-  .-emu-layout body.-emu #sidebar input[type="checkbox"], body.-emu #sidebar .-emu-layout input[type="checkbox"],
-  .-emu-layout body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) input[type="checkbox"], body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .-emu-layout input[type="checkbox"], .-emu-layout body.-emu #client-settings.window-app.form .window-content #config-tabs .module-settings-wrapper div.form-group input[type="checkbox"], body.-emu #client-settings.window-app.form .window-content #config-tabs .module-settings-wrapper div.form-group .-emu-layout input[type="checkbox"], .-emu-layout body.-emu #module-management .package-title input[type="checkbox"], body.-emu #module-management .package-title .-emu-layout input[type="checkbox"] {
-    width: var(--emu-space-button-xs);
-    height: var(--emu-space-button-xs);
-    cursor: pointer;
-    flex: 0 0 auto;
-    margin: 0;
-    position: relative;
-    top: auto; }
-  body.-emu .dialog input:disabled[type="checkbox"],
-  body.-emu #sidebar input:disabled[type="checkbox"],
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) input:disabled[type="checkbox"], body.-emu #client-settings.window-app.form .window-content #config-tabs .module-settings-wrapper div.form-group input:disabled[type="checkbox"], body.-emu #module-management .package-title input:disabled[type="checkbox"] {
-    opacity: 0.5;
-    pointer-events: none; }
-  body.-emu .dialog input:checked[type="checkbox"],
-  body.-emu #sidebar input:checked[type="checkbox"],
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) input:checked[type="checkbox"], body.-emu #client-settings.window-app.form .window-content #config-tabs .module-settings-wrapper div.form-group input:checked[type="checkbox"], body.-emu #module-management .package-title input:checked[type="checkbox"] {
-    background-color: rgba(var(--color-primary), 1);
-    color: rgba(var(--color-text-lightest), 1); }
-
-.-emu-layout body.-emu .dialog input[type="radio"], body.-emu .dialog .-emu-layout input[type="radio"],
-.-emu-layout body.-emu #sidebar input[type="radio"], body.-emu #sidebar .-emu-layout input[type="radio"],
-.-emu-layout body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) input[type="radio"], body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .-emu-layout input[type="radio"] {
+  transition: box-shadow 0.3s cubic-bezier(0.075, 0.82, 0.165, 1);
+}
+.-emu-layout body.-emu .dialog input[type="checkbox"],
+body.-emu .dialog .-emu-layout input[type="checkbox"],
+.-emu-layout body.-emu #sidebar input[type="checkbox"],
+body.-emu #sidebar .-emu-layout input[type="checkbox"],
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  input[type="checkbox"],
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .-emu-layout
+  input[type="checkbox"],
+.-emu-layout
+  body.-emu
+  #client-settings.window-app.form
+  .window-content
+  #config-tabs
+  .module-settings-wrapper
+  div.form-group
+  input[type="checkbox"],
+body.-emu
+  #client-settings.window-app.form
+  .window-content
+  #config-tabs
+  .module-settings-wrapper
+  div.form-group
+  .-emu-layout
+  input[type="checkbox"],
+.-emu-layout body.-emu #module-management .package-title input[type="checkbox"],
+body.-emu
+  #module-management
+  .package-title
+  .-emu-layout
+  input[type="checkbox"] {
+  width: var(--emu-space-button-xs);
+  height: var(--emu-space-button-xs);
+  cursor: pointer;
+  flex: 0 0 auto;
   margin: 0;
-  top: auto; }
+  position: relative;
+  top: auto;
+}
+body.-emu .dialog input:disabled[type="checkbox"],
+body.-emu #sidebar input:disabled[type="checkbox"],
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  input:disabled[type="checkbox"],
+body.-emu
+  #client-settings.window-app.form
+  .window-content
+  #config-tabs
+  .module-settings-wrapper
+  div.form-group
+  input:disabled[type="checkbox"],
+body.-emu #module-management .package-title input:disabled[type="checkbox"] {
+  opacity: 0.5;
+  pointer-events: none;
+}
+body.-emu .dialog input:checked[type="checkbox"],
+body.-emu #sidebar input:checked[type="checkbox"],
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  input:checked[type="checkbox"],
+body.-emu
+  #client-settings.window-app.form
+  .window-content
+  #config-tabs
+  .module-settings-wrapper
+  div.form-group
+  input:checked[type="checkbox"],
+body.-emu #module-management .package-title input:checked[type="checkbox"] {
+  background-color: rgba(var(--color-primary), 1);
+  color: rgba(var(--color-text-lightest), 1);
+}
+
+.-emu-layout body.-emu .dialog input[type="radio"],
+body.-emu .dialog .-emu-layout input[type="radio"],
+.-emu-layout body.-emu #sidebar input[type="radio"],
+body.-emu #sidebar .-emu-layout input[type="radio"],
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  input[type="radio"],
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .-emu-layout
+  input[type="radio"] {
+  margin: 0;
+  top: auto;
+}
 
 body.-emu .dialog input[type="color"],
 body.-emu .dialog input[type="color"][data-edit],
 body.-emu #sidebar input[type="color"],
 body.-emu #sidebar input[type="color"][data-edit],
-body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) input[type="color"],
-body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) input[type="color"][data-edit] {
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  input[type="color"],
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  input[type="color"][data-edit] {
   background: transparent;
   border: rgba(var(--color-border-lighter), 1) 1px solid;
   border-radius: var(--emu-border-radius-forms, 0);
-  transition: box-shadow 0.3s cubic-bezier(0.075, 0.82, 0.165, 1); }
-  .-emu-layout body.-emu .dialog input[type="color"], body.-emu .dialog .-emu-layout input[type="color"],
-  .-emu-layout body.-emu #sidebar input[type="color"], body.-emu #sidebar .-emu-layout input[type="color"],
-  .-emu-layout body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) input[type="color"], body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .-emu-layout input[type="color"] {
-    cursor: pointer;
-    font-family: inherit;
-    font-size: inherit;
-    height: var(--emu-space-button);
-    margin: 0;
-    padding: 0 var(--emu-space-sm);
-    position: relative; }
-    .-emu-layout body.-emu .dialog input[type="color"] + input[type="color"], body.-emu .dialog .-emu-layout input[type="color"] + input[type="color"], .-emu-layout body.-emu #sidebar input[type="color"] + input[type="color"], body.-emu #sidebar .-emu-layout input[type="color"] + input[type="color"], .-emu-layout body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) input[type="color"] + input[type="color"], body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .-emu-layout input[type="color"] + input[type="color"] {
-      -webkit-margin-start: var(--emu-space-base);
-              margin-inline-start: var(--emu-space-base); }
-  body.-emu .dialog input:disabled[type="color"],
-  body.-emu #sidebar input:disabled[type="color"],
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) input:disabled[type="color"] {
-    opacity: 0.5;
-    pointer-events: none; }
+  transition: box-shadow 0.3s cubic-bezier(0.075, 0.82, 0.165, 1);
+}
+.-emu-layout body.-emu .dialog input[type="color"],
+body.-emu .dialog .-emu-layout input[type="color"],
+.-emu-layout body.-emu #sidebar input[type="color"],
+body.-emu #sidebar .-emu-layout input[type="color"],
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  input[type="color"],
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .-emu-layout
+  input[type="color"] {
+  cursor: pointer;
+  font-family: inherit;
+  font-size: inherit;
+  height: var(--emu-space-button);
+  margin: 0;
+  padding: 0 var(--emu-space-sm);
+  position: relative;
+}
+.-emu-layout body.-emu .dialog input[type="color"] + input[type="color"],
+body.-emu .dialog .-emu-layout input[type="color"] + input[type="color"],
+.-emu-layout body.-emu #sidebar input[type="color"] + input[type="color"],
+body.-emu #sidebar .-emu-layout input[type="color"] + input[type="color"],
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  input[type="color"]
+  + input[type="color"],
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .-emu-layout
+  input[type="color"]
+  + input[type="color"] {
+  -webkit-margin-start: var(--emu-space-base);
+  margin-inline-start: var(--emu-space-base);
+}
+body.-emu .dialog input:disabled[type="color"],
+body.-emu #sidebar input:disabled[type="color"],
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  input:disabled[type="color"] {
+  opacity: 0.5;
+  pointer-events: none;
+}
 
 body.-emu .dialog input[type="range"],
 body.-emu #sidebar input[type="range"],
-body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) input[type="range"] {
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  input[type="range"] {
   background: transparent;
   border: 0;
   box-shadow: none;
-  -webkit-appearance: none; }
-  .-emu-layout body.-emu .dialog input[type="range"], body.-emu .dialog .-emu-layout input[type="range"],
-  .-emu-layout body.-emu #sidebar input[type="range"], body.-emu #sidebar .-emu-layout input[type="range"],
-  .-emu-layout body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) input[type="range"], body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .-emu-layout input[type="range"] {
-    margin: 0;
-    width: 100%; }
-  body.-emu .dialog input:hover[type="range"],
-  body.-emu #sidebar input:hover[type="range"],
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) input:hover[type="range"], body.-emu .dialog input:focus[type="range"],
-  body.-emu #sidebar input:focus[type="range"],
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) input:focus[type="range"] {
-    box-shadow: none;
-    outline: none; }
-  body.-emu .dialog input[type="range"]::-webkit-slider-runnable-track,
-  body.-emu #sidebar input[type="range"]::-webkit-slider-runnable-track,
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) input[type="range"]::-webkit-slider-runnable-track {
-    background-color: rgba(var(--color-background), 0.8);
-    border: rgba(var(--color-border), 1) 1px solid;
-    border-radius: var(--emu-border-radius-forms, 0);
-    box-shadow: none;
-    transition: background 0.3s cubic-bezier(0.075, 0.82, 0.165, 1); }
-    .-emu-layout body.-emu .dialog input[type="range"]::-webkit-slider-runnable-track, body.-emu .dialog .-emu-layout input[type="range"]::-webkit-slider-runnable-track,
-    .-emu-layout body.-emu #sidebar input[type="range"]::-webkit-slider-runnable-track, body.-emu #sidebar .-emu-layout input[type="range"]::-webkit-slider-runnable-track,
-    .-emu-layout body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) input[type="range"]::-webkit-slider-runnable-track, body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .-emu-layout input[type="range"]::-webkit-slider-runnable-track {
-      width: 100%;
-      height: 0.5rem;
-      cursor: pointer; }
-  body.-emu .dialog input[type="range"]:focus::-webkit-slider-runnable-track,
-  body.-emu #sidebar input[type="range"]:focus::-webkit-slider-runnable-track,
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) input[type="range"]:focus::-webkit-slider-runnable-track {
-    background-color: rgba(var(--color-background), 1); }
-  body.-emu .dialog input[type="range"]:focus::-ms-fill-lower,
-  body.-emu #sidebar input[type="range"]:focus::-ms-fill-lower,
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) input[type="range"]:focus::-ms-fill-lower {
-    background-color: rgba(var(--color-background), 1); }
-  body.-emu .dialog input[type="range"]:focus::-ms-fill-upper,
-  body.-emu #sidebar input[type="range"]:focus::-ms-fill-upper,
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) input[type="range"]:focus::-ms-fill-upper {
-    background-color: rgba(var(--color-background), 1); }
-  body.-emu .dialog input[type="range"]::-webkit-slider-thumb,
-  body.-emu #sidebar input[type="range"]::-webkit-slider-thumb,
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) input[type="range"]::-webkit-slider-thumb {
-    background-color: rgba(var(--color-primary), 1);
-    border-radius: var(--emu-border-radius-forms, 0);
-    border: rgba(var(--color-border-lighter), 1) 1px solid;
-    box-shadow: none;
-    transition: box-shadow 0.3s cubic-bezier(0.075, 0.82, 0.165, 1);
-    -webkit-appearance: none; }
-    .-emu-layout body.-emu .dialog input[type="range"]::-webkit-slider-thumb, body.-emu .dialog .-emu-layout input[type="range"]::-webkit-slider-thumb,
-    .-emu-layout body.-emu #sidebar input[type="range"]::-webkit-slider-thumb, body.-emu #sidebar .-emu-layout input[type="range"]::-webkit-slider-thumb,
-    .-emu-layout body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) input[type="range"]::-webkit-slider-thumb, body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .-emu-layout input[type="range"]::-webkit-slider-thumb {
-      width: 1rem;
-      height: 1rem;
-      cursor: pointer;
-      -webkit-margin-before: -0.3125rem;
-              margin-block-start: -0.3125rem; }
-    body.-emu .dialog input::-webkit-slider-thumb:hover[type="range"],
-    body.-emu #sidebar input::-webkit-slider-thumb:hover[type="range"],
-    body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) input::-webkit-slider-thumb:hover[type="range"] {
-      box-shadow: inset 0 0 0 2px rgba(var(--color-white), 1), 0 1px 2px 0 rgba(var(--color-black), 0.3); }
-  body.-emu .dialog input[type="range"]::-moz-range-track,
-  body.-emu #sidebar input[type="range"]::-moz-range-track,
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) input[type="range"]::-moz-range-track {
-    background-color: rgba(var(--color-background), 0.8);
-    border: rgba(var(--color-border-lighter), 1) 1px solid;
-    border-radius: var(--emu-border-radius-forms, 0);
-    box-shadow: none;
-    transition: background 0.3s cubic-bezier(0.075, 0.82, 0.165, 1); }
-    .-emu-layout body.-emu .dialog input[type="range"]::-moz-range-track, body.-emu .dialog .-emu-layout input[type="range"]::-moz-range-track,
-    .-emu-layout body.-emu #sidebar input[type="range"]::-moz-range-track, body.-emu #sidebar .-emu-layout input[type="range"]::-moz-range-track,
-    .-emu-layout body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) input[type="range"]::-moz-range-track, body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .-emu-layout input[type="range"]::-moz-range-track {
-      width: 100%;
-      height: 0.5rem;
-      cursor: pointer; }
-  body.-emu .dialog input[type="range"]::-moz-range-thumb,
-  body.-emu #sidebar input[type="range"]::-moz-range-thumb,
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) input[type="range"]::-moz-range-thumb {
-    background-color: rgba(var(--color-primary), 1);
-    border-radius: var(--emu-border-radius-forms, 0);
-    border: rgba(var(--color-border-lighter), 1) 1px solid;
-    box-shadow: none;
-    transition: box-shadow 0.3s cubic-bezier(0.075, 0.82, 0.165, 1);
-    -webkit-appearance: none; }
-    .-emu-layout body.-emu .dialog input[type="range"]::-moz-range-thumb, body.-emu .dialog .-emu-layout input[type="range"]::-moz-range-thumb,
-    .-emu-layout body.-emu #sidebar input[type="range"]::-moz-range-thumb, body.-emu #sidebar .-emu-layout input[type="range"]::-moz-range-thumb,
-    .-emu-layout body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) input[type="range"]::-moz-range-thumb, body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .-emu-layout input[type="range"]::-moz-range-thumb {
-      width: 1rem;
-      height: 1rem;
-      cursor: pointer;
-      margin-block-start: -0.3125rem; }
-    body.-emu .dialog input::-moz-range-thumb:hover[type="range"],
-    body.-emu #sidebar input::-moz-range-thumb:hover[type="range"],
-    body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) input::-moz-range-thumb:hover[type="range"] {
-      box-shadow: inset 0 0 0 2px rgba(var(--color-white), 1), 0 1px 2px 0 rgba(var(--color-black), 0.3); }
-  body.-emu .dialog input[type="range"] + .range-value, body.-emu #sidebar input[type="range"] + .range-value, body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) input[type="range"] + .range-value {
-    border: none;
-    color: rgba(var(--color-text), 1); }
-    .-emu-layout body.-emu .dialog input[type="range"] + .range-value, body.-emu .dialog .-emu-layout input[type="range"] + .range-value, .-emu-layout body.-emu #sidebar input[type="range"] + .range-value, body.-emu #sidebar .-emu-layout input[type="range"] + .range-value, .-emu-layout body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) input[type="range"] + .range-value, body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .-emu-layout input[type="range"] + .range-value {
-      align-items: center;
-      display: flex;
-      flex: 0 0 auto;
-      font-size: var(--emu-font-size-md);
-      -webkit-margin-start: var(--emu-space-sm);
-              margin-inline-start: var(--emu-space-sm);
-      padding: 0; }
+  -webkit-appearance: none;
+}
+.-emu-layout body.-emu .dialog input[type="range"],
+body.-emu .dialog .-emu-layout input[type="range"],
+.-emu-layout body.-emu #sidebar input[type="range"],
+body.-emu #sidebar .-emu-layout input[type="range"],
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  input[type="range"],
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .-emu-layout
+  input[type="range"] {
+  margin: 0;
+  width: 100%;
+}
+body.-emu .dialog input:hover[type="range"],
+body.-emu #sidebar input:hover[type="range"],
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  input:hover[type="range"],
+body.-emu .dialog input:focus[type="range"],
+body.-emu #sidebar input:focus[type="range"],
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  input:focus[type="range"] {
+  box-shadow: none;
+  outline: none;
+}
+body.-emu .dialog input[type="range"]::-webkit-slider-runnable-track,
+body.-emu #sidebar input[type="range"]::-webkit-slider-runnable-track,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  input[type="range"]::-webkit-slider-runnable-track {
+  background-color: rgba(var(--color-background), 0.8);
+  border: rgba(var(--color-border), 1) 1px solid;
+  border-radius: var(--emu-border-radius-forms, 0);
+  box-shadow: none;
+  transition: background 0.3s cubic-bezier(0.075, 0.82, 0.165, 1);
+}
+.-emu-layout
+  body.-emu
+  .dialog
+  input[type="range"]::-webkit-slider-runnable-track,
+body.-emu
+  .dialog
+  .-emu-layout
+  input[type="range"]::-webkit-slider-runnable-track,
+.-emu-layout
+  body.-emu
+  #sidebar
+  input[type="range"]::-webkit-slider-runnable-track,
+body.-emu
+  #sidebar
+  .-emu-layout
+  input[type="range"]::-webkit-slider-runnable-track,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  input[type="range"]::-webkit-slider-runnable-track,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .-emu-layout
+  input[type="range"]::-webkit-slider-runnable-track {
+  width: 100%;
+  height: 0.5rem;
+  cursor: pointer;
+}
+body.-emu .dialog input[type="range"]:focus::-webkit-slider-runnable-track,
+body.-emu #sidebar input[type="range"]:focus::-webkit-slider-runnable-track,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  input[type="range"]:focus::-webkit-slider-runnable-track {
+  background-color: rgba(var(--color-background), 1);
+}
+body.-emu .dialog input[type="range"]:focus::-ms-fill-lower,
+body.-emu #sidebar input[type="range"]:focus::-ms-fill-lower,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  input[type="range"]:focus::-ms-fill-lower {
+  background-color: rgba(var(--color-background), 1);
+}
+body.-emu .dialog input[type="range"]:focus::-ms-fill-upper,
+body.-emu #sidebar input[type="range"]:focus::-ms-fill-upper,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  input[type="range"]:focus::-ms-fill-upper {
+  background-color: rgba(var(--color-background), 1);
+}
+body.-emu .dialog input[type="range"]::-webkit-slider-thumb,
+body.-emu #sidebar input[type="range"]::-webkit-slider-thumb,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  input[type="range"]::-webkit-slider-thumb {
+  background-color: rgba(var(--color-primary), 1);
+  border-radius: var(--emu-border-radius-forms, 0);
+  border: rgba(var(--color-border-lighter), 1) 1px solid;
+  box-shadow: none;
+  transition: box-shadow 0.3s cubic-bezier(0.075, 0.82, 0.165, 1);
+  -webkit-appearance: none;
+}
+.-emu-layout body.-emu .dialog input[type="range"]::-webkit-slider-thumb,
+body.-emu .dialog .-emu-layout input[type="range"]::-webkit-slider-thumb,
+.-emu-layout body.-emu #sidebar input[type="range"]::-webkit-slider-thumb,
+body.-emu #sidebar .-emu-layout input[type="range"]::-webkit-slider-thumb,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  input[type="range"]::-webkit-slider-thumb,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .-emu-layout
+  input[type="range"]::-webkit-slider-thumb {
+  width: 1rem;
+  height: 1rem;
+  cursor: pointer;
+  -webkit-margin-before: -0.3125rem;
+  margin-block-start: -0.3125rem;
+}
+body.-emu .dialog input::-webkit-slider-thumb:hover[type="range"],
+body.-emu #sidebar input::-webkit-slider-thumb:hover[type="range"],
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  input::-webkit-slider-thumb:hover[type="range"] {
+  box-shadow: inset 0 0 0 2px rgba(var(--color-white), 1),
+    0 1px 2px 0 rgba(var(--color-black), 0.3);
+}
+body.-emu .dialog input[type="range"]::-moz-range-track,
+body.-emu #sidebar input[type="range"]::-moz-range-track,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  input[type="range"]::-moz-range-track {
+  background-color: rgba(var(--color-background), 0.8);
+  border: rgba(var(--color-border-lighter), 1) 1px solid;
+  border-radius: var(--emu-border-radius-forms, 0);
+  box-shadow: none;
+  transition: background 0.3s cubic-bezier(0.075, 0.82, 0.165, 1);
+}
+.-emu-layout body.-emu .dialog input[type="range"]::-moz-range-track,
+body.-emu .dialog .-emu-layout input[type="range"]::-moz-range-track,
+.-emu-layout body.-emu #sidebar input[type="range"]::-moz-range-track,
+body.-emu #sidebar .-emu-layout input[type="range"]::-moz-range-track,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  input[type="range"]::-moz-range-track,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .-emu-layout
+  input[type="range"]::-moz-range-track {
+  width: 100%;
+  height: 0.5rem;
+  cursor: pointer;
+}
+body.-emu .dialog input[type="range"]::-moz-range-thumb,
+body.-emu #sidebar input[type="range"]::-moz-range-thumb,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  input[type="range"]::-moz-range-thumb {
+  background-color: rgba(var(--color-primary), 1);
+  border-radius: var(--emu-border-radius-forms, 0);
+  border: rgba(var(--color-border-lighter), 1) 1px solid;
+  box-shadow: none;
+  transition: box-shadow 0.3s cubic-bezier(0.075, 0.82, 0.165, 1);
+  -webkit-appearance: none;
+}
+.-emu-layout body.-emu .dialog input[type="range"]::-moz-range-thumb,
+body.-emu .dialog .-emu-layout input[type="range"]::-moz-range-thumb,
+.-emu-layout body.-emu #sidebar input[type="range"]::-moz-range-thumb,
+body.-emu #sidebar .-emu-layout input[type="range"]::-moz-range-thumb,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  input[type="range"]::-moz-range-thumb,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .-emu-layout
+  input[type="range"]::-moz-range-thumb {
+  width: 1rem;
+  height: 1rem;
+  cursor: pointer;
+  margin-block-start: -0.3125rem;
+}
+body.-emu .dialog input::-moz-range-thumb:hover[type="range"],
+body.-emu #sidebar input::-moz-range-thumb:hover[type="range"],
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  input::-moz-range-thumb:hover[type="range"] {
+  box-shadow: inset 0 0 0 2px rgba(var(--color-white), 1),
+    0 1px 2px 0 rgba(var(--color-black), 0.3);
+}
+body.-emu .dialog input[type="range"] + .range-value,
+body.-emu #sidebar input[type="range"] + .range-value,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  input[type="range"]
+  + .range-value {
+  border: none;
+  color: rgba(var(--color-text), 1);
+}
+.-emu-layout body.-emu .dialog input[type="range"] + .range-value,
+body.-emu .dialog .-emu-layout input[type="range"] + .range-value,
+.-emu-layout body.-emu #sidebar input[type="range"] + .range-value,
+body.-emu #sidebar .-emu-layout input[type="range"] + .range-value,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  input[type="range"]
+  + .range-value,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .-emu-layout
+  input[type="range"]
+  + .range-value {
+  align-items: center;
+  display: flex;
+  flex: 0 0 auto;
+  font-size: var(--emu-font-size-md);
+  -webkit-margin-start: var(--emu-space-sm);
+  margin-inline-start: var(--emu-space-sm);
+  padding: 0;
+}
 
 body.-emu .dialog textarea,
 body.-emu #sidebar textarea,
@@ -519,114 +3735,468 @@ body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) textarea {
   border: rgba(var(--color-border-lighter), 1) 1px solid;
   border-radius: var(--emu-border-radius-forms, 0);
   color: rgba(var(--color-text), 1);
-  transition: box-shadow 0.3s cubic-bezier(0.075, 0.82, 0.165, 1); }
-  .-emu-layout body.-emu .dialog textarea, body.-emu .dialog .-emu-layout textarea,
-  .-emu-layout body.-emu #sidebar textarea, body.-emu #sidebar .-emu-layout textarea,
-  .-emu-layout body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) textarea, body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .-emu-layout textarea {
-    font-family: inherit;
-    font-size: inherit;
-    margin: 0;
-    min-height: 4rem;
-    padding: var(--emu-space-sm);
-    position: relative;
-    resize: none;
-    transition: box-shadow 0.3s cubic-bezier(0.075, 0.82, 0.165, 1);
-    -webkit-user-select: text;
-       -moz-user-select: text;
-        -ms-user-select: text;
-            user-select: text;
-    width: 100%; }
-  .-emu-layout.-emu-compact body.-emu .dialog textarea, body.-emu .dialog .-emu-layout.-emu-compact textarea,
-  .-emu-layout.-emu-compact body.-emu #sidebar textarea, body.-emu #sidebar .-emu-layout.-emu-compact textarea,
-  .-emu-layout.-emu-compact body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) textarea, body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .-emu-layout.-emu-compact textarea {
-    min-height: 3rem; }
-  body.-emu .dialog textarea::-moz-placeholder,
-  body.-emu #sidebar textarea::-moz-placeholder,
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) textarea::-moz-placeholder {
-    color: rgba(var(--color-text), 0.5); }
-  body.-emu .dialog textarea::placeholder,
-  body.-emu #sidebar textarea::placeholder,
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) textarea::placeholder {
-    color: rgba(var(--color-text), 0.5); }
-  body.-emu .dialog textarea:disabled,
-  body.-emu #sidebar textarea:disabled,
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) textarea:disabled {
-    opacity: 0.5;
-    pointer-events: none; }
+  transition: box-shadow 0.3s cubic-bezier(0.075, 0.82, 0.165, 1);
+}
+.-emu-layout body.-emu .dialog textarea,
+body.-emu .dialog .-emu-layout textarea,
+.-emu-layout body.-emu #sidebar textarea,
+body.-emu #sidebar .-emu-layout textarea,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  textarea,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .-emu-layout
+  textarea {
+  font-family: inherit;
+  font-size: inherit;
+  margin: 0;
+  min-height: 4rem;
+  padding: var(--emu-space-sm);
+  position: relative;
+  resize: none;
+  transition: box-shadow 0.3s cubic-bezier(0.075, 0.82, 0.165, 1);
+  -webkit-user-select: text;
+  -moz-user-select: text;
+  -ms-user-select: text;
+  user-select: text;
+  width: 100%;
+}
+.-emu-layout.-emu-compact body.-emu .dialog textarea,
+body.-emu .dialog .-emu-layout.-emu-compact textarea,
+.-emu-layout.-emu-compact body.-emu #sidebar textarea,
+body.-emu #sidebar .-emu-layout.-emu-compact textarea,
+.-emu-layout.-emu-compact
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  textarea,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .-emu-layout.-emu-compact
+  textarea {
+  min-height: 3rem;
+}
+body.-emu .dialog textarea::-moz-placeholder,
+body.-emu #sidebar textarea::-moz-placeholder,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  textarea::-moz-placeholder {
+  color: rgba(var(--color-text), 0.5);
+}
+body.-emu .dialog textarea::placeholder,
+body.-emu #sidebar textarea::placeholder,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  textarea::placeholder {
+  color: rgba(var(--color-text), 0.5);
+}
+body.-emu .dialog textarea:disabled,
+body.-emu #sidebar textarea:disabled,
+body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) textarea:disabled {
+  opacity: 0.5;
+  pointer-events: none;
+}
 
 body.-emu #sidebar .sidebar-tab .directory-header,
 body.-emu #sidebar .sidebar-tab .directory-footer,
 body.-emu .sidebar-popout .sidebar-tab .directory-header,
-body.-emu .sidebar-popout .sidebar-tab .directory-footer, body.-emu #sidebar #combat #combat-round,
-body.-emu .sidebar-popout #combat #combat-round, body.-emu #sidebar #chat section.dice-tray,
-body.-emu .sidebar-popout #chat section.dice-tray, body.-emu #sidebar .token-mold,
+body.-emu .sidebar-popout .sidebar-tab .directory-footer,
+body.-emu #sidebar #combat #combat-round,
+body.-emu .sidebar-popout #combat #combat-round,
+body.-emu #sidebar #chat section.dice-tray,
+body.-emu .sidebar-popout #chat section.dice-tray,
+body.-emu #sidebar .token-mold,
 body.-emu .sidebar-popout .token-mold {
-  background-color: rgba(var(--color-background), var(--emu-background-opacity-sidebar, 0.8));
+  background-color: rgba(
+    var(--color-background),
+    var(--emu-background-opacity-sidebar, 0.8)
+  );
   background-image: var(--emu-image-background, none);
   border: none;
-  color: rgba(var(--color-text-lightest), 1); }
-  .-emu-layout body.-emu #sidebar .sidebar-tab .directory-header, body.-emu #sidebar .sidebar-tab .-emu-layout .directory-header,
-  .-emu-layout body.-emu #sidebar .sidebar-tab .directory-footer, body.-emu #sidebar .sidebar-tab .-emu-layout .directory-footer,
-  .-emu-layout body.-emu .sidebar-popout .sidebar-tab .directory-header, body.-emu .sidebar-popout .sidebar-tab .-emu-layout .directory-header,
-  .-emu-layout body.-emu .sidebar-popout .sidebar-tab .directory-footer, body.-emu .sidebar-popout .sidebar-tab .-emu-layout .directory-footer, .-emu-layout body.-emu #sidebar #combat #combat-round, body.-emu #sidebar #combat .-emu-layout #combat-round,
-  .-emu-layout body.-emu .sidebar-popout #combat #combat-round, body.-emu .sidebar-popout #combat .-emu-layout #combat-round, .-emu-layout body.-emu #sidebar #chat section.dice-tray, body.-emu #sidebar #chat .-emu-layout section.dice-tray,
-  .-emu-layout body.-emu .sidebar-popout #chat section.dice-tray, body.-emu .sidebar-popout #chat .-emu-layout section.dice-tray, .-emu-layout body.-emu #sidebar .token-mold, body.-emu #sidebar .-emu-layout .token-mold,
-  .-emu-layout body.-emu .sidebar-popout .token-mold, body.-emu .sidebar-popout .-emu-layout .token-mold {
-    align-items: center;
-    display: flex;
-    flex: 0 0 auto;
-    line-height: initial;
-    margin: 0;
-    padding: var(--emu-space-sm);
-    position: relative;
-    text-align: start; }
-    .-emu-layout body.-emu #sidebar .sidebar-tab .directory-header:empty, body.-emu #sidebar .sidebar-tab .-emu-layout .directory-header:empty,
-    .-emu-layout body.-emu #sidebar .sidebar-tab .directory-footer:empty, body.-emu #sidebar .sidebar-tab .-emu-layout .directory-footer:empty,
-    .-emu-layout body.-emu .sidebar-popout .sidebar-tab .directory-header:empty, body.-emu .sidebar-popout .sidebar-tab .-emu-layout .directory-header:empty,
-    .-emu-layout body.-emu .sidebar-popout .sidebar-tab .directory-footer:empty, body.-emu .sidebar-popout .sidebar-tab .-emu-layout .directory-footer:empty, .-emu-layout body.-emu #sidebar #combat #combat-round:empty, body.-emu #sidebar #combat .-emu-layout #combat-round:empty,
-    .-emu-layout body.-emu .sidebar-popout #combat #combat-round:empty, body.-emu .sidebar-popout #combat .-emu-layout #combat-round:empty, .-emu-layout body.-emu #sidebar #chat section.dice-tray:empty, body.-emu #sidebar #chat .-emu-layout section.dice-tray:empty,
-    .-emu-layout body.-emu .sidebar-popout #chat section.dice-tray:empty, body.-emu .sidebar-popout #chat .-emu-layout section.dice-tray:empty, .-emu-layout body.-emu #sidebar .token-mold:empty, body.-emu #sidebar .-emu-layout .token-mold:empty,
-    .-emu-layout body.-emu .sidebar-popout .token-mold:empty, body.-emu .sidebar-popout .-emu-layout .token-mold:empty {
-      display: none; }
+  color: rgba(var(--color-text-lightest), 1);
+}
+.-emu-layout body.-emu #sidebar .sidebar-tab .directory-header,
+body.-emu #sidebar .sidebar-tab .-emu-layout .directory-header,
+.-emu-layout body.-emu #sidebar .sidebar-tab .directory-footer,
+body.-emu #sidebar .sidebar-tab .-emu-layout .directory-footer,
+.-emu-layout body.-emu .sidebar-popout .sidebar-tab .directory-header,
+body.-emu .sidebar-popout .sidebar-tab .-emu-layout .directory-header,
+.-emu-layout body.-emu .sidebar-popout .sidebar-tab .directory-footer,
+body.-emu .sidebar-popout .sidebar-tab .-emu-layout .directory-footer,
+.-emu-layout body.-emu #sidebar #combat #combat-round,
+body.-emu #sidebar #combat .-emu-layout #combat-round,
+.-emu-layout body.-emu .sidebar-popout #combat #combat-round,
+body.-emu .sidebar-popout #combat .-emu-layout #combat-round,
+.-emu-layout body.-emu #sidebar #chat section.dice-tray,
+body.-emu #sidebar #chat .-emu-layout section.dice-tray,
+.-emu-layout body.-emu .sidebar-popout #chat section.dice-tray,
+body.-emu .sidebar-popout #chat .-emu-layout section.dice-tray,
+.-emu-layout body.-emu #sidebar .token-mold,
+body.-emu #sidebar .-emu-layout .token-mold,
+.-emu-layout body.-emu .sidebar-popout .token-mold,
+body.-emu .sidebar-popout .-emu-layout .token-mold {
+  align-items: center;
+  display: flex;
+  flex: 0 0 auto;
+  line-height: initial;
+  margin: 0;
+  padding: var(--emu-space-sm);
+  position: relative;
+  text-align: start;
+}
+.-emu-layout body.-emu #sidebar .sidebar-tab .directory-header:empty,
+body.-emu #sidebar .sidebar-tab .-emu-layout .directory-header:empty,
+.-emu-layout body.-emu #sidebar .sidebar-tab .directory-footer:empty,
+body.-emu #sidebar .sidebar-tab .-emu-layout .directory-footer:empty,
+.-emu-layout body.-emu .sidebar-popout .sidebar-tab .directory-header:empty,
+body.-emu .sidebar-popout .sidebar-tab .-emu-layout .directory-header:empty,
+.-emu-layout body.-emu .sidebar-popout .sidebar-tab .directory-footer:empty,
+body.-emu .sidebar-popout .sidebar-tab .-emu-layout .directory-footer:empty,
+.-emu-layout body.-emu #sidebar #combat #combat-round:empty,
+body.-emu #sidebar #combat .-emu-layout #combat-round:empty,
+.-emu-layout body.-emu .sidebar-popout #combat #combat-round:empty,
+body.-emu .sidebar-popout #combat .-emu-layout #combat-round:empty,
+.-emu-layout body.-emu #sidebar #chat section.dice-tray:empty,
+body.-emu #sidebar #chat .-emu-layout section.dice-tray:empty,
+.-emu-layout body.-emu .sidebar-popout #chat section.dice-tray:empty,
+body.-emu .sidebar-popout #chat .-emu-layout section.dice-tray:empty,
+.-emu-layout body.-emu #sidebar .token-mold:empty,
+body.-emu #sidebar .-emu-layout .token-mold:empty,
+.-emu-layout body.-emu .sidebar-popout .token-mold:empty,
+body.-emu .sidebar-popout .-emu-layout .token-mold:empty {
+  display: none;
+}
 
-body.-emu .dialog .tabs a:hover, body.-emu .dialog .sheet-tabs a:hover, body.-emu #sidebar .tabs a:hover, body.-emu #sidebar .sheet-tabs a:hover, body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .tabs a:hover, body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .sheet-tabs a:hover, body.-emu #module-management .list-filters a:hover, body.-emu .dialog button:hover,
+body.-emu .dialog .tabs a:hover,
+body.-emu .dialog .sheet-tabs a:hover,
+body.-emu #sidebar .tabs a:hover,
+body.-emu #sidebar .sheet-tabs a:hover,
+body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .tabs a:hover,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .sheet-tabs
+  a:hover,
+body.-emu #module-management .list-filters a:hover,
+body.-emu .dialog button:hover,
 body.-emu #sidebar button:hover,
-body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) button:hover, body.-emu #menu #menu-items li:hover, body.-emu #sidebar #combat #combat-controls .combat-control:hover,
-body.-emu .sidebar-popout #combat #combat-controls .combat-control:hover, body.-emu .filepicker.window-app .display-modes .display-mode:hover, body.-emu .journal-sheet.sheet.window-app .window-content .editor-edit:hover, body.-emu #calendar-time-container .calendar--time-controls .advance-btn:hover,
-body.-emu #calendar-weather-container .calendar--time-controls .advance-btn:hover, body.-emu #sidebar #combat .add-temporary:hover,
-body.-emu .sidebar-popout #combat .add-temporary:hover, body.-emu .window-app[id*="ActiveEffects-"] .window-content > form li.filter-item:hover, body.-emu #specials-config .fxmaster .directory-header a:hover, body.-emu .moulinette-options li:hover, body.-emu #moulinette.forge .filepicker .display-modes a:hover, body.-emu #OneJournalShell.window-app .history-navigation a:hover, body.-emu ul.command-menu li:hover, body.-emu #token-action-hud button.tah-title-button:hover,
-body.-emu #token-action-hud .tah-action button:hover, body.-emu #sidebar .token-mold > label > span:hover,
-body.-emu .sidebar-popout .token-mold > label > span:hover, .-emu-layout body.-emu .sheet.active-effect-sheet .effects-header a:hover, body.-emu .sheet.active-effect-sheet .-emu-layout .effects-header a:hover, .-emu-layout body.-emu .sheet.roll-table-config .table-results .table-header a:hover, body.-emu .sheet.roll-table-config .table-results .-emu-layout .table-header a:hover, .-emu-layout body.-emu .dice-so-nice section.content .settings-list .sfxs-list .sfx-header a:hover, body.-emu .dice-so-nice section.content .settings-list .sfxs-list .-emu-layout .sfx-header a:hover, .-emu-layout body.-emu .window-app[id*="ActiveEffects-"] .window-content > form .dnd5e.sheet.item .effect-header a:hover, body.-emu .window-app[id*="ActiveEffects-"] .window-content > form .dnd5e.sheet.item .-emu-layout .effect-header a:hover, .-emu-layout body.-emu .sheet.active-effect-sheet .changes-list li a:hover, body.-emu .sheet.active-effect-sheet .changes-list .-emu-layout li a:hover, .-emu-layout body.-emu .sheet.roll-table-config .table-results .table-result a:hover, body.-emu .sheet.roll-table-config .table-results .-emu-layout .table-result a:hover, .-emu-layout body.-emu .dice-so-nice section.content .settings-list .sfxs-list .sfx a:hover, body.-emu .dice-so-nice section.content .settings-list .sfxs-list .-emu-layout .sfx a:hover, body.-emu .dialog .directory .directory-item.folder .folder-header .create-folder:hover,
-body.-emu .dialog .directory .directory-item.folder .folder-header .create-entity:hover,
-body.-emu #sidebar .directory .directory-item.folder .folder-header .create-folder:hover,
-body.-emu #sidebar .directory .directory-item.folder .folder-header .create-entity:hover,
-body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .directory .directory-item.folder .folder-header .create-folder:hover,
-body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .directory .directory-item.folder .folder-header .create-entity:hover, body.-emu #navigation #nav-toggle:hover, .-emu-layout body.-emu .window-app .window-header > a:hover, .-emu-layout body.-emu .window-app .window-header a.header-button:hover, .-emu-layout body.-emu #sidebar #chat #chat-log .message .button.message-delete:hover, .-emu-layout body.-emu .sidebar-popout #chat #chat-log .message .button.message-delete:hover, .-emu-layout body.-emu #sidebar #chat #chat-controls .chat-control-icon .fa-dice-d20:hover, .-emu-layout body.-emu .sidebar-popout #chat #chat-controls .chat-control-icon .fa-dice-d20:hover, .-emu-layout body.-emu #sidebar #chat #chat-controls .control-buttons .button:hover, .-emu-layout body.-emu .sidebar-popout #chat #chat-controls .control-buttons .button:hover, body.-emu #sidebar #combat #combat-round .encounters a:hover,
-body.-emu .sidebar-popout #combat #combat-round .encounters a:hover, body.-emu #sidebar #combat #combat-tracker .combatant .combatant-control:hover,
-body.-emu .sidebar-popout #combat #combat-tracker .combatant .combatant-control:hover, body.-emu #sidebar #playlists .directory-list .playlist-header .sound-controls .sound-control:hover,
-body.-emu #sidebar #playlists .directory-list .sound .sound-controls .sound-control:hover,
-body.-emu .sidebar-popout #playlists .directory-list .playlist-header .sound-controls .sound-control:hover,
-body.-emu .sidebar-popout #playlists .directory-list .sound .sound-controls .sound-control:hover, body.-emu #sidebar #playlists #currently-playing .sound .sound-control:hover,
-body.-emu .sidebar-popout #playlists #currently-playing .sound .sound-control:hover, body.-emu .window-app[id*="chat-popout-"] .chat-message .chat-card .die-result-overlay-br button:hover,
-body.-emu #sidebar #chat #chat-log .chat-message .chat-card .die-result-overlay-br button:hover, body.-emu #dfcp-rt-buttons button:hover, body.-emu .active-effect-sheet[id*="ActiveEffectsConfig-"] .effect-special-duration .effect-control:hover, body.-emu #specials-config .fxmaster .special-effects .controls a:hover, body.-emu div.permission-viewer a:hover, .-emu-layout body.-emu #sidebar #chat #chat-log .message .button.polyglot-message-language:hover, .-emu-layout body.-emu .sidebar-popout #chat #chat-log .message .button.polyglot-message-language:hover, body.-emu #smalltime-app #displayContainer .arrow:hover, body.-emu #token-action-hud #tah-reposition:hover,
-body.-emu #token-action-hud #tah-categories:hover, body.-emu #sidebar .token-mold > a:hover,
-body.-emu .sidebar-popout .token-mold > a:hover, body.-emu #sidebar .sidebar-tab .directory-header .header-control:hover,
-body.-emu .sidebar-popout .sidebar-tab .directory-header .header-control:hover, body.-emu .dialog .directory .directory-item:hover,
+body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) button:hover,
+body.-emu #menu #menu-items li:hover,
+body.-emu #sidebar #combat #combat-controls .combat-control:hover,
+body.-emu .sidebar-popout #combat #combat-controls .combat-control:hover,
+body.-emu .filepicker.window-app .display-modes .display-mode:hover,
+body.-emu .journal-sheet.sheet.window-app .window-content .editor-edit:hover,
+body.-emu #calendar-time-container .calendar--time-controls .advance-btn:hover,
+body.-emu
+  #calendar-weather-container
+  .calendar--time-controls
+  .advance-btn:hover,
+body.-emu #sidebar #combat .add-temporary:hover,
+body.-emu .sidebar-popout #combat .add-temporary:hover,
+body.-emu
+  .window-app[id*="ActiveEffects-"]
+  .window-content
+  > form
+  li.filter-item:hover,
+body.-emu #specials-config .fxmaster .directory-header a:hover,
+body.-emu .moulinette-options li:hover,
+body.-emu #moulinette.forge .filepicker .display-modes a:hover,
+body.-emu #OneJournalShell.window-app .history-navigation a:hover,
+body.-emu ul.command-menu li:hover,
+body.-emu #token-action-hud button.tah-title-button:hover,
+body.-emu #token-action-hud .tah-action button:hover,
+body.-emu #sidebar .token-mold > label > span:hover,
+body.-emu .sidebar-popout .token-mold > label > span:hover,
+.-emu-layout body.-emu .sheet.active-effect-sheet .effects-header a:hover,
+body.-emu .sheet.active-effect-sheet .-emu-layout .effects-header a:hover,
+.-emu-layout
+  body.-emu
+  .sheet.roll-table-config
+  .table-results
+  .table-header
+  a:hover,
+body.-emu
+  .sheet.roll-table-config
+  .table-results
+  .-emu-layout
+  .table-header
+  a:hover,
+.-emu-layout
+  body.-emu
+  .dice-so-nice
+  section.content
+  .settings-list
+  .sfxs-list
+  .sfx-header
+  a:hover,
+body.-emu
+  .dice-so-nice
+  section.content
+  .settings-list
+  .sfxs-list
+  .-emu-layout
+  .sfx-header
+  a:hover,
+.-emu-layout
+  body.-emu
+  .window-app[id*="ActiveEffects-"]
+  .window-content
+  > form
+  .dnd5e.sheet.item
+  .effect-header
+  a:hover,
+body.-emu
+  .window-app[id*="ActiveEffects-"]
+  .window-content
+  > form
+  .dnd5e.sheet.item
+  .-emu-layout
+  .effect-header
+  a:hover,
+.-emu-layout body.-emu .sheet.active-effect-sheet .changes-list li a:hover,
+body.-emu .sheet.active-effect-sheet .changes-list .-emu-layout li a:hover,
+.-emu-layout
+  body.-emu
+  .sheet.roll-table-config
+  .table-results
+  .table-result
+  a:hover,
+body.-emu
+  .sheet.roll-table-config
+  .table-results
+  .-emu-layout
+  .table-result
+  a:hover,
+.-emu-layout
+  body.-emu
+  .dice-so-nice
+  section.content
+  .settings-list
+  .sfxs-list
+  .sfx
+  a:hover,
+body.-emu
+  .dice-so-nice
+  section.content
+  .settings-list
+  .sfxs-list
+  .-emu-layout
+  .sfx
+  a:hover,
+body.-emu
+  .dialog
+  .directory
+  .directory-item.folder
+  .folder-header
+  .create-folder:hover,
+body.-emu
+  .dialog
+  .directory
+  .directory-item.folder
+  .folder-header
+  .create-entity:hover,
+body.-emu
+  #sidebar
+  .directory
+  .directory-item.folder
+  .folder-header
+  .create-folder:hover,
+body.-emu
+  #sidebar
+  .directory
+  .directory-item.folder
+  .folder-header
+  .create-entity:hover,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .directory
+  .directory-item.folder
+  .folder-header
+  .create-folder:hover,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .directory
+  .directory-item.folder
+  .folder-header
+  .create-entity:hover,
+body.-emu #navigation #nav-toggle:hover,
+.-emu-layout body.-emu .window-app .window-header > a:hover,
+.-emu-layout body.-emu .window-app .window-header a.header-button:hover,
+.-emu-layout
+  body.-emu
+  #sidebar
+  #chat
+  #chat-log
+  .message
+  .button.message-delete:hover,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #chat
+  #chat-log
+  .message
+  .button.message-delete:hover,
+.-emu-layout
+  body.-emu
+  #sidebar
+  #chat
+  #chat-controls
+  .chat-control-icon
+  .fa-dice-d20:hover,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #chat
+  #chat-controls
+  .chat-control-icon
+  .fa-dice-d20:hover,
+.-emu-layout
+  body.-emu
+  #sidebar
+  #chat
+  #chat-controls
+  .control-buttons
+  .button:hover,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #chat
+  #chat-controls
+  .control-buttons
+  .button:hover,
+body.-emu #sidebar #combat #combat-round .encounters a:hover,
+body.-emu .sidebar-popout #combat #combat-round .encounters a:hover,
+body.-emu #sidebar #combat #combat-tracker .combatant .combatant-control:hover,
+body.-emu
+  .sidebar-popout
+  #combat
+  #combat-tracker
+  .combatant
+  .combatant-control:hover,
+body.-emu
+  #sidebar
+  #playlists
+  .directory-list
+  .playlist-header
+  .sound-controls
+  .sound-control:hover,
+body.-emu
+  #sidebar
+  #playlists
+  .directory-list
+  .sound
+  .sound-controls
+  .sound-control:hover,
+body.-emu
+  .sidebar-popout
+  #playlists
+  .directory-list
+  .playlist-header
+  .sound-controls
+  .sound-control:hover,
+body.-emu
+  .sidebar-popout
+  #playlists
+  .directory-list
+  .sound
+  .sound-controls
+  .sound-control:hover,
+body.-emu #sidebar #playlists #currently-playing .sound .sound-control:hover,
+body.-emu
+  .sidebar-popout
+  #playlists
+  #currently-playing
+  .sound
+  .sound-control:hover,
+body.-emu
+  .window-app[id*="chat-popout-"]
+  .chat-message
+  .chat-card
+  .die-result-overlay-br
+  button:hover,
+body.-emu
+  #sidebar
+  #chat
+  #chat-log
+  .chat-message
+  .chat-card
+  .die-result-overlay-br
+  button:hover,
+body.-emu #dfcp-rt-buttons button:hover,
+body.-emu
+  .active-effect-sheet[id*="ActiveEffectsConfig-"]
+  .effect-special-duration
+  .effect-control:hover,
+body.-emu #specials-config .fxmaster .special-effects .controls a:hover,
+body.-emu div.permission-viewer a:hover,
+.-emu-layout
+  body.-emu
+  #sidebar
+  #chat
+  #chat-log
+  .message
+  .button.polyglot-message-language:hover,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #chat
+  #chat-log
+  .message
+  .button.polyglot-message-language:hover,
+body.-emu #smalltime-app #displayContainer .arrow:hover,
+body.-emu #token-action-hud #tah-reposition:hover,
+body.-emu #token-action-hud #tah-categories:hover,
+body.-emu #sidebar .token-mold > a:hover,
+body.-emu .sidebar-popout .token-mold > a:hover,
+body.-emu #sidebar .sidebar-tab .directory-header .header-control:hover,
+body.-emu .sidebar-popout .sidebar-tab .directory-header .header-control:hover,
+body.-emu .dialog .directory .directory-item:hover,
 body.-emu #sidebar .directory .directory-item:hover,
-body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .directory .directory-item:hover, body.-emu .dialog .directory .directory-item.folder .folder-header:hover,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .directory
+  .directory-item:hover,
+body.-emu .dialog .directory .directory-item.folder .folder-header:hover,
 body.-emu #sidebar .directory .directory-item.folder .folder-header:hover,
-body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .directory .directory-item.folder .folder-header:hover, body.-emu #hotbar .bar-controls .page-control:hover,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .directory
+  .directory-item.folder
+  .folder-header:hover,
+body.-emu #hotbar .bar-controls .page-control:hover,
 body.-emu #hotbar .bar-controls #macro-directory:hover,
-body.-emu #hotbar .bar-controls #bar-toggle:hover, body.-emu #hotbar .macro:hover, body.-emu #hud .control-icon:hover, body.-emu #hud .control-icon.active, body.-emu #controls .scene-control:hover,
-body.-emu #controls .control-tool:hover, body.-emu #controls .scene-control.active,
-body.-emu #controls .control-tool.active, body.-emu #controls .control-tool.toggle:hover, body.-emu #navigation #scene-list .scene:hover,
-body.-emu #navigation .scene-list .scene:hover, body.-emu .window-app .window-resizable-handle:hover, body.-emu .sheet .sheet-header > img:hover, body.-emu #sidebar #sidebar-tabs > .item:hover,
+body.-emu #hotbar .bar-controls #bar-toggle:hover,
+body.-emu #hotbar .macro:hover,
+body.-emu #hud .control-icon:hover,
+body.-emu #hud .control-icon.active,
+body.-emu #controls .scene-control:hover,
+body.-emu #controls .control-tool:hover,
+body.-emu #controls .scene-control.active,
+body.-emu #controls .control-tool.active,
+body.-emu #controls .control-tool.toggle:hover,
+body.-emu #navigation #scene-list .scene:hover,
+body.-emu #navigation .scene-list .scene:hover,
+body.-emu .window-app .window-resizable-handle:hover,
+body.-emu .sheet .sheet-header > img:hover,
+body.-emu #sidebar #sidebar-tabs > .item:hover,
 body.-emu #sidebar #sidebar-tabs > .collapse:hover,
 body.-emu .sidebar-popout #sidebar-tabs > .item:hover,
-body.-emu .sidebar-popout #sidebar-tabs > .collapse:hover, body.-emu #sidebar #combat #combat-tracker .combatant:hover,
-body.-emu .sidebar-popout #combat #combat-tracker .combatant:hover, body.-emu #df-curvy-walls-tools .control-tool:hover, body.-emu #navigation .monks-scene-navigation .scene-list > .nav-item > .scene-name:hover, body.-emu #OneJournalShell.window-app .sidebar-toggle:hover, body.-emu .window-app .window-draggable-handle:hover, body.-emu #tokenAttacher .control-tool:hover {
+body.-emu .sidebar-popout #sidebar-tabs > .collapse:hover,
+body.-emu #sidebar #combat #combat-tracker .combatant:hover,
+body.-emu .sidebar-popout #combat #combat-tracker .combatant:hover,
+body.-emu #df-curvy-walls-tools .control-tool:hover,
+body.-emu
+  #navigation
+  .monks-scene-navigation
+  .scene-list
+  > .nav-item
+  > .scene-name:hover,
+body.-emu #OneJournalShell.window-app .sidebar-toggle:hover,
+body.-emu .window-app .window-draggable-handle:hover,
+body.-emu #tokenAttacher .control-tool:hover {
   box-shadow: inset 0 0 0 2px rgba(var(--color-white), 1);
-  text-shadow: none; }
+  text-shadow: none;
+}
 
 body.-emu .dialog input:hover[type="text"],
 body.-emu .dialog input:hover[type="number"],
@@ -640,51 +4210,368 @@ body.-emu #sidebar input:hover[type="date"],
 body.-emu #sidebar input:hover[type="time"],
 body.-emu #sidebar input:hover[type="password"],
 body.-emu #sidebar input:hover[type="datetime-local"],
-body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) input:hover[type="text"],
-body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) input:hover[type="number"],
-body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) input:hover[type="date"],
-body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) input:hover[type="time"],
-body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) input:hover[type="password"],
-body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) input:hover[type="datetime-local"], body.-emu #hud input:hover[type="text"], body.-emu #sidebar #chat section.dice-tray input.dice-tray__input:hover,
-body.-emu .sidebar-popout #chat section.dice-tray input.dice-tray__input:hover, body.-emu #client-settings.window-app.form .window-content #config-tabs div.tab[data-tab="modules"] #searchField #searchInput:hover, body.-emu .dialog select:hover,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  input:hover[type="text"],
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  input:hover[type="number"],
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  input:hover[type="date"],
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  input:hover[type="time"],
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  input:hover[type="password"],
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  input:hover[type="datetime-local"],
+body.-emu #hud input:hover[type="text"],
+body.-emu #sidebar #chat section.dice-tray input.dice-tray__input:hover,
+body.-emu .sidebar-popout #chat section.dice-tray input.dice-tray__input:hover,
+body.-emu
+  #client-settings.window-app.form
+  .window-content
+  #config-tabs
+  div.tab[data-tab="modules"]
+  #searchField
+  #searchInput:hover,
+body.-emu .dialog select:hover,
 body.-emu #sidebar select:hover,
-body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) select:hover, body.-emu .dialog input:hover[type="checkbox"],
+body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) select:hover,
+body.-emu .dialog input:hover[type="checkbox"],
 body.-emu #sidebar input:hover[type="checkbox"],
-body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) input:hover[type="checkbox"], body.-emu #client-settings.window-app.form .window-content #config-tabs .module-settings-wrapper div.form-group input:hover[type="checkbox"], body.-emu #module-management .package-title input:hover[type="checkbox"], body.-emu .dialog input:hover[type="color"],
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  input:hover[type="checkbox"],
+body.-emu
+  #client-settings.window-app.form
+  .window-content
+  #config-tabs
+  .module-settings-wrapper
+  div.form-group
+  input:hover[type="checkbox"],
+body.-emu #module-management .package-title input:hover[type="checkbox"],
+body.-emu .dialog input:hover[type="color"],
 body.-emu #sidebar input:hover[type="color"],
-body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) input:hover[type="color"], body.-emu .dialog textarea:hover,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  input:hover[type="color"],
+body.-emu .dialog textarea:hover,
 body.-emu #sidebar textarea:hover,
-body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) textarea:hover, body.-emu .dialog .tox .tox-tbtn:hover,
+body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) textarea:hover,
+body.-emu .dialog .tox .tox-tbtn:hover,
 body.-emu #sidebar .tox .tox-tbtn:hover,
-body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .tox .tox-tbtn:hover, body.-emu #sidebar #combat #combat-tracker .combatant.defeated.active,
-body.-emu .sidebar-popout #combat #combat-tracker .combatant.defeated.active, body.-emu #sidebar #playlists .directory-list .directory-item.playlist:not(.collapsed),
-body.-emu .sidebar-popout #playlists .directory-list .directory-item.playlist:not(.collapsed), body.-emu #npcgenerator-menu.window-app .npc-generator .npc-generator-header:hover, body.-emu .simple-dice-roller-popup li:hover {
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .tox
+  .tox-tbtn:hover,
+body.-emu #sidebar #combat #combat-tracker .combatant.defeated.active,
+body.-emu .sidebar-popout #combat #combat-tracker .combatant.defeated.active,
+body.-emu
+  #sidebar
+  #playlists
+  .directory-list
+  .directory-item.playlist:not(.collapsed),
+body.-emu
+  .sidebar-popout
+  #playlists
+  .directory-list
+  .directory-item.playlist:not(.collapsed),
+body.-emu
+  #npcgenerator-menu.window-app
+  .npc-generator
+  .npc-generator-header:hover,
+body.-emu .simple-dice-roller-popup li:hover {
   box-shadow: inset 0 0 0 2px rgba(var(--color-primary), 1);
-  text-shadow: none; }
+  text-shadow: none;
+}
 
-body.-emu .dialog .tabs a:focus, body.-emu .dialog .sheet-tabs a:focus, body.-emu #sidebar .tabs a:focus, body.-emu #sidebar .sheet-tabs a:focus, body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .tabs a:focus, body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .sheet-tabs a:focus, body.-emu #module-management .list-filters a:focus, body.-emu .dialog button:focus,
+body.-emu .dialog .tabs a:focus,
+body.-emu .dialog .sheet-tabs a:focus,
+body.-emu #sidebar .tabs a:focus,
+body.-emu #sidebar .sheet-tabs a:focus,
+body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .tabs a:focus,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .sheet-tabs
+  a:focus,
+body.-emu #module-management .list-filters a:focus,
+body.-emu .dialog button:focus,
 body.-emu #sidebar button:focus,
-body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) button:focus, body.-emu #menu #menu-items li:focus, body.-emu #sidebar #combat #combat-controls .combat-control:focus,
-body.-emu .sidebar-popout #combat #combat-controls .combat-control:focus, body.-emu .filepicker.window-app .display-modes .display-mode:focus, body.-emu .journal-sheet.sheet.window-app .window-content .editor-edit:focus, body.-emu #calendar-time-container .calendar--time-controls .advance-btn:focus,
-body.-emu #calendar-weather-container .calendar--time-controls .advance-btn:focus, body.-emu #sidebar #combat .add-temporary:focus,
-body.-emu .sidebar-popout #combat .add-temporary:focus, body.-emu .window-app[id*="ActiveEffects-"] .window-content > form li.filter-item:focus, body.-emu #specials-config .fxmaster .directory-header a:focus, body.-emu .moulinette-options li:focus, body.-emu #moulinette.forge .filepicker .display-modes a:focus, body.-emu #OneJournalShell.window-app .history-navigation a:focus, body.-emu ul.command-menu li:focus, body.-emu #token-action-hud button.tah-title-button:focus,
-body.-emu #token-action-hud .tah-action button:focus, body.-emu #sidebar .token-mold > label > span:focus,
-body.-emu .sidebar-popout .token-mold > label > span:focus, .-emu-layout body.-emu .sheet.active-effect-sheet .effects-header a:focus, body.-emu .sheet.active-effect-sheet .-emu-layout .effects-header a:focus, .-emu-layout body.-emu .sheet.roll-table-config .table-results .table-header a:focus, body.-emu .sheet.roll-table-config .table-results .-emu-layout .table-header a:focus, .-emu-layout body.-emu .dice-so-nice section.content .settings-list .sfxs-list .sfx-header a:focus, body.-emu .dice-so-nice section.content .settings-list .sfxs-list .-emu-layout .sfx-header a:focus, .-emu-layout body.-emu .window-app[id*="ActiveEffects-"] .window-content > form .dnd5e.sheet.item .effect-header a:focus, body.-emu .window-app[id*="ActiveEffects-"] .window-content > form .dnd5e.sheet.item .-emu-layout .effect-header a:focus, .-emu-layout body.-emu .sheet.active-effect-sheet .changes-list li a:focus, body.-emu .sheet.active-effect-sheet .changes-list .-emu-layout li a:focus, .-emu-layout body.-emu .sheet.roll-table-config .table-results .table-result a:focus, body.-emu .sheet.roll-table-config .table-results .-emu-layout .table-result a:focus, .-emu-layout body.-emu .dice-so-nice section.content .settings-list .sfxs-list .sfx a:focus, body.-emu .dice-so-nice section.content .settings-list .sfxs-list .-emu-layout .sfx a:focus, body.-emu .dialog .directory .directory-item.folder .folder-header .create-folder:focus,
-body.-emu .dialog .directory .directory-item.folder .folder-header .create-entity:focus,
-body.-emu #sidebar .directory .directory-item.folder .folder-header .create-folder:focus,
-body.-emu #sidebar .directory .directory-item.folder .folder-header .create-entity:focus,
-body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .directory .directory-item.folder .folder-header .create-folder:focus,
-body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .directory .directory-item.folder .folder-header .create-entity:focus, body.-emu #navigation #nav-toggle:focus, .-emu-layout body.-emu .window-app .window-header > a:focus, .-emu-layout body.-emu .window-app .window-header a.header-button:focus, .-emu-layout body.-emu #sidebar #chat #chat-log .message .button.message-delete:focus, .-emu-layout body.-emu .sidebar-popout #chat #chat-log .message .button.message-delete:focus, .-emu-layout body.-emu #sidebar #chat #chat-controls .chat-control-icon .fa-dice-d20:focus, .-emu-layout body.-emu .sidebar-popout #chat #chat-controls .chat-control-icon .fa-dice-d20:focus, .-emu-layout body.-emu #sidebar #chat #chat-controls .control-buttons .button:focus, .-emu-layout body.-emu .sidebar-popout #chat #chat-controls .control-buttons .button:focus, body.-emu #sidebar #combat #combat-round .encounters a:focus,
-body.-emu .sidebar-popout #combat #combat-round .encounters a:focus, body.-emu #sidebar #combat #combat-tracker .combatant .combatant-control:focus,
-body.-emu .sidebar-popout #combat #combat-tracker .combatant .combatant-control:focus, body.-emu #sidebar #playlists .directory-list .playlist-header .sound-controls .sound-control:focus,
-body.-emu #sidebar #playlists .directory-list .sound .sound-controls .sound-control:focus,
-body.-emu .sidebar-popout #playlists .directory-list .playlist-header .sound-controls .sound-control:focus,
-body.-emu .sidebar-popout #playlists .directory-list .sound .sound-controls .sound-control:focus, body.-emu #sidebar #playlists #currently-playing .sound .sound-control:focus,
-body.-emu .sidebar-popout #playlists #currently-playing .sound .sound-control:focus, body.-emu .window-app[id*="chat-popout-"] .chat-message .chat-card .die-result-overlay-br button:focus,
-body.-emu #sidebar #chat #chat-log .chat-message .chat-card .die-result-overlay-br button:focus, body.-emu #dfcp-rt-buttons button:focus, body.-emu .active-effect-sheet[id*="ActiveEffectsConfig-"] .effect-special-duration .effect-control:focus, body.-emu #specials-config .fxmaster .special-effects .controls a:focus, body.-emu div.permission-viewer a:focus, .-emu-layout body.-emu #sidebar #chat #chat-log .message .button.polyglot-message-language:focus, .-emu-layout body.-emu .sidebar-popout #chat #chat-log .message .button.polyglot-message-language:focus, body.-emu #smalltime-app #displayContainer .arrow:focus, body.-emu #token-action-hud #tah-reposition:focus,
-body.-emu #token-action-hud #tah-categories:focus, body.-emu #sidebar .token-mold > a:focus,
-body.-emu .sidebar-popout .token-mold > a:focus, body.-emu #sidebar .sidebar-tab .directory-header .header-control:focus,
-body.-emu .sidebar-popout .sidebar-tab .directory-header .header-control:focus, body.-emu .dialog input:focus[type="text"],
+body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) button:focus,
+body.-emu #menu #menu-items li:focus,
+body.-emu #sidebar #combat #combat-controls .combat-control:focus,
+body.-emu .sidebar-popout #combat #combat-controls .combat-control:focus,
+body.-emu .filepicker.window-app .display-modes .display-mode:focus,
+body.-emu .journal-sheet.sheet.window-app .window-content .editor-edit:focus,
+body.-emu #calendar-time-container .calendar--time-controls .advance-btn:focus,
+body.-emu
+  #calendar-weather-container
+  .calendar--time-controls
+  .advance-btn:focus,
+body.-emu #sidebar #combat .add-temporary:focus,
+body.-emu .sidebar-popout #combat .add-temporary:focus,
+body.-emu
+  .window-app[id*="ActiveEffects-"]
+  .window-content
+  > form
+  li.filter-item:focus,
+body.-emu #specials-config .fxmaster .directory-header a:focus,
+body.-emu .moulinette-options li:focus,
+body.-emu #moulinette.forge .filepicker .display-modes a:focus,
+body.-emu #OneJournalShell.window-app .history-navigation a:focus,
+body.-emu ul.command-menu li:focus,
+body.-emu #token-action-hud button.tah-title-button:focus,
+body.-emu #token-action-hud .tah-action button:focus,
+body.-emu #sidebar .token-mold > label > span:focus,
+body.-emu .sidebar-popout .token-mold > label > span:focus,
+.-emu-layout body.-emu .sheet.active-effect-sheet .effects-header a:focus,
+body.-emu .sheet.active-effect-sheet .-emu-layout .effects-header a:focus,
+.-emu-layout
+  body.-emu
+  .sheet.roll-table-config
+  .table-results
+  .table-header
+  a:focus,
+body.-emu
+  .sheet.roll-table-config
+  .table-results
+  .-emu-layout
+  .table-header
+  a:focus,
+.-emu-layout
+  body.-emu
+  .dice-so-nice
+  section.content
+  .settings-list
+  .sfxs-list
+  .sfx-header
+  a:focus,
+body.-emu
+  .dice-so-nice
+  section.content
+  .settings-list
+  .sfxs-list
+  .-emu-layout
+  .sfx-header
+  a:focus,
+.-emu-layout
+  body.-emu
+  .window-app[id*="ActiveEffects-"]
+  .window-content
+  > form
+  .dnd5e.sheet.item
+  .effect-header
+  a:focus,
+body.-emu
+  .window-app[id*="ActiveEffects-"]
+  .window-content
+  > form
+  .dnd5e.sheet.item
+  .-emu-layout
+  .effect-header
+  a:focus,
+.-emu-layout body.-emu .sheet.active-effect-sheet .changes-list li a:focus,
+body.-emu .sheet.active-effect-sheet .changes-list .-emu-layout li a:focus,
+.-emu-layout
+  body.-emu
+  .sheet.roll-table-config
+  .table-results
+  .table-result
+  a:focus,
+body.-emu
+  .sheet.roll-table-config
+  .table-results
+  .-emu-layout
+  .table-result
+  a:focus,
+.-emu-layout
+  body.-emu
+  .dice-so-nice
+  section.content
+  .settings-list
+  .sfxs-list
+  .sfx
+  a:focus,
+body.-emu
+  .dice-so-nice
+  section.content
+  .settings-list
+  .sfxs-list
+  .-emu-layout
+  .sfx
+  a:focus,
+body.-emu
+  .dialog
+  .directory
+  .directory-item.folder
+  .folder-header
+  .create-folder:focus,
+body.-emu
+  .dialog
+  .directory
+  .directory-item.folder
+  .folder-header
+  .create-entity:focus,
+body.-emu
+  #sidebar
+  .directory
+  .directory-item.folder
+  .folder-header
+  .create-folder:focus,
+body.-emu
+  #sidebar
+  .directory
+  .directory-item.folder
+  .folder-header
+  .create-entity:focus,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .directory
+  .directory-item.folder
+  .folder-header
+  .create-folder:focus,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .directory
+  .directory-item.folder
+  .folder-header
+  .create-entity:focus,
+body.-emu #navigation #nav-toggle:focus,
+.-emu-layout body.-emu .window-app .window-header > a:focus,
+.-emu-layout body.-emu .window-app .window-header a.header-button:focus,
+.-emu-layout
+  body.-emu
+  #sidebar
+  #chat
+  #chat-log
+  .message
+  .button.message-delete:focus,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #chat
+  #chat-log
+  .message
+  .button.message-delete:focus,
+.-emu-layout
+  body.-emu
+  #sidebar
+  #chat
+  #chat-controls
+  .chat-control-icon
+  .fa-dice-d20:focus,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #chat
+  #chat-controls
+  .chat-control-icon
+  .fa-dice-d20:focus,
+.-emu-layout
+  body.-emu
+  #sidebar
+  #chat
+  #chat-controls
+  .control-buttons
+  .button:focus,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #chat
+  #chat-controls
+  .control-buttons
+  .button:focus,
+body.-emu #sidebar #combat #combat-round .encounters a:focus,
+body.-emu .sidebar-popout #combat #combat-round .encounters a:focus,
+body.-emu #sidebar #combat #combat-tracker .combatant .combatant-control:focus,
+body.-emu
+  .sidebar-popout
+  #combat
+  #combat-tracker
+  .combatant
+  .combatant-control:focus,
+body.-emu
+  #sidebar
+  #playlists
+  .directory-list
+  .playlist-header
+  .sound-controls
+  .sound-control:focus,
+body.-emu
+  #sidebar
+  #playlists
+  .directory-list
+  .sound
+  .sound-controls
+  .sound-control:focus,
+body.-emu
+  .sidebar-popout
+  #playlists
+  .directory-list
+  .playlist-header
+  .sound-controls
+  .sound-control:focus,
+body.-emu
+  .sidebar-popout
+  #playlists
+  .directory-list
+  .sound
+  .sound-controls
+  .sound-control:focus,
+body.-emu #sidebar #playlists #currently-playing .sound .sound-control:focus,
+body.-emu
+  .sidebar-popout
+  #playlists
+  #currently-playing
+  .sound
+  .sound-control:focus,
+body.-emu
+  .window-app[id*="chat-popout-"]
+  .chat-message
+  .chat-card
+  .die-result-overlay-br
+  button:focus,
+body.-emu
+  #sidebar
+  #chat
+  #chat-log
+  .chat-message
+  .chat-card
+  .die-result-overlay-br
+  button:focus,
+body.-emu #dfcp-rt-buttons button:focus,
+body.-emu
+  .active-effect-sheet[id*="ActiveEffectsConfig-"]
+  .effect-special-duration
+  .effect-control:focus,
+body.-emu #specials-config .fxmaster .special-effects .controls a:focus,
+body.-emu div.permission-viewer a:focus,
+.-emu-layout
+  body.-emu
+  #sidebar
+  #chat
+  #chat-log
+  .message
+  .button.polyglot-message-language:focus,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #chat
+  #chat-log
+  .message
+  .button.polyglot-message-language:focus,
+body.-emu #smalltime-app #displayContainer .arrow:focus,
+body.-emu #token-action-hud #tah-reposition:focus,
+body.-emu #token-action-hud #tah-categories:focus,
+body.-emu #sidebar .token-mold > a:focus,
+body.-emu .sidebar-popout .token-mold > a:focus,
+body.-emu #sidebar .sidebar-tab .directory-header .header-control:focus,
+body.-emu .sidebar-popout .sidebar-tab .directory-header .header-control:focus,
+body.-emu .dialog input:focus[type="text"],
 body.-emu .dialog input:focus[type="number"],
 body.-emu .dialog input:focus[type="date"],
 body.-emu .dialog input:focus[type="time"],
@@ -696,249 +4583,1898 @@ body.-emu #sidebar input:focus[type="date"],
 body.-emu #sidebar input:focus[type="time"],
 body.-emu #sidebar input:focus[type="password"],
 body.-emu #sidebar input:focus[type="datetime-local"],
-body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) input:focus[type="text"],
-body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) input:focus[type="number"],
-body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) input:focus[type="date"],
-body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) input:focus[type="time"],
-body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) input:focus[type="password"],
-body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) input:focus[type="datetime-local"], body.-emu #hud input:focus[type="text"], body.-emu #sidebar #chat section.dice-tray input.dice-tray__input:focus,
-body.-emu .sidebar-popout #chat section.dice-tray input.dice-tray__input:focus, body.-emu #client-settings.window-app.form .window-content #config-tabs div.tab[data-tab="modules"] #searchField #searchInput:focus, body.-emu .dialog select:focus,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  input:focus[type="text"],
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  input:focus[type="number"],
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  input:focus[type="date"],
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  input:focus[type="time"],
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  input:focus[type="password"],
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  input:focus[type="datetime-local"],
+body.-emu #hud input:focus[type="text"],
+body.-emu #sidebar #chat section.dice-tray input.dice-tray__input:focus,
+body.-emu .sidebar-popout #chat section.dice-tray input.dice-tray__input:focus,
+body.-emu
+  #client-settings.window-app.form
+  .window-content
+  #config-tabs
+  div.tab[data-tab="modules"]
+  #searchField
+  #searchInput:focus,
+body.-emu .dialog select:focus,
 body.-emu #sidebar select:focus,
-body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) select:focus, body.-emu .dialog input:focus[type="checkbox"],
+body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) select:focus,
+body.-emu .dialog input:focus[type="checkbox"],
 body.-emu #sidebar input:focus[type="checkbox"],
-body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) input:focus[type="checkbox"], body.-emu #client-settings.window-app.form .window-content #config-tabs .module-settings-wrapper div.form-group input:focus[type="checkbox"], body.-emu #module-management .package-title input:focus[type="checkbox"], body.-emu .dialog input:focus[type="color"],
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  input:focus[type="checkbox"],
+body.-emu
+  #client-settings.window-app.form
+  .window-content
+  #config-tabs
+  .module-settings-wrapper
+  div.form-group
+  input:focus[type="checkbox"],
+body.-emu #module-management .package-title input:focus[type="checkbox"],
+body.-emu .dialog input:focus[type="color"],
 body.-emu #sidebar input:focus[type="color"],
-body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) input:focus[type="color"], body.-emu .dialog textarea:focus,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  input:focus[type="color"],
+body.-emu .dialog textarea:focus,
 body.-emu #sidebar textarea:focus,
-body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) textarea:focus, body.-emu .dialog .tabs a.active:focus, body.-emu .dialog .sheet-tabs a.active:focus, body.-emu #sidebar .tabs a.active:focus, body.-emu #sidebar .sheet-tabs a.active:focus, body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .tabs a.active:focus, body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .sheet-tabs a.active:focus, body.-emu #module-management .list-filters a.active:focus, body.-emu .dialog button.active:focus,
+body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) textarea:focus,
+body.-emu .dialog .tabs a.active:focus,
+body.-emu .dialog .sheet-tabs a.active:focus,
+body.-emu #sidebar .tabs a.active:focus,
+body.-emu #sidebar .sheet-tabs a.active:focus,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .tabs
+  a.active:focus,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .sheet-tabs
+  a.active:focus,
+body.-emu #module-management .list-filters a.active:focus,
+body.-emu .dialog button.active:focus,
 body.-emu #sidebar button.active:focus,
-body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) button.active:focus, body.-emu #menu #menu-items li.active:focus, body.-emu #sidebar #combat #combat-controls .active.combat-control:focus,
-body.-emu .sidebar-popout #combat #combat-controls .active.combat-control:focus, body.-emu .filepicker.window-app .display-modes .active.display-mode:focus, body.-emu .journal-sheet.sheet.window-app .window-content .active.editor-edit:focus, body.-emu #calendar-time-container .calendar--time-controls .active.advance-btn:focus,
-body.-emu #calendar-weather-container .calendar--time-controls .active.advance-btn:focus, body.-emu #sidebar #combat .active.add-temporary:focus,
-body.-emu .sidebar-popout #combat .active.add-temporary:focus, body.-emu .window-app[id*="ActiveEffects-"] .window-content > form li.active.filter-item:focus, body.-emu #specials-config .fxmaster .directory-header a.active:focus, body.-emu .moulinette-options li.active:focus, body.-emu #moulinette.forge .filepicker .display-modes a.active:focus, body.-emu #OneJournalShell.window-app .history-navigation a.active:focus, body.-emu ul.command-menu li.active:focus, body.-emu #token-action-hud button.active.tah-title-button:focus,
-body.-emu #token-action-hud .tah-action button.active:focus, body.-emu #sidebar .token-mold > label > span.active:focus,
-body.-emu .sidebar-popout .token-mold > label > span.active:focus, .-emu-layout body.-emu .sheet.active-effect-sheet .effects-header a.active:focus, body.-emu .sheet.active-effect-sheet .-emu-layout .effects-header a.active:focus, .-emu-layout body.-emu .sheet.roll-table-config .table-results .table-header a.active:focus, body.-emu .sheet.roll-table-config .table-results .-emu-layout .table-header a.active:focus, .-emu-layout body.-emu .dice-so-nice section.content .settings-list .sfxs-list .sfx-header a.active:focus, body.-emu .dice-so-nice section.content .settings-list .sfxs-list .-emu-layout .sfx-header a.active:focus, .-emu-layout body.-emu .window-app[id*="ActiveEffects-"] .window-content > form .dnd5e.sheet.item .effect-header a.active:focus, body.-emu .window-app[id*="ActiveEffects-"] .window-content > form .dnd5e.sheet.item .-emu-layout .effect-header a.active:focus, .-emu-layout body.-emu .sheet.active-effect-sheet .changes-list li a.active:focus, body.-emu .sheet.active-effect-sheet .changes-list .-emu-layout li a.active:focus, .-emu-layout body.-emu .sheet.roll-table-config .table-results .table-result a.active:focus, body.-emu .sheet.roll-table-config .table-results .-emu-layout .table-result a.active:focus, .-emu-layout body.-emu .dice-so-nice section.content .settings-list .sfxs-list .sfx a.active:focus, body.-emu .dice-so-nice section.content .settings-list .sfxs-list .-emu-layout .sfx a.active:focus, body.-emu .dialog .directory .directory-item.folder .folder-header .active.create-folder:focus,
-body.-emu .dialog .directory .directory-item.folder .folder-header .active.create-entity:focus,
-body.-emu #sidebar .directory .directory-item.folder .folder-header .active.create-folder:focus,
-body.-emu #sidebar .directory .directory-item.folder .folder-header .active.create-entity:focus,
-body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .directory .directory-item.folder .folder-header .active.create-folder:focus,
-body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .directory .directory-item.folder .folder-header .active.create-entity:focus, body.-emu #navigation .active#nav-toggle:focus, .-emu-layout body.-emu .window-app .window-header > a.active:focus, .-emu-layout body.-emu .window-app .window-header a.active.header-button:focus, .-emu-layout body.-emu #sidebar #chat #chat-log .message .active.button.message-delete:focus, .-emu-layout body.-emu .sidebar-popout #chat #chat-log .message .active.button.message-delete:focus, .-emu-layout body.-emu #sidebar #chat #chat-controls .chat-control-icon .active.fa-dice-d20:focus, .-emu-layout body.-emu .sidebar-popout #chat #chat-controls .chat-control-icon .active.fa-dice-d20:focus, .-emu-layout body.-emu #sidebar #chat #chat-controls .control-buttons .active.button:focus, .-emu-layout body.-emu .sidebar-popout #chat #chat-controls .control-buttons .active.button:focus, body.-emu #sidebar #combat #combat-round .encounters a.active:focus,
-body.-emu .sidebar-popout #combat #combat-round .encounters a.active:focus, body.-emu #sidebar #combat #combat-tracker .combatant .active.combatant-control:focus,
-body.-emu .sidebar-popout #combat #combat-tracker .combatant .active.combatant-control:focus, body.-emu #sidebar #playlists .directory-list .playlist-header .sound-controls .active.sound-control:focus,
-body.-emu #sidebar #playlists .directory-list .sound .sound-controls .active.sound-control:focus,
-body.-emu .sidebar-popout #playlists .directory-list .playlist-header .sound-controls .active.sound-control:focus,
-body.-emu .sidebar-popout #playlists .directory-list .sound .sound-controls .active.sound-control:focus, body.-emu #sidebar #playlists #currently-playing .sound .active.sound-control:focus,
-body.-emu .sidebar-popout #playlists #currently-playing .sound .active.sound-control:focus, body.-emu .window-app[id*="chat-popout-"] .chat-message .chat-card .die-result-overlay-br button.active:focus,
-body.-emu #sidebar #chat #chat-log .chat-message .chat-card .die-result-overlay-br button.active:focus, body.-emu #dfcp-rt-buttons button.active:focus, body.-emu .active-effect-sheet[id*="ActiveEffectsConfig-"] .effect-special-duration .active.effect-control:focus, body.-emu #specials-config .fxmaster .special-effects .controls a.active:focus, body.-emu div.permission-viewer a.active:focus, .-emu-layout body.-emu #sidebar #chat #chat-log .message .active.button.polyglot-message-language:focus, .-emu-layout body.-emu .sidebar-popout #chat #chat-log .message .active.button.polyglot-message-language:focus, body.-emu #smalltime-app #displayContainer .active.arrow:focus, body.-emu #token-action-hud .active#tah-reposition:focus,
-body.-emu #token-action-hud .active#tah-categories:focus, body.-emu #sidebar .token-mold > a.active:focus,
-body.-emu .sidebar-popout .token-mold > a.active:focus, body.-emu #sidebar .sidebar-tab .directory-header .active.header-control:focus,
-body.-emu .sidebar-popout .sidebar-tab .directory-header .active.header-control:focus, body.-emu .dialog .tox .tox-tbtn.tox-tbtn--enabled:focus,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  button.active:focus,
+body.-emu #menu #menu-items li.active:focus,
+body.-emu #sidebar #combat #combat-controls .active.combat-control:focus,
+body.-emu .sidebar-popout #combat #combat-controls .active.combat-control:focus,
+body.-emu .filepicker.window-app .display-modes .active.display-mode:focus,
+body.-emu
+  .journal-sheet.sheet.window-app
+  .window-content
+  .active.editor-edit:focus,
+body.-emu
+  #calendar-time-container
+  .calendar--time-controls
+  .active.advance-btn:focus,
+body.-emu
+  #calendar-weather-container
+  .calendar--time-controls
+  .active.advance-btn:focus,
+body.-emu #sidebar #combat .active.add-temporary:focus,
+body.-emu .sidebar-popout #combat .active.add-temporary:focus,
+body.-emu
+  .window-app[id*="ActiveEffects-"]
+  .window-content
+  > form
+  li.active.filter-item:focus,
+body.-emu #specials-config .fxmaster .directory-header a.active:focus,
+body.-emu .moulinette-options li.active:focus,
+body.-emu #moulinette.forge .filepicker .display-modes a.active:focus,
+body.-emu #OneJournalShell.window-app .history-navigation a.active:focus,
+body.-emu ul.command-menu li.active:focus,
+body.-emu #token-action-hud button.active.tah-title-button:focus,
+body.-emu #token-action-hud .tah-action button.active:focus,
+body.-emu #sidebar .token-mold > label > span.active:focus,
+body.-emu .sidebar-popout .token-mold > label > span.active:focus,
+.-emu-layout
+  body.-emu
+  .sheet.active-effect-sheet
+  .effects-header
+  a.active:focus,
+body.-emu
+  .sheet.active-effect-sheet
+  .-emu-layout
+  .effects-header
+  a.active:focus,
+.-emu-layout
+  body.-emu
+  .sheet.roll-table-config
+  .table-results
+  .table-header
+  a.active:focus,
+body.-emu
+  .sheet.roll-table-config
+  .table-results
+  .-emu-layout
+  .table-header
+  a.active:focus,
+.-emu-layout
+  body.-emu
+  .dice-so-nice
+  section.content
+  .settings-list
+  .sfxs-list
+  .sfx-header
+  a.active:focus,
+body.-emu
+  .dice-so-nice
+  section.content
+  .settings-list
+  .sfxs-list
+  .-emu-layout
+  .sfx-header
+  a.active:focus,
+.-emu-layout
+  body.-emu
+  .window-app[id*="ActiveEffects-"]
+  .window-content
+  > form
+  .dnd5e.sheet.item
+  .effect-header
+  a.active:focus,
+body.-emu
+  .window-app[id*="ActiveEffects-"]
+  .window-content
+  > form
+  .dnd5e.sheet.item
+  .-emu-layout
+  .effect-header
+  a.active:focus,
+.-emu-layout
+  body.-emu
+  .sheet.active-effect-sheet
+  .changes-list
+  li
+  a.active:focus,
+body.-emu
+  .sheet.active-effect-sheet
+  .changes-list
+  .-emu-layout
+  li
+  a.active:focus,
+.-emu-layout
+  body.-emu
+  .sheet.roll-table-config
+  .table-results
+  .table-result
+  a.active:focus,
+body.-emu
+  .sheet.roll-table-config
+  .table-results
+  .-emu-layout
+  .table-result
+  a.active:focus,
+.-emu-layout
+  body.-emu
+  .dice-so-nice
+  section.content
+  .settings-list
+  .sfxs-list
+  .sfx
+  a.active:focus,
+body.-emu
+  .dice-so-nice
+  section.content
+  .settings-list
+  .sfxs-list
+  .-emu-layout
+  .sfx
+  a.active:focus,
+body.-emu
+  .dialog
+  .directory
+  .directory-item.folder
+  .folder-header
+  .active.create-folder:focus,
+body.-emu
+  .dialog
+  .directory
+  .directory-item.folder
+  .folder-header
+  .active.create-entity:focus,
+body.-emu
+  #sidebar
+  .directory
+  .directory-item.folder
+  .folder-header
+  .active.create-folder:focus,
+body.-emu
+  #sidebar
+  .directory
+  .directory-item.folder
+  .folder-header
+  .active.create-entity:focus,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .directory
+  .directory-item.folder
+  .folder-header
+  .active.create-folder:focus,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .directory
+  .directory-item.folder
+  .folder-header
+  .active.create-entity:focus,
+body.-emu #navigation .active#nav-toggle:focus,
+.-emu-layout body.-emu .window-app .window-header > a.active:focus,
+.-emu-layout body.-emu .window-app .window-header a.active.header-button:focus,
+.-emu-layout
+  body.-emu
+  #sidebar
+  #chat
+  #chat-log
+  .message
+  .active.button.message-delete:focus,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #chat
+  #chat-log
+  .message
+  .active.button.message-delete:focus,
+.-emu-layout
+  body.-emu
+  #sidebar
+  #chat
+  #chat-controls
+  .chat-control-icon
+  .active.fa-dice-d20:focus,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #chat
+  #chat-controls
+  .chat-control-icon
+  .active.fa-dice-d20:focus,
+.-emu-layout
+  body.-emu
+  #sidebar
+  #chat
+  #chat-controls
+  .control-buttons
+  .active.button:focus,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #chat
+  #chat-controls
+  .control-buttons
+  .active.button:focus,
+body.-emu #sidebar #combat #combat-round .encounters a.active:focus,
+body.-emu .sidebar-popout #combat #combat-round .encounters a.active:focus,
+body.-emu
+  #sidebar
+  #combat
+  #combat-tracker
+  .combatant
+  .active.combatant-control:focus,
+body.-emu
+  .sidebar-popout
+  #combat
+  #combat-tracker
+  .combatant
+  .active.combatant-control:focus,
+body.-emu
+  #sidebar
+  #playlists
+  .directory-list
+  .playlist-header
+  .sound-controls
+  .active.sound-control:focus,
+body.-emu
+  #sidebar
+  #playlists
+  .directory-list
+  .sound
+  .sound-controls
+  .active.sound-control:focus,
+body.-emu
+  .sidebar-popout
+  #playlists
+  .directory-list
+  .playlist-header
+  .sound-controls
+  .active.sound-control:focus,
+body.-emu
+  .sidebar-popout
+  #playlists
+  .directory-list
+  .sound
+  .sound-controls
+  .active.sound-control:focus,
+body.-emu
+  #sidebar
+  #playlists
+  #currently-playing
+  .sound
+  .active.sound-control:focus,
+body.-emu
+  .sidebar-popout
+  #playlists
+  #currently-playing
+  .sound
+  .active.sound-control:focus,
+body.-emu
+  .window-app[id*="chat-popout-"]
+  .chat-message
+  .chat-card
+  .die-result-overlay-br
+  button.active:focus,
+body.-emu
+  #sidebar
+  #chat
+  #chat-log
+  .chat-message
+  .chat-card
+  .die-result-overlay-br
+  button.active:focus,
+body.-emu #dfcp-rt-buttons button.active:focus,
+body.-emu
+  .active-effect-sheet[id*="ActiveEffectsConfig-"]
+  .effect-special-duration
+  .active.effect-control:focus,
+body.-emu #specials-config .fxmaster .special-effects .controls a.active:focus,
+body.-emu div.permission-viewer a.active:focus,
+.-emu-layout
+  body.-emu
+  #sidebar
+  #chat
+  #chat-log
+  .message
+  .active.button.polyglot-message-language:focus,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #chat
+  #chat-log
+  .message
+  .active.button.polyglot-message-language:focus,
+body.-emu #smalltime-app #displayContainer .active.arrow:focus,
+body.-emu #token-action-hud .active#tah-reposition:focus,
+body.-emu #token-action-hud .active#tah-categories:focus,
+body.-emu #sidebar .token-mold > a.active:focus,
+body.-emu .sidebar-popout .token-mold > a.active:focus,
+body.-emu #sidebar .sidebar-tab .directory-header .active.header-control:focus,
+body.-emu
+  .sidebar-popout
+  .sidebar-tab
+  .directory-header
+  .active.header-control:focus,
+body.-emu .dialog .tox .tox-tbtn.tox-tbtn--enabled:focus,
 body.-emu #sidebar .tox .tox-tbtn.tox-tbtn--enabled:focus,
-body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .tox .tox-tbtn.tox-tbtn--enabled:focus, body.-emu #hotbar .macro.active:focus, body.-emu #hud .control-icon.active:focus, body.-emu #controls .scene-control.active:focus,
-body.-emu #controls .control-tool.active:focus, body.-emu #controls .control-tool.toggle.active:focus, body.-emu #navigation #scene-list .scene.active:focus, body.-emu #navigation #scene-list .scene.view:focus,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .tox
+  .tox-tbtn.tox-tbtn--enabled:focus,
+body.-emu #hotbar .macro.active:focus,
+body.-emu #hud .control-icon.active:focus,
+body.-emu #controls .scene-control.active:focus,
+body.-emu #controls .control-tool.active:focus,
+body.-emu #controls .control-tool.toggle.active:focus,
+body.-emu #navigation #scene-list .scene.active:focus,
+body.-emu #navigation #scene-list .scene.view:focus,
 body.-emu #navigation .scene-list .scene.active:focus,
-body.-emu #navigation .scene-list .scene.view:focus, body.-emu #navigation #scene-list .scene.active:focus:not(.gm), body.-emu #navigation #scene-list .scene.view:focus:not(.gm),
+body.-emu #navigation .scene-list .scene.view:focus,
+body.-emu #navigation #scene-list .scene.active:focus:not(.gm),
+body.-emu #navigation #scene-list .scene.view:focus:not(.gm),
 body.-emu #navigation .scene-list .scene.active:focus:not(.gm),
-body.-emu #navigation .scene-list .scene.view:focus:not(.gm), body.-emu #sidebar #sidebar-tabs > .item.active:focus,
+body.-emu #navigation .scene-list .scene.view:focus:not(.gm),
+body.-emu #sidebar #sidebar-tabs > .item.active:focus,
 body.-emu #sidebar #sidebar-tabs > .collapse.active:focus,
 body.-emu .sidebar-popout #sidebar-tabs > .item.active:focus,
-body.-emu .sidebar-popout #sidebar-tabs > .collapse.active:focus, .-emu-layout.-emu-subtle-layout body.-emu #sidebar:hover #emu-sidebar-lock:focus, .-emu-layout.-emu-subtle-layout body.-emu #sidebar.is-locked #emu-sidebar-lock:focus, body.-emu #sidebar #combat #combat-tracker .combatant.active:focus,
-body.-emu .sidebar-popout #combat #combat-tracker .combatant.active:focus, body.-emu .filepicker.window-app .filepicker-body.private .current-dir button.privacy:focus, body.-emu .user-config.sheet.window-app #characters .directory-item.context:focus,
-body.-emu .user-config.sheet.window-app .directory-item.context:focus, body.-emu #df-curvy-walls-tools .control-tool.active:focus, body.-emu #lmrtfy.lmrtfy-parchment .lmrtfy-actor-avatars input:checked + label:focus, body.-emu #navigation .monks-scene-navigation .scene-list > .nav-item.active > .scene-name:focus, body.-emu .dialog .directory .directory-item:focus,
+body.-emu .sidebar-popout #sidebar-tabs > .collapse.active:focus,
+.-emu-layout.-emu-subtle-layout
+  body.-emu
+  #sidebar:hover
+  #emu-sidebar-lock:focus,
+.-emu-layout.-emu-subtle-layout
+  body.-emu
+  #sidebar.is-locked
+  #emu-sidebar-lock:focus,
+body.-emu #sidebar #combat #combat-tracker .combatant.active:focus,
+body.-emu .sidebar-popout #combat #combat-tracker .combatant.active:focus,
+body.-emu
+  .filepicker.window-app
+  .filepicker-body.private
+  .current-dir
+  button.privacy:focus,
+body.-emu
+  .user-config.sheet.window-app
+  #characters
+  .directory-item.context:focus,
+body.-emu .user-config.sheet.window-app .directory-item.context:focus,
+body.-emu #df-curvy-walls-tools .control-tool.active:focus,
+body.-emu
+  #lmrtfy.lmrtfy-parchment
+  .lmrtfy-actor-avatars
+  input:checked
+  + label:focus,
+body.-emu
+  #navigation
+  .monks-scene-navigation
+  .scene-list
+  > .nav-item.active
+  > .scene-name:focus,
+body.-emu .dialog .directory .directory-item:focus,
 body.-emu #sidebar .directory .directory-item:focus,
-body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .directory .directory-item:focus, body.-emu .dialog .directory .directory-item.folder .folder-header:focus,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .directory
+  .directory-item:focus,
+body.-emu .dialog .directory .directory-item.folder .folder-header:focus,
 body.-emu #sidebar .directory .directory-item.folder .folder-header:focus,
-body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .directory .directory-item.folder .folder-header:focus, body.-emu .dialog a[href]:focus,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .directory
+  .directory-item.folder
+  .folder-header:focus,
+body.-emu .dialog a[href]:focus,
 body.-emu #sidebar a[href]:focus,
-body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) a[href]:focus, body.-emu #context-menu ol.context-items .context-item:focus, body.-emu #hotbar .bar-controls .page-control:focus,
+body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) a[href]:focus,
+body.-emu #context-menu ol.context-items .context-item:focus,
+body.-emu #hotbar .bar-controls .page-control:focus,
 body.-emu #hotbar .bar-controls #macro-directory:focus,
-body.-emu #hotbar .bar-controls #bar-toggle:focus, body.-emu #hotbar .macro:focus, body.-emu #hud .control-icon:focus, body.-emu #controls .scene-control:focus,
-body.-emu #controls .control-tool:focus, body.-emu #controls .control-tool.toggle:focus, body.-emu #controls .control-tool.toggle.active, body.-emu #navigation #scene-list .scene.view,
-body.-emu #navigation .scene-list .scene.view, body.-emu #navigation #scene-list .scene:focus,
-body.-emu #navigation .scene-list .scene:focus, body.-emu .window-app .window-resizable-handle:focus, body.-emu .sheet .sheet-header > img:focus, body.-emu .filepicker.window-app .filepicker-body.private, body.-emu #df-curvy-walls-tools .control-tool:focus, body.-emu #df-curvy-walls-tools .control-tool.active, body.-emu .dice-so-nice section.content .settings-list .select2:focus .select2-selection, body.-emu .dice-so-nice section.content .settings-list .select2.select2-container--focus .select2-selection, body.-emu #lmrtfy.lmrtfy-parchment .lmrtfy-actor-avatars input:checked + label, body.-emu #OneJournalShell.window-app .sidebar-toggle:focus, body.-emu #search-anywhere-modal #search-anywhere-autocomplete, body.-emu .window-app .window-draggable-handle:focus, body.-emu #tokenAttacher .control-tool:focus {
-  box-shadow: inset 0 0 0 2px rgba(var(--color-primary), 1), inset 0 0 0 3px rgba(var(--color-white), 1), 0 1px 2px 0 rgba(var(--color-black), 0.3);
+body.-emu #hotbar .bar-controls #bar-toggle:focus,
+body.-emu #hotbar .macro:focus,
+body.-emu #hud .control-icon:focus,
+body.-emu #controls .scene-control:focus,
+body.-emu #controls .control-tool:focus,
+body.-emu #controls .control-tool.toggle:focus,
+body.-emu #controls .control-tool.toggle.active,
+body.-emu #navigation #scene-list .scene.view,
+body.-emu #navigation .scene-list .scene.view,
+body.-emu #navigation #scene-list .scene:focus,
+body.-emu #navigation .scene-list .scene:focus,
+body.-emu .window-app .window-resizable-handle:focus,
+body.-emu .sheet .sheet-header > img:focus,
+body.-emu .filepicker.window-app .filepicker-body.private,
+body.-emu #df-curvy-walls-tools .control-tool:focus,
+body.-emu #df-curvy-walls-tools .control-tool.active,
+body.-emu
+  .dice-so-nice
+  section.content
+  .settings-list
+  .select2:focus
+  .select2-selection,
+body.-emu
+  .dice-so-nice
+  section.content
+  .settings-list
+  .select2.select2-container--focus
+  .select2-selection,
+body.-emu #lmrtfy.lmrtfy-parchment .lmrtfy-actor-avatars input:checked + label,
+body.-emu #OneJournalShell.window-app .sidebar-toggle:focus,
+body.-emu #search-anywhere-modal #search-anywhere-autocomplete,
+body.-emu .window-app .window-draggable-handle:focus,
+body.-emu #tokenAttacher .control-tool:focus {
+  box-shadow: inset 0 0 0 2px rgba(var(--color-primary), 1),
+    inset 0 0 0 3px rgba(var(--color-white), 1),
+    0 1px 2px 0 rgba(var(--color-black), 0.3);
   text-shadow: none;
-  outline: none; }
+  outline: none;
+}
 
-body.-emu .dialog .tabs a.active, body.-emu .dialog .sheet-tabs a.active, body.-emu #sidebar .tabs a.active, body.-emu #sidebar .sheet-tabs a.active, body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .tabs a.active, body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .sheet-tabs a.active, body.-emu #module-management .list-filters a.active, body.-emu .dialog button.active,
+body.-emu .dialog .tabs a.active,
+body.-emu .dialog .sheet-tabs a.active,
+body.-emu #sidebar .tabs a.active,
+body.-emu #sidebar .sheet-tabs a.active,
+body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .tabs a.active,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .sheet-tabs
+  a.active,
+body.-emu #module-management .list-filters a.active,
+body.-emu .dialog button.active,
 body.-emu #sidebar button.active,
-body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) button.active, body.-emu #menu #menu-items li.active, body.-emu #sidebar #combat #combat-controls .active.combat-control,
-body.-emu .sidebar-popout #combat #combat-controls .active.combat-control, body.-emu .filepicker.window-app .display-modes .active.display-mode, body.-emu .journal-sheet.sheet.window-app .window-content .active.editor-edit, body.-emu #calendar-time-container .calendar--time-controls .active.advance-btn,
-body.-emu #calendar-weather-container .calendar--time-controls .active.advance-btn, body.-emu #sidebar #combat .active.add-temporary,
-body.-emu .sidebar-popout #combat .active.add-temporary, body.-emu .window-app[id*="ActiveEffects-"] .window-content > form li.active.filter-item, body.-emu #specials-config .fxmaster .directory-header a.active, body.-emu .moulinette-options li.active, body.-emu #moulinette.forge .filepicker .display-modes a.active, body.-emu #OneJournalShell.window-app .history-navigation a.active, body.-emu ul.command-menu li.active, body.-emu #token-action-hud button.active.tah-title-button,
-body.-emu #token-action-hud .tah-action button.active, body.-emu #sidebar .token-mold > label > span.active,
-body.-emu .sidebar-popout .token-mold > label > span.active, .-emu-layout body.-emu .sheet.active-effect-sheet .effects-header a.active, body.-emu .sheet.active-effect-sheet .-emu-layout .effects-header a.active, .-emu-layout body.-emu .sheet.roll-table-config .table-results .table-header a.active, body.-emu .sheet.roll-table-config .table-results .-emu-layout .table-header a.active, .-emu-layout body.-emu .dice-so-nice section.content .settings-list .sfxs-list .sfx-header a.active, body.-emu .dice-so-nice section.content .settings-list .sfxs-list .-emu-layout .sfx-header a.active, .-emu-layout body.-emu .window-app[id*="ActiveEffects-"] .window-content > form .dnd5e.sheet.item .effect-header a.active, body.-emu .window-app[id*="ActiveEffects-"] .window-content > form .dnd5e.sheet.item .-emu-layout .effect-header a.active, .-emu-layout body.-emu .sheet.active-effect-sheet .changes-list li a.active, body.-emu .sheet.active-effect-sheet .changes-list .-emu-layout li a.active, .-emu-layout body.-emu .sheet.roll-table-config .table-results .table-result a.active, body.-emu .sheet.roll-table-config .table-results .-emu-layout .table-result a.active, .-emu-layout body.-emu .dice-so-nice section.content .settings-list .sfxs-list .sfx a.active, body.-emu .dice-so-nice section.content .settings-list .sfxs-list .-emu-layout .sfx a.active, body.-emu .dialog .directory .directory-item.folder .folder-header .active.create-folder,
-body.-emu .dialog .directory .directory-item.folder .folder-header .active.create-entity,
-body.-emu #sidebar .directory .directory-item.folder .folder-header .active.create-folder,
-body.-emu #sidebar .directory .directory-item.folder .folder-header .active.create-entity,
-body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .directory .directory-item.folder .folder-header .active.create-folder,
-body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .directory .directory-item.folder .folder-header .active.create-entity, body.-emu #navigation .active#nav-toggle, .-emu-layout body.-emu .window-app .window-header > a.active, .-emu-layout body.-emu .window-app .window-header a.active.header-button, .-emu-layout body.-emu #sidebar #chat #chat-log .message .active.button.message-delete, .-emu-layout body.-emu .sidebar-popout #chat #chat-log .message .active.button.message-delete, .-emu-layout body.-emu #sidebar #chat #chat-controls .chat-control-icon .active.fa-dice-d20, .-emu-layout body.-emu .sidebar-popout #chat #chat-controls .chat-control-icon .active.fa-dice-d20, .-emu-layout body.-emu #sidebar #chat #chat-controls .control-buttons .active.button, .-emu-layout body.-emu .sidebar-popout #chat #chat-controls .control-buttons .active.button, body.-emu #sidebar #combat #combat-round .encounters a.active,
-body.-emu .sidebar-popout #combat #combat-round .encounters a.active, body.-emu #sidebar #combat #combat-tracker .combatant .active.combatant-control,
-body.-emu .sidebar-popout #combat #combat-tracker .combatant .active.combatant-control, body.-emu #sidebar #playlists .directory-list .playlist-header .sound-controls .active.sound-control,
-body.-emu #sidebar #playlists .directory-list .sound .sound-controls .active.sound-control,
-body.-emu .sidebar-popout #playlists .directory-list .playlist-header .sound-controls .active.sound-control,
-body.-emu .sidebar-popout #playlists .directory-list .sound .sound-controls .active.sound-control, body.-emu #sidebar #playlists #currently-playing .sound .active.sound-control,
-body.-emu .sidebar-popout #playlists #currently-playing .sound .active.sound-control, body.-emu .window-app[id*="chat-popout-"] .chat-message .chat-card .die-result-overlay-br button.active,
-body.-emu #sidebar #chat #chat-log .chat-message .chat-card .die-result-overlay-br button.active, body.-emu #dfcp-rt-buttons button.active, body.-emu .active-effect-sheet[id*="ActiveEffectsConfig-"] .effect-special-duration .active.effect-control, body.-emu #specials-config .fxmaster .special-effects .controls a.active, body.-emu div.permission-viewer a.active, .-emu-layout body.-emu #sidebar #chat #chat-log .message .active.button.polyglot-message-language, .-emu-layout body.-emu .sidebar-popout #chat #chat-log .message .active.button.polyglot-message-language, body.-emu #smalltime-app #displayContainer .active.arrow, body.-emu #token-action-hud .active#tah-reposition,
-body.-emu #token-action-hud .active#tah-categories, body.-emu #sidebar .token-mold > a.active,
-body.-emu .sidebar-popout .token-mold > a.active, body.-emu #sidebar .sidebar-tab .directory-header .active.header-control,
-body.-emu .sidebar-popout .sidebar-tab .directory-header .active.header-control, body.-emu .dialog .tox .tox-tbtn.tox-tbtn--enabled,
+body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) button.active,
+body.-emu #menu #menu-items li.active,
+body.-emu #sidebar #combat #combat-controls .active.combat-control,
+body.-emu .sidebar-popout #combat #combat-controls .active.combat-control,
+body.-emu .filepicker.window-app .display-modes .active.display-mode,
+body.-emu .journal-sheet.sheet.window-app .window-content .active.editor-edit,
+body.-emu #calendar-time-container .calendar--time-controls .active.advance-btn,
+body.-emu
+  #calendar-weather-container
+  .calendar--time-controls
+  .active.advance-btn,
+body.-emu #sidebar #combat .active.add-temporary,
+body.-emu .sidebar-popout #combat .active.add-temporary,
+body.-emu
+  .window-app[id*="ActiveEffects-"]
+  .window-content
+  > form
+  li.active.filter-item,
+body.-emu #specials-config .fxmaster .directory-header a.active,
+body.-emu .moulinette-options li.active,
+body.-emu #moulinette.forge .filepicker .display-modes a.active,
+body.-emu #OneJournalShell.window-app .history-navigation a.active,
+body.-emu ul.command-menu li.active,
+body.-emu #token-action-hud button.active.tah-title-button,
+body.-emu #token-action-hud .tah-action button.active,
+body.-emu #sidebar .token-mold > label > span.active,
+body.-emu .sidebar-popout .token-mold > label > span.active,
+.-emu-layout body.-emu .sheet.active-effect-sheet .effects-header a.active,
+body.-emu .sheet.active-effect-sheet .-emu-layout .effects-header a.active,
+.-emu-layout
+  body.-emu
+  .sheet.roll-table-config
+  .table-results
+  .table-header
+  a.active,
+body.-emu
+  .sheet.roll-table-config
+  .table-results
+  .-emu-layout
+  .table-header
+  a.active,
+.-emu-layout
+  body.-emu
+  .dice-so-nice
+  section.content
+  .settings-list
+  .sfxs-list
+  .sfx-header
+  a.active,
+body.-emu
+  .dice-so-nice
+  section.content
+  .settings-list
+  .sfxs-list
+  .-emu-layout
+  .sfx-header
+  a.active,
+.-emu-layout
+  body.-emu
+  .window-app[id*="ActiveEffects-"]
+  .window-content
+  > form
+  .dnd5e.sheet.item
+  .effect-header
+  a.active,
+body.-emu
+  .window-app[id*="ActiveEffects-"]
+  .window-content
+  > form
+  .dnd5e.sheet.item
+  .-emu-layout
+  .effect-header
+  a.active,
+.-emu-layout body.-emu .sheet.active-effect-sheet .changes-list li a.active,
+body.-emu .sheet.active-effect-sheet .changes-list .-emu-layout li a.active,
+.-emu-layout
+  body.-emu
+  .sheet.roll-table-config
+  .table-results
+  .table-result
+  a.active,
+body.-emu
+  .sheet.roll-table-config
+  .table-results
+  .-emu-layout
+  .table-result
+  a.active,
+.-emu-layout
+  body.-emu
+  .dice-so-nice
+  section.content
+  .settings-list
+  .sfxs-list
+  .sfx
+  a.active,
+body.-emu
+  .dice-so-nice
+  section.content
+  .settings-list
+  .sfxs-list
+  .-emu-layout
+  .sfx
+  a.active,
+body.-emu
+  .dialog
+  .directory
+  .directory-item.folder
+  .folder-header
+  .active.create-folder,
+body.-emu
+  .dialog
+  .directory
+  .directory-item.folder
+  .folder-header
+  .active.create-entity,
+body.-emu
+  #sidebar
+  .directory
+  .directory-item.folder
+  .folder-header
+  .active.create-folder,
+body.-emu
+  #sidebar
+  .directory
+  .directory-item.folder
+  .folder-header
+  .active.create-entity,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .directory
+  .directory-item.folder
+  .folder-header
+  .active.create-folder,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .directory
+  .directory-item.folder
+  .folder-header
+  .active.create-entity,
+body.-emu #navigation .active#nav-toggle,
+.-emu-layout body.-emu .window-app .window-header > a.active,
+.-emu-layout body.-emu .window-app .window-header a.active.header-button,
+.-emu-layout
+  body.-emu
+  #sidebar
+  #chat
+  #chat-log
+  .message
+  .active.button.message-delete,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #chat
+  #chat-log
+  .message
+  .active.button.message-delete,
+.-emu-layout
+  body.-emu
+  #sidebar
+  #chat
+  #chat-controls
+  .chat-control-icon
+  .active.fa-dice-d20,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #chat
+  #chat-controls
+  .chat-control-icon
+  .active.fa-dice-d20,
+.-emu-layout
+  body.-emu
+  #sidebar
+  #chat
+  #chat-controls
+  .control-buttons
+  .active.button,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #chat
+  #chat-controls
+  .control-buttons
+  .active.button,
+body.-emu #sidebar #combat #combat-round .encounters a.active,
+body.-emu .sidebar-popout #combat #combat-round .encounters a.active,
+body.-emu #sidebar #combat #combat-tracker .combatant .active.combatant-control,
+body.-emu
+  .sidebar-popout
+  #combat
+  #combat-tracker
+  .combatant
+  .active.combatant-control,
+body.-emu
+  #sidebar
+  #playlists
+  .directory-list
+  .playlist-header
+  .sound-controls
+  .active.sound-control,
+body.-emu
+  #sidebar
+  #playlists
+  .directory-list
+  .sound
+  .sound-controls
+  .active.sound-control,
+body.-emu
+  .sidebar-popout
+  #playlists
+  .directory-list
+  .playlist-header
+  .sound-controls
+  .active.sound-control,
+body.-emu
+  .sidebar-popout
+  #playlists
+  .directory-list
+  .sound
+  .sound-controls
+  .active.sound-control,
+body.-emu #sidebar #playlists #currently-playing .sound .active.sound-control,
+body.-emu
+  .sidebar-popout
+  #playlists
+  #currently-playing
+  .sound
+  .active.sound-control,
+body.-emu
+  .window-app[id*="chat-popout-"]
+  .chat-message
+  .chat-card
+  .die-result-overlay-br
+  button.active,
+body.-emu
+  #sidebar
+  #chat
+  #chat-log
+  .chat-message
+  .chat-card
+  .die-result-overlay-br
+  button.active,
+body.-emu #dfcp-rt-buttons button.active,
+body.-emu
+  .active-effect-sheet[id*="ActiveEffectsConfig-"]
+  .effect-special-duration
+  .active.effect-control,
+body.-emu #specials-config .fxmaster .special-effects .controls a.active,
+body.-emu div.permission-viewer a.active,
+.-emu-layout
+  body.-emu
+  #sidebar
+  #chat
+  #chat-log
+  .message
+  .active.button.polyglot-message-language,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #chat
+  #chat-log
+  .message
+  .active.button.polyglot-message-language,
+body.-emu #smalltime-app #displayContainer .active.arrow,
+body.-emu #token-action-hud .active#tah-reposition,
+body.-emu #token-action-hud .active#tah-categories,
+body.-emu #sidebar .token-mold > a.active,
+body.-emu .sidebar-popout .token-mold > a.active,
+body.-emu #sidebar .sidebar-tab .directory-header .active.header-control,
+body.-emu .sidebar-popout .sidebar-tab .directory-header .active.header-control,
+body.-emu .dialog .tox .tox-tbtn.tox-tbtn--enabled,
 body.-emu #sidebar .tox .tox-tbtn.tox-tbtn--enabled,
-body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .tox .tox-tbtn.tox-tbtn--enabled, body.-emu #hotbar .macro.active, body.-emu #hud .control-icon.active, body.-emu #controls .scene-control.active,
-body.-emu #controls .control-tool.active, body.-emu #controls .control-tool.toggle.active, body.-emu #navigation #scene-list .scene.active, body.-emu #navigation #scene-list .scene.view,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .tox
+  .tox-tbtn.tox-tbtn--enabled,
+body.-emu #hotbar .macro.active,
+body.-emu #hud .control-icon.active,
+body.-emu #controls .scene-control.active,
+body.-emu #controls .control-tool.active,
+body.-emu #controls .control-tool.toggle.active,
+body.-emu #navigation #scene-list .scene.active,
+body.-emu #navigation #scene-list .scene.view,
 body.-emu #navigation .scene-list .scene.active,
-body.-emu #navigation .scene-list .scene.view, body.-emu #navigation #scene-list .scene.active:not(.gm), body.-emu #navigation #scene-list .scene.view:not(.gm),
+body.-emu #navigation .scene-list .scene.view,
+body.-emu #navigation #scene-list .scene.active:not(.gm),
+body.-emu #navigation #scene-list .scene.view:not(.gm),
 body.-emu #navigation .scene-list .scene.active:not(.gm),
-body.-emu #navigation .scene-list .scene.view:not(.gm), body.-emu #sidebar #sidebar-tabs > .item.active,
+body.-emu #navigation .scene-list .scene.view:not(.gm),
+body.-emu #sidebar #sidebar-tabs > .item.active,
 body.-emu #sidebar #sidebar-tabs > .collapse.active,
 body.-emu .sidebar-popout #sidebar-tabs > .item.active,
-body.-emu .sidebar-popout #sidebar-tabs > .collapse.active, .-emu-layout.-emu-subtle-layout body.-emu #sidebar:hover #emu-sidebar-lock, .-emu-layout.-emu-subtle-layout body.-emu #sidebar.is-locked #emu-sidebar-lock, body.-emu #sidebar #combat #combat-tracker .combatant.active,
-body.-emu .sidebar-popout #combat #combat-tracker .combatant.active, body.-emu .filepicker.window-app .filepicker-body.private .current-dir button.privacy, body.-emu .user-config.sheet.window-app #characters .directory-item.context,
-body.-emu .user-config.sheet.window-app .directory-item.context, body.-emu #df-curvy-walls-tools .control-tool.active, body.-emu #lmrtfy.lmrtfy-parchment .lmrtfy-actor-avatars input:checked + label, body.-emu #navigation .monks-scene-navigation .scene-list > .nav-item.active > .scene-name {
+body.-emu .sidebar-popout #sidebar-tabs > .collapse.active,
+.-emu-layout.-emu-subtle-layout body.-emu #sidebar:hover #emu-sidebar-lock,
+.-emu-layout.-emu-subtle-layout body.-emu #sidebar.is-locked #emu-sidebar-lock,
+body.-emu #sidebar #combat #combat-tracker .combatant.active,
+body.-emu .sidebar-popout #combat #combat-tracker .combatant.active,
+body.-emu
+  .filepicker.window-app
+  .filepicker-body.private
+  .current-dir
+  button.privacy,
+body.-emu .user-config.sheet.window-app #characters .directory-item.context,
+body.-emu .user-config.sheet.window-app .directory-item.context,
+body.-emu #df-curvy-walls-tools .control-tool.active,
+body.-emu #lmrtfy.lmrtfy-parchment .lmrtfy-actor-avatars input:checked + label,
+body.-emu
+  #navigation
+  .monks-scene-navigation
+  .scene-list
+  > .nav-item.active
+  > .scene-name {
   background-color: rgba(var(--color-primary), 1);
   color: rgba(var(--color-text-lightest), 1);
-  text-shadow: none; }
-  body.-emu .dialog .tabs a.active:hover, body.-emu .dialog .sheet-tabs a.active:hover, body.-emu #sidebar .tabs a.active:hover, body.-emu #sidebar .sheet-tabs a.active:hover, body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .tabs a.active:hover, body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .sheet-tabs a.active:hover, body.-emu #module-management .list-filters a.active:hover, body.-emu .dialog button.active:hover,
-  body.-emu #sidebar button.active:hover,
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) button.active:hover, body.-emu #menu #menu-items li.active:hover, body.-emu #sidebar #combat #combat-controls .active.combat-control:hover,
-  body.-emu .sidebar-popout #combat #combat-controls .active.combat-control:hover, body.-emu .filepicker.window-app .display-modes .active.display-mode:hover, body.-emu .journal-sheet.sheet.window-app .window-content .active.editor-edit:hover, body.-emu #calendar-time-container .calendar--time-controls .active.advance-btn:hover,
-  body.-emu #calendar-weather-container .calendar--time-controls .active.advance-btn:hover, body.-emu #sidebar #combat .active.add-temporary:hover,
-  body.-emu .sidebar-popout #combat .active.add-temporary:hover, body.-emu .window-app[id*="ActiveEffects-"] .window-content > form li.active.filter-item:hover, body.-emu #specials-config .fxmaster .directory-header a.active:hover, body.-emu .moulinette-options li.active:hover, body.-emu #moulinette.forge .filepicker .display-modes a.active:hover, body.-emu #OneJournalShell.window-app .history-navigation a.active:hover, body.-emu ul.command-menu li.active:hover, body.-emu #token-action-hud button.active.tah-title-button:hover,
-  body.-emu #token-action-hud .tah-action button.active:hover, body.-emu #sidebar .token-mold > label > span.active:hover,
-  body.-emu .sidebar-popout .token-mold > label > span.active:hover, .-emu-layout body.-emu .sheet.active-effect-sheet .effects-header a.active:hover, body.-emu .sheet.active-effect-sheet .-emu-layout .effects-header a.active:hover, .-emu-layout body.-emu .sheet.roll-table-config .table-results .table-header a.active:hover, body.-emu .sheet.roll-table-config .table-results .-emu-layout .table-header a.active:hover, .-emu-layout body.-emu .dice-so-nice section.content .settings-list .sfxs-list .sfx-header a.active:hover, body.-emu .dice-so-nice section.content .settings-list .sfxs-list .-emu-layout .sfx-header a.active:hover, .-emu-layout body.-emu .window-app[id*="ActiveEffects-"] .window-content > form .dnd5e.sheet.item .effect-header a.active:hover, body.-emu .window-app[id*="ActiveEffects-"] .window-content > form .dnd5e.sheet.item .-emu-layout .effect-header a.active:hover, .-emu-layout body.-emu .sheet.active-effect-sheet .changes-list li a.active:hover, body.-emu .sheet.active-effect-sheet .changes-list .-emu-layout li a.active:hover, .-emu-layout body.-emu .sheet.roll-table-config .table-results .table-result a.active:hover, body.-emu .sheet.roll-table-config .table-results .-emu-layout .table-result a.active:hover, .-emu-layout body.-emu .dice-so-nice section.content .settings-list .sfxs-list .sfx a.active:hover, body.-emu .dice-so-nice section.content .settings-list .sfxs-list .-emu-layout .sfx a.active:hover, body.-emu .dialog .directory .directory-item.folder .folder-header .active.create-folder:hover,
-  body.-emu .dialog .directory .directory-item.folder .folder-header .active.create-entity:hover,
-  body.-emu #sidebar .directory .directory-item.folder .folder-header .active.create-folder:hover,
-  body.-emu #sidebar .directory .directory-item.folder .folder-header .active.create-entity:hover,
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .directory .directory-item.folder .folder-header .active.create-folder:hover,
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .directory .directory-item.folder .folder-header .active.create-entity:hover, body.-emu #navigation .active#nav-toggle:hover, .-emu-layout body.-emu .window-app .window-header > a.active:hover, .-emu-layout body.-emu .window-app .window-header a.active.header-button:hover, .-emu-layout body.-emu #sidebar #chat #chat-log .message .active.button.message-delete:hover, .-emu-layout body.-emu .sidebar-popout #chat #chat-log .message .active.button.message-delete:hover, .-emu-layout body.-emu #sidebar #chat #chat-controls .chat-control-icon .active.fa-dice-d20:hover, .-emu-layout body.-emu .sidebar-popout #chat #chat-controls .chat-control-icon .active.fa-dice-d20:hover, .-emu-layout body.-emu #sidebar #chat #chat-controls .control-buttons .active.button:hover, .-emu-layout body.-emu .sidebar-popout #chat #chat-controls .control-buttons .active.button:hover, body.-emu #sidebar #combat #combat-round .encounters a.active:hover,
-  body.-emu .sidebar-popout #combat #combat-round .encounters a.active:hover, body.-emu #sidebar #combat #combat-tracker .combatant .active.combatant-control:hover,
-  body.-emu .sidebar-popout #combat #combat-tracker .combatant .active.combatant-control:hover, body.-emu #sidebar #playlists .directory-list .playlist-header .sound-controls .active.sound-control:hover,
-  body.-emu #sidebar #playlists .directory-list .sound .sound-controls .active.sound-control:hover,
-  body.-emu .sidebar-popout #playlists .directory-list .playlist-header .sound-controls .active.sound-control:hover,
-  body.-emu .sidebar-popout #playlists .directory-list .sound .sound-controls .active.sound-control:hover, body.-emu #sidebar #playlists #currently-playing .sound .active.sound-control:hover,
-  body.-emu .sidebar-popout #playlists #currently-playing .sound .active.sound-control:hover, body.-emu .window-app[id*="chat-popout-"] .chat-message .chat-card .die-result-overlay-br button.active:hover,
-  body.-emu #sidebar #chat #chat-log .chat-message .chat-card .die-result-overlay-br button.active:hover, body.-emu #dfcp-rt-buttons button.active:hover, body.-emu .active-effect-sheet[id*="ActiveEffectsConfig-"] .effect-special-duration .active.effect-control:hover, body.-emu #specials-config .fxmaster .special-effects .controls a.active:hover, body.-emu div.permission-viewer a.active:hover, .-emu-layout body.-emu #sidebar #chat #chat-log .message .active.button.polyglot-message-language:hover, .-emu-layout body.-emu .sidebar-popout #chat #chat-log .message .active.button.polyglot-message-language:hover, body.-emu #smalltime-app #displayContainer .active.arrow:hover, body.-emu #token-action-hud .active#tah-reposition:hover,
-  body.-emu #token-action-hud .active#tah-categories:hover, body.-emu #sidebar .token-mold > a.active:hover,
-  body.-emu .sidebar-popout .token-mold > a.active:hover, body.-emu #sidebar .sidebar-tab .directory-header .active.header-control:hover,
-  body.-emu .sidebar-popout .sidebar-tab .directory-header .active.header-control:hover, body.-emu .dialog .tox .tox-tbtn.tox-tbtn--enabled:hover,
-  body.-emu #sidebar .tox .tox-tbtn.tox-tbtn--enabled:hover,
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .tox .tox-tbtn.tox-tbtn--enabled:hover, body.-emu #hotbar .macro.active:hover, body.-emu #hud .control-icon.active:hover, body.-emu #controls .scene-control.active:hover,
-  body.-emu #controls .control-tool.active:hover, body.-emu #controls .control-tool.toggle.active:hover, body.-emu #navigation #scene-list .scene.active:hover, body.-emu #navigation #scene-list .scene.view:hover,
-  body.-emu #navigation .scene-list .scene.active:hover,
-  body.-emu #navigation .scene-list .scene.view:hover, body.-emu #navigation #scene-list .scene.active:hover:not(.gm), body.-emu #navigation #scene-list .scene.view:hover:not(.gm),
-  body.-emu #navigation .scene-list .scene.active:hover:not(.gm),
-  body.-emu #navigation .scene-list .scene.view:hover:not(.gm), body.-emu #sidebar #sidebar-tabs > .item.active:hover,
-  body.-emu #sidebar #sidebar-tabs > .collapse.active:hover,
-  body.-emu .sidebar-popout #sidebar-tabs > .item.active:hover,
-  body.-emu .sidebar-popout #sidebar-tabs > .collapse.active:hover, .-emu-layout.-emu-subtle-layout body.-emu #sidebar:hover #emu-sidebar-lock:hover, .-emu-layout.-emu-subtle-layout body.-emu #sidebar.is-locked #emu-sidebar-lock:hover, body.-emu #sidebar #combat #combat-tracker .combatant.active:hover,
-  body.-emu .sidebar-popout #combat #combat-tracker .combatant.active:hover, body.-emu .filepicker.window-app .filepicker-body.private .current-dir button.privacy:hover, body.-emu .user-config.sheet.window-app #characters .directory-item.context:hover,
-  body.-emu .user-config.sheet.window-app .directory-item.context:hover, body.-emu #df-curvy-walls-tools .control-tool.active:hover, body.-emu #lmrtfy.lmrtfy-parchment .lmrtfy-actor-avatars input:checked + label:hover, body.-emu #navigation .monks-scene-navigation .scene-list > .nav-item.active > .scene-name:hover {
-    background-color: rgba(var(--color-primary), 1);
-    color: rgba(var(--color-text-lightest), 1);
-    text-shadow: none; }
+  text-shadow: none;
+}
+body.-emu .dialog .tabs a.active:hover,
+body.-emu .dialog .sheet-tabs a.active:hover,
+body.-emu #sidebar .tabs a.active:hover,
+body.-emu #sidebar .sheet-tabs a.active:hover,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .tabs
+  a.active:hover,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .sheet-tabs
+  a.active:hover,
+body.-emu #module-management .list-filters a.active:hover,
+body.-emu .dialog button.active:hover,
+body.-emu #sidebar button.active:hover,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  button.active:hover,
+body.-emu #menu #menu-items li.active:hover,
+body.-emu #sidebar #combat #combat-controls .active.combat-control:hover,
+body.-emu .sidebar-popout #combat #combat-controls .active.combat-control:hover,
+body.-emu .filepicker.window-app .display-modes .active.display-mode:hover,
+body.-emu
+  .journal-sheet.sheet.window-app
+  .window-content
+  .active.editor-edit:hover,
+body.-emu
+  #calendar-time-container
+  .calendar--time-controls
+  .active.advance-btn:hover,
+body.-emu
+  #calendar-weather-container
+  .calendar--time-controls
+  .active.advance-btn:hover,
+body.-emu #sidebar #combat .active.add-temporary:hover,
+body.-emu .sidebar-popout #combat .active.add-temporary:hover,
+body.-emu
+  .window-app[id*="ActiveEffects-"]
+  .window-content
+  > form
+  li.active.filter-item:hover,
+body.-emu #specials-config .fxmaster .directory-header a.active:hover,
+body.-emu .moulinette-options li.active:hover,
+body.-emu #moulinette.forge .filepicker .display-modes a.active:hover,
+body.-emu #OneJournalShell.window-app .history-navigation a.active:hover,
+body.-emu ul.command-menu li.active:hover,
+body.-emu #token-action-hud button.active.tah-title-button:hover,
+body.-emu #token-action-hud .tah-action button.active:hover,
+body.-emu #sidebar .token-mold > label > span.active:hover,
+body.-emu .sidebar-popout .token-mold > label > span.active:hover,
+.-emu-layout
+  body.-emu
+  .sheet.active-effect-sheet
+  .effects-header
+  a.active:hover,
+body.-emu
+  .sheet.active-effect-sheet
+  .-emu-layout
+  .effects-header
+  a.active:hover,
+.-emu-layout
+  body.-emu
+  .sheet.roll-table-config
+  .table-results
+  .table-header
+  a.active:hover,
+body.-emu
+  .sheet.roll-table-config
+  .table-results
+  .-emu-layout
+  .table-header
+  a.active:hover,
+.-emu-layout
+  body.-emu
+  .dice-so-nice
+  section.content
+  .settings-list
+  .sfxs-list
+  .sfx-header
+  a.active:hover,
+body.-emu
+  .dice-so-nice
+  section.content
+  .settings-list
+  .sfxs-list
+  .-emu-layout
+  .sfx-header
+  a.active:hover,
+.-emu-layout
+  body.-emu
+  .window-app[id*="ActiveEffects-"]
+  .window-content
+  > form
+  .dnd5e.sheet.item
+  .effect-header
+  a.active:hover,
+body.-emu
+  .window-app[id*="ActiveEffects-"]
+  .window-content
+  > form
+  .dnd5e.sheet.item
+  .-emu-layout
+  .effect-header
+  a.active:hover,
+.-emu-layout
+  body.-emu
+  .sheet.active-effect-sheet
+  .changes-list
+  li
+  a.active:hover,
+body.-emu
+  .sheet.active-effect-sheet
+  .changes-list
+  .-emu-layout
+  li
+  a.active:hover,
+.-emu-layout
+  body.-emu
+  .sheet.roll-table-config
+  .table-results
+  .table-result
+  a.active:hover,
+body.-emu
+  .sheet.roll-table-config
+  .table-results
+  .-emu-layout
+  .table-result
+  a.active:hover,
+.-emu-layout
+  body.-emu
+  .dice-so-nice
+  section.content
+  .settings-list
+  .sfxs-list
+  .sfx
+  a.active:hover,
+body.-emu
+  .dice-so-nice
+  section.content
+  .settings-list
+  .sfxs-list
+  .-emu-layout
+  .sfx
+  a.active:hover,
+body.-emu
+  .dialog
+  .directory
+  .directory-item.folder
+  .folder-header
+  .active.create-folder:hover,
+body.-emu
+  .dialog
+  .directory
+  .directory-item.folder
+  .folder-header
+  .active.create-entity:hover,
+body.-emu
+  #sidebar
+  .directory
+  .directory-item.folder
+  .folder-header
+  .active.create-folder:hover,
+body.-emu
+  #sidebar
+  .directory
+  .directory-item.folder
+  .folder-header
+  .active.create-entity:hover,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .directory
+  .directory-item.folder
+  .folder-header
+  .active.create-folder:hover,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .directory
+  .directory-item.folder
+  .folder-header
+  .active.create-entity:hover,
+body.-emu #navigation .active#nav-toggle:hover,
+.-emu-layout body.-emu .window-app .window-header > a.active:hover,
+.-emu-layout body.-emu .window-app .window-header a.active.header-button:hover,
+.-emu-layout
+  body.-emu
+  #sidebar
+  #chat
+  #chat-log
+  .message
+  .active.button.message-delete:hover,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #chat
+  #chat-log
+  .message
+  .active.button.message-delete:hover,
+.-emu-layout
+  body.-emu
+  #sidebar
+  #chat
+  #chat-controls
+  .chat-control-icon
+  .active.fa-dice-d20:hover,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #chat
+  #chat-controls
+  .chat-control-icon
+  .active.fa-dice-d20:hover,
+.-emu-layout
+  body.-emu
+  #sidebar
+  #chat
+  #chat-controls
+  .control-buttons
+  .active.button:hover,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #chat
+  #chat-controls
+  .control-buttons
+  .active.button:hover,
+body.-emu #sidebar #combat #combat-round .encounters a.active:hover,
+body.-emu .sidebar-popout #combat #combat-round .encounters a.active:hover,
+body.-emu
+  #sidebar
+  #combat
+  #combat-tracker
+  .combatant
+  .active.combatant-control:hover,
+body.-emu
+  .sidebar-popout
+  #combat
+  #combat-tracker
+  .combatant
+  .active.combatant-control:hover,
+body.-emu
+  #sidebar
+  #playlists
+  .directory-list
+  .playlist-header
+  .sound-controls
+  .active.sound-control:hover,
+body.-emu
+  #sidebar
+  #playlists
+  .directory-list
+  .sound
+  .sound-controls
+  .active.sound-control:hover,
+body.-emu
+  .sidebar-popout
+  #playlists
+  .directory-list
+  .playlist-header
+  .sound-controls
+  .active.sound-control:hover,
+body.-emu
+  .sidebar-popout
+  #playlists
+  .directory-list
+  .sound
+  .sound-controls
+  .active.sound-control:hover,
+body.-emu
+  #sidebar
+  #playlists
+  #currently-playing
+  .sound
+  .active.sound-control:hover,
+body.-emu
+  .sidebar-popout
+  #playlists
+  #currently-playing
+  .sound
+  .active.sound-control:hover,
+body.-emu
+  .window-app[id*="chat-popout-"]
+  .chat-message
+  .chat-card
+  .die-result-overlay-br
+  button.active:hover,
+body.-emu
+  #sidebar
+  #chat
+  #chat-log
+  .chat-message
+  .chat-card
+  .die-result-overlay-br
+  button.active:hover,
+body.-emu #dfcp-rt-buttons button.active:hover,
+body.-emu
+  .active-effect-sheet[id*="ActiveEffectsConfig-"]
+  .effect-special-duration
+  .active.effect-control:hover,
+body.-emu #specials-config .fxmaster .special-effects .controls a.active:hover,
+body.-emu div.permission-viewer a.active:hover,
+.-emu-layout
+  body.-emu
+  #sidebar
+  #chat
+  #chat-log
+  .message
+  .active.button.polyglot-message-language:hover,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #chat
+  #chat-log
+  .message
+  .active.button.polyglot-message-language:hover,
+body.-emu #smalltime-app #displayContainer .active.arrow:hover,
+body.-emu #token-action-hud .active#tah-reposition:hover,
+body.-emu #token-action-hud .active#tah-categories:hover,
+body.-emu #sidebar .token-mold > a.active:hover,
+body.-emu .sidebar-popout .token-mold > a.active:hover,
+body.-emu #sidebar .sidebar-tab .directory-header .active.header-control:hover,
+body.-emu
+  .sidebar-popout
+  .sidebar-tab
+  .directory-header
+  .active.header-control:hover,
+body.-emu .dialog .tox .tox-tbtn.tox-tbtn--enabled:hover,
+body.-emu #sidebar .tox .tox-tbtn.tox-tbtn--enabled:hover,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .tox
+  .tox-tbtn.tox-tbtn--enabled:hover,
+body.-emu #hotbar .macro.active:hover,
+body.-emu #hud .control-icon.active:hover,
+body.-emu #controls .scene-control.active:hover,
+body.-emu #controls .control-tool.active:hover,
+body.-emu #controls .control-tool.toggle.active:hover,
+body.-emu #navigation #scene-list .scene.active:hover,
+body.-emu #navigation #scene-list .scene.view:hover,
+body.-emu #navigation .scene-list .scene.active:hover,
+body.-emu #navigation .scene-list .scene.view:hover,
+body.-emu #navigation #scene-list .scene.active:hover:not(.gm),
+body.-emu #navigation #scene-list .scene.view:hover:not(.gm),
+body.-emu #navigation .scene-list .scene.active:hover:not(.gm),
+body.-emu #navigation .scene-list .scene.view:hover:not(.gm),
+body.-emu #sidebar #sidebar-tabs > .item.active:hover,
+body.-emu #sidebar #sidebar-tabs > .collapse.active:hover,
+body.-emu .sidebar-popout #sidebar-tabs > .item.active:hover,
+body.-emu .sidebar-popout #sidebar-tabs > .collapse.active:hover,
+.-emu-layout.-emu-subtle-layout
+  body.-emu
+  #sidebar:hover
+  #emu-sidebar-lock:hover,
+.-emu-layout.-emu-subtle-layout
+  body.-emu
+  #sidebar.is-locked
+  #emu-sidebar-lock:hover,
+body.-emu #sidebar #combat #combat-tracker .combatant.active:hover,
+body.-emu .sidebar-popout #combat #combat-tracker .combatant.active:hover,
+body.-emu
+  .filepicker.window-app
+  .filepicker-body.private
+  .current-dir
+  button.privacy:hover,
+body.-emu
+  .user-config.sheet.window-app
+  #characters
+  .directory-item.context:hover,
+body.-emu .user-config.sheet.window-app .directory-item.context:hover,
+body.-emu #df-curvy-walls-tools .control-tool.active:hover,
+body.-emu
+  #lmrtfy.lmrtfy-parchment
+  .lmrtfy-actor-avatars
+  input:checked
+  + label:hover,
+body.-emu
+  #navigation
+  .monks-scene-navigation
+  .scene-list
+  > .nav-item.active
+  > .scene-name:hover {
+  background-color: rgba(var(--color-primary), 1);
+  color: rgba(var(--color-text-lightest), 1);
+  text-shadow: none;
+}
 
-body.-emu .sheet.active-effect-sheet .effects-header, body.-emu .sheet.roll-table-config .table-results .table-header, body.-emu .dice-so-nice section.content .settings-list .sfxs-list .sfx-header, body.-emu .window-app[id*="ActiveEffects-"] .window-content > form .dnd5e.sheet.item .effect-header {
+body.-emu .sheet.active-effect-sheet .effects-header,
+body.-emu .sheet.roll-table-config .table-results .table-header,
+body.-emu .dice-so-nice section.content .settings-list .sfxs-list .sfx-header,
+body.-emu
+  .window-app[id*="ActiveEffects-"]
+  .window-content
+  > form
+  .dnd5e.sheet.item
+  .effect-header {
   align-items: center;
   background: rgba(var(--color-background), 0.1);
   border: none;
   -webkit-border-after: rgba(var(--color-border), 1) 1px solid;
-          border-block-end: rgba(var(--color-border), 1) 1px solid; }
-  .-emu-layout body.-emu .sheet.active-effect-sheet .effects-header, body.-emu .sheet.active-effect-sheet .-emu-layout .effects-header, .-emu-layout body.-emu .sheet.roll-table-config .table-results .table-header, body.-emu .sheet.roll-table-config .table-results .-emu-layout .table-header, .-emu-layout body.-emu .dice-so-nice section.content .settings-list .sfxs-list .sfx-header, body.-emu .dice-so-nice section.content .settings-list .sfxs-list .-emu-layout .sfx-header, .-emu-layout body.-emu .window-app[id*="ActiveEffects-"] .window-content > form .dnd5e.sheet.item .effect-header, body.-emu .window-app[id*="ActiveEffects-"] .window-content > form .dnd5e.sheet.item .-emu-layout .effect-header {
-    height: auto;
-    -webkit-margin-before: var(--emu-space-base);
-            margin-block-start: var(--emu-space-base);
-    padding: var(--emu-space-sm); }
-    .-emu-layout body.-emu .sheet.active-effect-sheet .effects-header > div, body.-emu .sheet.active-effect-sheet .-emu-layout .effects-header > div, .-emu-layout body.-emu .sheet.roll-table-config .table-results .table-header > div, body.-emu .sheet.roll-table-config .table-results .-emu-layout .table-header > div, .-emu-layout body.-emu .dice-so-nice section.content .settings-list .sfxs-list .sfx-header > div, body.-emu .dice-so-nice section.content .settings-list .sfxs-list .-emu-layout .sfx-header > div, .-emu-layout body.-emu .window-app[id*="ActiveEffects-"] .window-content > form .dnd5e.sheet.item .effect-header > div, body.-emu .window-app[id*="ActiveEffects-"] .window-content > form .dnd5e.sheet.item .-emu-layout .effect-header > div {
-      height: auto;
-      line-height: initial;
-      margin: 0;
-      padding: 0;
-      -webkit-padding-start: var(--emu-space-base);
-              padding-inline-start: var(--emu-space-base); }
-      .-emu-layout body.-emu .sheet.active-effect-sheet .effects-header > div:first-of-type, body.-emu .sheet.active-effect-sheet .-emu-layout .effects-header > div:first-of-type, .-emu-layout body.-emu .sheet.roll-table-config .table-results .table-header > div:first-of-type, body.-emu .sheet.roll-table-config .table-results .-emu-layout .table-header > div:first-of-type, .-emu-layout body.-emu .dice-so-nice section.content .settings-list .sfxs-list .sfx-header > div:first-of-type, body.-emu .dice-so-nice section.content .settings-list .sfxs-list .-emu-layout .sfx-header > div:first-of-type, .-emu-layout body.-emu .window-app[id*="ActiveEffects-"] .window-content > form .dnd5e.sheet.item .effect-header > div:first-of-type, body.-emu .window-app[id*="ActiveEffects-"] .window-content > form .dnd5e.sheet.item .-emu-layout .effect-header > div:first-of-type {
-        -webkit-padding-start: 0;
-                padding-inline-start: 0; }
-  body.-emu .sheet.active-effect-sheet .effects-header a, body.-emu .sheet.roll-table-config .table-results .table-header a, body.-emu .dice-so-nice section.content .settings-list .sfxs-list .sfx-header a, body.-emu .window-app[id*="ActiveEffects-"] .window-content > form .dnd5e.sheet.item .effect-header a {
-    color: rgba(var(--color-text), 1); }
-    .-emu-layout body.-emu .sheet.active-effect-sheet .effects-header a, body.-emu .sheet.active-effect-sheet .-emu-layout .effects-header a, .-emu-layout body.-emu .sheet.roll-table-config .table-results .table-header a, body.-emu .sheet.roll-table-config .table-results .-emu-layout .table-header a, .-emu-layout body.-emu .dice-so-nice section.content .settings-list .sfxs-list .sfx-header a, body.-emu .dice-so-nice section.content .settings-list .sfxs-list .-emu-layout .sfx-header a, .-emu-layout body.-emu .window-app[id*="ActiveEffects-"] .window-content > form .dnd5e.sheet.item .effect-header a, body.-emu .window-app[id*="ActiveEffects-"] .window-content > form .dnd5e.sheet.item .-emu-layout .effect-header a {
-      color: rgba(var(--color-text), 1); }
+  border-block-end: rgba(var(--color-border), 1) 1px solid;
+}
+.-emu-layout body.-emu .sheet.active-effect-sheet .effects-header,
+body.-emu .sheet.active-effect-sheet .-emu-layout .effects-header,
+.-emu-layout body.-emu .sheet.roll-table-config .table-results .table-header,
+body.-emu .sheet.roll-table-config .table-results .-emu-layout .table-header,
+.-emu-layout
+  body.-emu
+  .dice-so-nice
+  section.content
+  .settings-list
+  .sfxs-list
+  .sfx-header,
+body.-emu
+  .dice-so-nice
+  section.content
+  .settings-list
+  .sfxs-list
+  .-emu-layout
+  .sfx-header,
+.-emu-layout
+  body.-emu
+  .window-app[id*="ActiveEffects-"]
+  .window-content
+  > form
+  .dnd5e.sheet.item
+  .effect-header,
+body.-emu
+  .window-app[id*="ActiveEffects-"]
+  .window-content
+  > form
+  .dnd5e.sheet.item
+  .-emu-layout
+  .effect-header {
+  height: auto;
+  -webkit-margin-before: var(--emu-space-base);
+  margin-block-start: var(--emu-space-base);
+  padding: var(--emu-space-sm);
+}
+.-emu-layout body.-emu .sheet.active-effect-sheet .effects-header > div,
+body.-emu .sheet.active-effect-sheet .-emu-layout .effects-header > div,
+.-emu-layout
+  body.-emu
+  .sheet.roll-table-config
+  .table-results
+  .table-header
+  > div,
+body.-emu
+  .sheet.roll-table-config
+  .table-results
+  .-emu-layout
+  .table-header
+  > div,
+.-emu-layout
+  body.-emu
+  .dice-so-nice
+  section.content
+  .settings-list
+  .sfxs-list
+  .sfx-header
+  > div,
+body.-emu
+  .dice-so-nice
+  section.content
+  .settings-list
+  .sfxs-list
+  .-emu-layout
+  .sfx-header
+  > div,
+.-emu-layout
+  body.-emu
+  .window-app[id*="ActiveEffects-"]
+  .window-content
+  > form
+  .dnd5e.sheet.item
+  .effect-header
+  > div,
+body.-emu
+  .window-app[id*="ActiveEffects-"]
+  .window-content
+  > form
+  .dnd5e.sheet.item
+  .-emu-layout
+  .effect-header
+  > div {
+  height: auto;
+  line-height: initial;
+  margin: 0;
+  padding: 0;
+  -webkit-padding-start: var(--emu-space-base);
+  padding-inline-start: var(--emu-space-base);
+}
+.-emu-layout
+  body.-emu
+  .sheet.active-effect-sheet
+  .effects-header
+  > div:first-of-type,
+body.-emu
+  .sheet.active-effect-sheet
+  .-emu-layout
+  .effects-header
+  > div:first-of-type,
+.-emu-layout
+  body.-emu
+  .sheet.roll-table-config
+  .table-results
+  .table-header
+  > div:first-of-type,
+body.-emu
+  .sheet.roll-table-config
+  .table-results
+  .-emu-layout
+  .table-header
+  > div:first-of-type,
+.-emu-layout
+  body.-emu
+  .dice-so-nice
+  section.content
+  .settings-list
+  .sfxs-list
+  .sfx-header
+  > div:first-of-type,
+body.-emu
+  .dice-so-nice
+  section.content
+  .settings-list
+  .sfxs-list
+  .-emu-layout
+  .sfx-header
+  > div:first-of-type,
+.-emu-layout
+  body.-emu
+  .window-app[id*="ActiveEffects-"]
+  .window-content
+  > form
+  .dnd5e.sheet.item
+  .effect-header
+  > div:first-of-type,
+body.-emu
+  .window-app[id*="ActiveEffects-"]
+  .window-content
+  > form
+  .dnd5e.sheet.item
+  .-emu-layout
+  .effect-header
+  > div:first-of-type {
+  -webkit-padding-start: 0;
+  padding-inline-start: 0;
+}
+body.-emu .sheet.active-effect-sheet .effects-header a,
+body.-emu .sheet.roll-table-config .table-results .table-header a,
+body.-emu .dice-so-nice section.content .settings-list .sfxs-list .sfx-header a,
+body.-emu
+  .window-app[id*="ActiveEffects-"]
+  .window-content
+  > form
+  .dnd5e.sheet.item
+  .effect-header
+  a {
+  color: rgba(var(--color-text), 1);
+}
+.-emu-layout body.-emu .sheet.active-effect-sheet .effects-header a,
+body.-emu .sheet.active-effect-sheet .-emu-layout .effects-header a,
+.-emu-layout body.-emu .sheet.roll-table-config .table-results .table-header a,
+body.-emu .sheet.roll-table-config .table-results .-emu-layout .table-header a,
+.-emu-layout
+  body.-emu
+  .dice-so-nice
+  section.content
+  .settings-list
+  .sfxs-list
+  .sfx-header
+  a,
+body.-emu
+  .dice-so-nice
+  section.content
+  .settings-list
+  .sfxs-list
+  .-emu-layout
+  .sfx-header
+  a,
+.-emu-layout
+  body.-emu
+  .window-app[id*="ActiveEffects-"]
+  .window-content
+  > form
+  .dnd5e.sheet.item
+  .effect-header
+  a,
+body.-emu
+  .window-app[id*="ActiveEffects-"]
+  .window-content
+  > form
+  .dnd5e.sheet.item
+  .-emu-layout
+  .effect-header
+  a {
+  color: rgba(var(--color-text), 1);
+}
 
-body.-emu .sheet.active-effect-sheet .changes-list li, body.-emu .sheet.roll-table-config .table-results .table-result, body.-emu .dice-so-nice section.content .settings-list .sfxs-list .sfx {
+body.-emu .sheet.active-effect-sheet .changes-list li,
+body.-emu .sheet.roll-table-config .table-results .table-result,
+body.-emu .dice-so-nice section.content .settings-list .sfxs-list .sfx {
   align-items: center;
-  border: none; }
-  .-emu-layout body.-emu .sheet.active-effect-sheet .changes-list li, body.-emu .sheet.active-effect-sheet .changes-list .-emu-layout li, .-emu-layout body.-emu .sheet.roll-table-config .table-results .table-result, body.-emu .sheet.roll-table-config .table-results .-emu-layout .table-result, .-emu-layout body.-emu .dice-so-nice section.content .settings-list .sfxs-list .sfx, body.-emu .dice-so-nice section.content .settings-list .sfxs-list .-emu-layout .sfx {
-    height: auto;
-    padding: var(--emu-space-sm); }
-    .-emu-layout body.-emu .sheet.active-effect-sheet .changes-list li > div, body.-emu .sheet.active-effect-sheet .changes-list .-emu-layout li > div, .-emu-layout body.-emu .sheet.roll-table-config .table-results .table-result > div, body.-emu .sheet.roll-table-config .table-results .-emu-layout .table-result > div, .-emu-layout body.-emu .dice-so-nice section.content .settings-list .sfxs-list .sfx > div, body.-emu .dice-so-nice section.content .settings-list .sfxs-list .-emu-layout .sfx > div {
-      align-items: center;
-      display: flex;
-      height: auto;
-      line-height: initial;
-      margin: 0;
-      padding: 0;
-      -webkit-padding-start: var(--emu-space-base);
-              padding-inline-start: var(--emu-space-base); }
-      .-emu-layout body.-emu .sheet.active-effect-sheet .changes-list li > div:first-of-type, body.-emu .sheet.active-effect-sheet .changes-list .-emu-layout li > div:first-of-type, .-emu-layout body.-emu .sheet.roll-table-config .table-results .table-result > div:first-of-type, body.-emu .sheet.roll-table-config .table-results .-emu-layout .table-result > div:first-of-type, .-emu-layout body.-emu .dice-so-nice section.content .settings-list .sfxs-list .sfx > div:first-of-type, body.-emu .dice-so-nice section.content .settings-list .sfxs-list .-emu-layout .sfx > div:first-of-type {
-        -webkit-padding-start: 0;
-                padding-inline-start: 0; }
-  body.-emu .sheet.active-effect-sheet .changes-list li a, body.-emu .sheet.roll-table-config .table-results .table-result a, body.-emu .dice-so-nice section.content .settings-list .sfxs-list .sfx a {
-    color: rgba(var(--color-text), 1); }
-    .-emu-layout body.-emu .sheet.active-effect-sheet .changes-list li a, body.-emu .sheet.active-effect-sheet .changes-list .-emu-layout li a, .-emu-layout body.-emu .sheet.roll-table-config .table-results .table-result a, body.-emu .sheet.roll-table-config .table-results .-emu-layout .table-result a, .-emu-layout body.-emu .dice-so-nice section.content .settings-list .sfxs-list .sfx a, body.-emu .dice-so-nice section.content .settings-list .sfxs-list .-emu-layout .sfx a {
-      color: rgba(var(--color-text), 1); }
+  border: none;
+}
+.-emu-layout body.-emu .sheet.active-effect-sheet .changes-list li,
+body.-emu .sheet.active-effect-sheet .changes-list .-emu-layout li,
+.-emu-layout body.-emu .sheet.roll-table-config .table-results .table-result,
+body.-emu .sheet.roll-table-config .table-results .-emu-layout .table-result,
+.-emu-layout
+  body.-emu
+  .dice-so-nice
+  section.content
+  .settings-list
+  .sfxs-list
+  .sfx,
+body.-emu
+  .dice-so-nice
+  section.content
+  .settings-list
+  .sfxs-list
+  .-emu-layout
+  .sfx {
+  height: auto;
+  padding: var(--emu-space-sm);
+}
+.-emu-layout body.-emu .sheet.active-effect-sheet .changes-list li > div,
+body.-emu .sheet.active-effect-sheet .changes-list .-emu-layout li > div,
+.-emu-layout
+  body.-emu
+  .sheet.roll-table-config
+  .table-results
+  .table-result
+  > div,
+body.-emu
+  .sheet.roll-table-config
+  .table-results
+  .-emu-layout
+  .table-result
+  > div,
+.-emu-layout
+  body.-emu
+  .dice-so-nice
+  section.content
+  .settings-list
+  .sfxs-list
+  .sfx
+  > div,
+body.-emu
+  .dice-so-nice
+  section.content
+  .settings-list
+  .sfxs-list
+  .-emu-layout
+  .sfx
+  > div {
+  align-items: center;
+  display: flex;
+  height: auto;
+  line-height: initial;
+  margin: 0;
+  padding: 0;
+  -webkit-padding-start: var(--emu-space-base);
+  padding-inline-start: var(--emu-space-base);
+}
+.-emu-layout
+  body.-emu
+  .sheet.active-effect-sheet
+  .changes-list
+  li
+  > div:first-of-type,
+body.-emu
+  .sheet.active-effect-sheet
+  .changes-list
+  .-emu-layout
+  li
+  > div:first-of-type,
+.-emu-layout
+  body.-emu
+  .sheet.roll-table-config
+  .table-results
+  .table-result
+  > div:first-of-type,
+body.-emu
+  .sheet.roll-table-config
+  .table-results
+  .-emu-layout
+  .table-result
+  > div:first-of-type,
+.-emu-layout
+  body.-emu
+  .dice-so-nice
+  section.content
+  .settings-list
+  .sfxs-list
+  .sfx
+  > div:first-of-type,
+body.-emu
+  .dice-so-nice
+  section.content
+  .settings-list
+  .sfxs-list
+  .-emu-layout
+  .sfx
+  > div:first-of-type {
+  -webkit-padding-start: 0;
+  padding-inline-start: 0;
+}
+body.-emu .sheet.active-effect-sheet .changes-list li a,
+body.-emu .sheet.roll-table-config .table-results .table-result a,
+body.-emu .dice-so-nice section.content .settings-list .sfxs-list .sfx a {
+  color: rgba(var(--color-text), 1);
+}
+.-emu-layout body.-emu .sheet.active-effect-sheet .changes-list li a,
+body.-emu .sheet.active-effect-sheet .changes-list .-emu-layout li a,
+.-emu-layout body.-emu .sheet.roll-table-config .table-results .table-result a,
+body.-emu .sheet.roll-table-config .table-results .-emu-layout .table-result a,
+.-emu-layout
+  body.-emu
+  .dice-so-nice
+  section.content
+  .settings-list
+  .sfxs-list
+  .sfx
+  a,
+body.-emu
+  .dice-so-nice
+  section.content
+  .settings-list
+  .sfxs-list
+  .-emu-layout
+  .sfx
+  a {
+  color: rgba(var(--color-text), 1);
+}
 
 body.-emu .dialog .tabs,
 body.-emu .dialog .sheet-tabs,
 body.-emu #sidebar .tabs,
 body.-emu #sidebar .sheet-tabs,
 body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .tabs,
-body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .sheet-tabs, body.-emu #module-management .list-filters {
+body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .sheet-tabs,
+body.-emu #module-management .list-filters {
   -webkit-border-before: none;
-          border-block-start: none;
+  border-block-start: none;
   -webkit-border-after: rgba(var(--color-primary), 1) 2px solid;
-          border-block-end: rgba(var(--color-primary), 1) 2px solid; }
-  .-emu-layout body.-emu .dialog .tabs, body.-emu .dialog .-emu-layout .tabs,
-  .-emu-layout body.-emu .dialog .sheet-tabs, body.-emu .dialog .-emu-layout .sheet-tabs,
-  .-emu-layout body.-emu #sidebar .tabs, body.-emu #sidebar .-emu-layout .tabs,
-  .-emu-layout body.-emu #sidebar .sheet-tabs, body.-emu #sidebar .-emu-layout .sheet-tabs,
-  .-emu-layout body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .tabs, body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .-emu-layout .tabs,
-  .-emu-layout body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .sheet-tabs, body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .-emu-layout .sheet-tabs, .-emu-layout body.-emu #module-management .list-filters, body.-emu #module-management .-emu-layout .list-filters {
-    display: flex;
-    flex: 0 0 auto;
-    height: initial;
-    line-height: initial;
-    margin: 0;
-    position: relative; }
-  body.-emu .dialog .tabs a, body.-emu .dialog .sheet-tabs a, body.-emu #sidebar .tabs a, body.-emu #sidebar .sheet-tabs a, body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .tabs a, body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .sheet-tabs a, body.-emu #module-management .list-filters a {
-    background-color: transparent;
-    background-image: none;
-    border-radius: var(--emu-border-radius-default, 0) var(--emu-border-radius-default, 0) 0 0;
-    color: rgba(var(--color-text), 1); }
-    .-emu-layout body.-emu .dialog .tabs a, body.-emu .dialog .-emu-layout .tabs a, .-emu-layout body.-emu .dialog .sheet-tabs a, body.-emu .dialog .-emu-layout .sheet-tabs a, .-emu-layout body.-emu #sidebar .tabs a, body.-emu #sidebar .-emu-layout .tabs a, .-emu-layout body.-emu #sidebar .sheet-tabs a, body.-emu #sidebar .-emu-layout .sheet-tabs a, .-emu-layout body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .tabs a, body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .-emu-layout .tabs a, .-emu-layout body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .sheet-tabs a, body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .-emu-layout .sheet-tabs a, .-emu-layout body.-emu #module-management .list-filters a, body.-emu #module-management .-emu-layout .list-filters a {
-      flex: 1;
-      font-size: var(--emu-font-size-md);
-      font-weight: normal;
-      text-shadow: none; }
-    .-emu-layout body.-emu .dialog .tabs a.active, body.-emu .dialog .-emu-layout .tabs a.active, .-emu-layout body.-emu .dialog .sheet-tabs a.active, body.-emu .dialog .-emu-layout .sheet-tabs a.active, .-emu-layout body.-emu #sidebar .tabs a.active, body.-emu #sidebar .-emu-layout .tabs a.active, .-emu-layout body.-emu #sidebar .sheet-tabs a.active, body.-emu #sidebar .-emu-layout .sheet-tabs a.active, .-emu-layout body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .tabs a.active, body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .-emu-layout .tabs a.active, .-emu-layout body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .sheet-tabs a.active, body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .-emu-layout .sheet-tabs a.active, .-emu-layout body.-emu #module-management .list-filters a.active, body.-emu #module-management .-emu-layout .list-filters a.active {
-      text-decoration: none; }
+  border-block-end: rgba(var(--color-primary), 1) 2px solid;
+}
+.-emu-layout body.-emu .dialog .tabs,
+body.-emu .dialog .-emu-layout .tabs,
+.-emu-layout body.-emu .dialog .sheet-tabs,
+body.-emu .dialog .-emu-layout .sheet-tabs,
+.-emu-layout body.-emu #sidebar .tabs,
+body.-emu #sidebar .-emu-layout .tabs,
+.-emu-layout body.-emu #sidebar .sheet-tabs,
+body.-emu #sidebar .-emu-layout .sheet-tabs,
+.-emu-layout body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .tabs,
+body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .-emu-layout .tabs,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .sheet-tabs,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .-emu-layout
+  .sheet-tabs,
+.-emu-layout body.-emu #module-management .list-filters,
+body.-emu #module-management .-emu-layout .list-filters {
+  display: flex;
+  flex: 0 0 auto;
+  height: initial;
+  line-height: initial;
+  margin: 0;
+  position: relative;
+}
+body.-emu .dialog .tabs a,
+body.-emu .dialog .sheet-tabs a,
+body.-emu #sidebar .tabs a,
+body.-emu #sidebar .sheet-tabs a,
+body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .tabs a,
+body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .sheet-tabs a,
+body.-emu #module-management .list-filters a {
+  background-color: transparent;
+  background-image: none;
+  border-radius: var(--emu-border-radius-default, 0)
+    var(--emu-border-radius-default, 0) 0 0;
+  color: rgba(var(--color-text), 1);
+}
+.-emu-layout body.-emu .dialog .tabs a,
+body.-emu .dialog .-emu-layout .tabs a,
+.-emu-layout body.-emu .dialog .sheet-tabs a,
+body.-emu .dialog .-emu-layout .sheet-tabs a,
+.-emu-layout body.-emu #sidebar .tabs a,
+body.-emu #sidebar .-emu-layout .tabs a,
+.-emu-layout body.-emu #sidebar .sheet-tabs a,
+body.-emu #sidebar .-emu-layout .sheet-tabs a,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .tabs
+  a,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .-emu-layout
+  .tabs
+  a,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .sheet-tabs
+  a,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .-emu-layout
+  .sheet-tabs
+  a,
+.-emu-layout body.-emu #module-management .list-filters a,
+body.-emu #module-management .-emu-layout .list-filters a {
+  flex: 1;
+  font-size: var(--emu-font-size-md);
+  font-weight: normal;
+  text-shadow: none;
+}
+.-emu-layout body.-emu .dialog .tabs a.active,
+body.-emu .dialog .-emu-layout .tabs a.active,
+.-emu-layout body.-emu .dialog .sheet-tabs a.active,
+body.-emu .dialog .-emu-layout .sheet-tabs a.active,
+.-emu-layout body.-emu #sidebar .tabs a.active,
+body.-emu #sidebar .-emu-layout .tabs a.active,
+.-emu-layout body.-emu #sidebar .sheet-tabs a.active,
+body.-emu #sidebar .-emu-layout .sheet-tabs a.active,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .tabs
+  a.active,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .-emu-layout
+  .tabs
+  a.active,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .sheet-tabs
+  a.active,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .-emu-layout
+  .sheet-tabs
+  a.active,
+.-emu-layout body.-emu #module-management .list-filters a.active,
+body.-emu #module-management .-emu-layout .list-filters a.active {
+  text-decoration: none;
+}
 
-.-emu-layout body.-emu .dialog .directory .directory-item h3 > i, body.-emu .dialog .directory .directory-item .-emu-layout h3 > i, .-emu-layout body.-emu .dialog .directory .directory-item h4 > i, body.-emu .dialog .directory .directory-item .-emu-layout h4 > i, .-emu-layout body.-emu #sidebar .directory .directory-item h3 > i, body.-emu #sidebar .directory .directory-item .-emu-layout h3 > i, .-emu-layout body.-emu #sidebar .directory .directory-item h4 > i, body.-emu #sidebar .directory .directory-item .-emu-layout h4 > i, .-emu-layout body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .directory .directory-item h3 > i, body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .directory .directory-item .-emu-layout h3 > i, .-emu-layout body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .directory .directory-item h4 > i, body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .directory .directory-item .-emu-layout h4 > i, .-emu-layout body.-emu .dialog .directory .directory-item.folder .folder-header h3 > i, body.-emu .dialog .directory .directory-item.folder .folder-header .-emu-layout h3 > i, .-emu-layout body.-emu #sidebar .directory .directory-item.folder .folder-header h3 > i, body.-emu #sidebar .directory .directory-item.folder .folder-header .-emu-layout h3 > i, .-emu-layout body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .directory .directory-item.folder .folder-header h3 > i, body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .directory .directory-item.folder .folder-header .-emu-layout h3 > i, .-emu-layout body.-emu #context-menu ol.context-items .context-item > i, body.-emu #context-menu ol.context-items .-emu-layout .context-item > i, .-emu-layout body.-emu #sidebar .sidebar-tab .directory-header .header-search > i, .-emu-layout body.-emu .sidebar-popout .sidebar-tab .directory-header .header-search > i {
+.-emu-layout body.-emu .dialog .directory .directory-item h3 > i,
+body.-emu .dialog .directory .directory-item .-emu-layout h3 > i,
+.-emu-layout body.-emu .dialog .directory .directory-item h4 > i,
+body.-emu .dialog .directory .directory-item .-emu-layout h4 > i,
+.-emu-layout body.-emu #sidebar .directory .directory-item h3 > i,
+body.-emu #sidebar .directory .directory-item .-emu-layout h3 > i,
+.-emu-layout body.-emu #sidebar .directory .directory-item h4 > i,
+body.-emu #sidebar .directory .directory-item .-emu-layout h4 > i,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .directory
+  .directory-item
+  h3
+  > i,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .directory
+  .directory-item
+  .-emu-layout
+  h3
+  > i,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .directory
+  .directory-item
+  h4
+  > i,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .directory
+  .directory-item
+  .-emu-layout
+  h4
+  > i,
+.-emu-layout
+  body.-emu
+  .dialog
+  .directory
+  .directory-item.folder
+  .folder-header
+  h3
+  > i,
+body.-emu
+  .dialog
+  .directory
+  .directory-item.folder
+  .folder-header
+  .-emu-layout
+  h3
+  > i,
+.-emu-layout
+  body.-emu
+  #sidebar
+  .directory
+  .directory-item.folder
+  .folder-header
+  h3
+  > i,
+body.-emu
+  #sidebar
+  .directory
+  .directory-item.folder
+  .folder-header
+  .-emu-layout
+  h3
+  > i,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .directory
+  .directory-item.folder
+  .folder-header
+  h3
+  > i,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .directory
+  .directory-item.folder
+  .folder-header
+  .-emu-layout
+  h3
+  > i,
+.-emu-layout body.-emu #context-menu ol.context-items .context-item > i,
+body.-emu #context-menu ol.context-items .-emu-layout .context-item > i,
+.-emu-layout
+  body.-emu
+  #sidebar
+  .sidebar-tab
+  .directory-header
+  .header-search
+  > i,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  .sidebar-tab
+  .directory-header
+  .header-search
+  > i {
   -webkit-margin-end: var(--emu-space-sm);
-          margin-inline-end: var(--emu-space-sm); }
+  margin-inline-end: var(--emu-space-sm);
+}
 
-.-emu-layout body.-emu .dialog .directory .directory-list, .-emu-layout body.-emu #sidebar .directory .directory-list, .-emu-layout body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .directory .directory-list, .-emu-layout body.-emu .dialog .directory .directory-item.folder .subdirectory, .-emu-layout body.-emu #sidebar .directory .directory-item.folder .subdirectory, .-emu-layout body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .directory .directory-item.folder .subdirectory, .-emu-layout body.-emu #context-menu ol.context-items, .-emu-layout body.-emu #hotbar #macro-list, .-emu-layout body.-emu #menu #menu-items, .-emu-layout body.-emu #notifications, .-emu-layout body.-emu #players > ol, .-emu-layout body.-emu #controls, .-emu-layout body.-emu #controls .control-tools, .-emu-layout body.-emu #navigation #scene-list, .-emu-layout body.-emu #navigation .scene-list, .-emu-layout body.-emu #sidebar #playlists .global-control.collapsed .playlist-sounds, .-emu-layout body.-emu .sidebar-popout #playlists .global-control.collapsed .playlist-sounds, .-emu-layout body.-emu #sidebar #playlists .global-control .playlist-sounds, .-emu-layout body.-emu .sidebar-popout #playlists .global-control .playlist-sounds, .-emu-layout body.-emu .filepicker.window-app .directory, .-emu-layout body.-emu #df-curvy-walls-tools .control-tools, .-emu-layout body.-emu .active-effect-sheet[id*="ActiveEffectsConfig-"] .special-duration-list, .-emu-layout body.-emu ul.command-menu, .-emu-layout body.-emu .thandulTogglables, .-emu-layout body.-emu #tokenAttacher .control-tools {
+.-emu-layout body.-emu .dialog .directory .directory-list,
+.-emu-layout body.-emu #sidebar .directory .directory-list,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .directory
+  .directory-list,
+.-emu-layout body.-emu .dialog .directory .directory-item.folder .subdirectory,
+.-emu-layout body.-emu #sidebar .directory .directory-item.folder .subdirectory,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .directory
+  .directory-item.folder
+  .subdirectory,
+.-emu-layout body.-emu #context-menu ol.context-items,
+.-emu-layout body.-emu #hotbar #macro-list,
+.-emu-layout body.-emu #menu #menu-items,
+.-emu-layout body.-emu #notifications,
+.-emu-layout body.-emu #players > ol,
+.-emu-layout body.-emu #controls,
+.-emu-layout body.-emu #controls .control-tools,
+.-emu-layout body.-emu #navigation #scene-list,
+.-emu-layout body.-emu #navigation .scene-list,
+.-emu-layout
+  body.-emu
+  #sidebar
+  #playlists
+  .global-control.collapsed
+  .playlist-sounds,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #playlists
+  .global-control.collapsed
+  .playlist-sounds,
+.-emu-layout body.-emu #sidebar #playlists .global-control .playlist-sounds,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #playlists
+  .global-control
+  .playlist-sounds,
+.-emu-layout body.-emu .filepicker.window-app .directory,
+.-emu-layout body.-emu #df-curvy-walls-tools .control-tools,
+.-emu-layout
+  body.-emu
+  .active-effect-sheet[id*="ActiveEffectsConfig-"]
+  .special-duration-list,
+.-emu-layout body.-emu ul.command-menu,
+.-emu-layout body.-emu .thandulTogglables,
+.-emu-layout body.-emu #tokenAttacher .control-tools {
   list-style: none;
   margin: 0;
-  padding: 0; }
+  padding: 0;
+}
 
-.-emu-layout.-emu-subtle-layout body.-emu #sidebar #emu-sidebar-lock, .-emu-layout body.-emu #sidebar #chat #chat-controls .chat-control-icon .fa-dice-d20, .-emu-layout body.-emu .sidebar-popout #chat #chat-controls .chat-control-icon .fa-dice-d20, .-emu-layout body.-emu #sidebar #combat #combat-tracker .combatant .combatant-control.roll, .-emu-layout body.-emu .sidebar-popout #combat #combat-tracker .combatant .combatant-control.roll, body.-emu .window-app[id*="chat-popout-"] .chat-message .chat-card .die-result-overlay-br button,
-body.-emu #sidebar #chat #chat-log .chat-message .chat-card .die-result-overlay-br button, .-emu-layout body.-emu .window-app.token-mold .window-content form select.icon.fas.fa {
+.-emu-layout.-emu-subtle-layout body.-emu #sidebar #emu-sidebar-lock,
+.-emu-layout
+  body.-emu
+  #sidebar
+  #chat
+  #chat-controls
+  .chat-control-icon
+  .fa-dice-d20,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #chat
+  #chat-controls
+  .chat-control-icon
+  .fa-dice-d20,
+.-emu-layout
+  body.-emu
+  #sidebar
+  #combat
+  #combat-tracker
+  .combatant
+  .combatant-control.roll,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #combat
+  #combat-tracker
+  .combatant
+  .combatant-control.roll,
+body.-emu
+  .window-app[id*="chat-popout-"]
+  .chat-message
+  .chat-card
+  .die-result-overlay-br
+  button,
+body.-emu
+  #sidebar
+  #chat
+  #chat-log
+  .chat-message
+  .chat-card
+  .die-result-overlay-br
+  button,
+.-emu-layout
+  body.-emu
+  .window-app.token-mold
+  .window-content
+  form
+  select.icon.fas.fa {
   font-family: "Font Awesome 5 Free";
   font-weight: 900;
   -webkit-font-smoothing: antialiased;
   font-style: normal;
   font-variant: normal;
   text-rendering: auto;
-  line-height: 1; }
+  line-height: 1;
+}
 
 body.-emu #sidebar #chat #icNotification,
 body.-emu #sidebar #chat #rollsNotification,
@@ -947,69 +6483,292 @@ body.-emu .sidebar-popout #chat #icNotification,
 body.-emu .sidebar-popout #chat #rollsNotification,
 body.-emu .sidebar-popout #chat #oocNotification {
   -webkit-animation-duration: 0.8s;
-          animation-duration: 0.8s;
+  animation-duration: 0.8s;
   -webkit-animation-iteration-count: infinite;
-          animation-iteration-count: infinite;
+  animation-iteration-count: infinite;
   -webkit-animation-name: emu-notification-flash;
-          animation-name: emu-notification-flash;
+  animation-name: emu-notification-flash;
   -webkit-animation-timing-function: cubic-bezier(0.77, 0, 0.175, 1);
-          animation-timing-function: cubic-bezier(0.77, 0, 0.175, 1);
+  animation-timing-function: cubic-bezier(0.77, 0, 0.175, 1);
   background-color: rgba(var(--color-primary), 1);
   display: none;
   opacity: 0;
   pointer-events: none;
-  z-index: 0; }
+  z-index: 0;
+}
 
-.-emu-layout body.-emu .window-app[id*="actor-flags-"] .window-content, body.-emu .-emu-layout .window-app[id*="actor-flags-"] .window-content, .-emu-layout body.-emu #default-token-config .window-content, body.-emu .-emu-layout #default-token-config .window-content, .-emu-layout body.-emu #drawing-config .window-content, body.-emu .-emu-layout #drawing-config .window-content, .-emu-layout body.-emu .sheet.scene-sheet .window-content, body.-emu .-emu-layout .sheet.scene-sheet .window-content, .-emu-layout body.-emu .window-app.sheet[id*="template-config"] .window-content, body.-emu .-emu-layout .window-app.sheet[id*="template-config"] .window-content, .-emu-layout body.-emu #wall-config .window-content, body.-emu .-emu-layout #wall-config .window-content, .-emu-layout body.-emu #healthestimate-style-form .window-content, body.-emu .-emu-layout #healthestimate-style-form .window-content, .-emu-layout body.-emu #midi-qol-settings .window-content, body.-emu .-emu-layout #midi-qol-settings .window-content, .-emu-layout body.-emu #mountup-settings-form .window-content, body.-emu .-emu-layout #mountup-settings-form .window-content, .-emu-layout body.-emu #narrator-config .window-content, body.-emu .-emu-layout #narrator-config .window-content, .-emu-layout body.-emu #turnmarker-settings-form .window-content, body.-emu .-emu-layout #turnmarker-settings-form .window-content {
-  padding: 0; }
+.-emu-layout body.-emu .window-app[id*="actor-flags-"] .window-content,
+body.-emu .-emu-layout .window-app[id*="actor-flags-"] .window-content,
+.-emu-layout body.-emu #default-token-config .window-content,
+body.-emu .-emu-layout #default-token-config .window-content,
+.-emu-layout body.-emu #drawing-config .window-content,
+body.-emu .-emu-layout #drawing-config .window-content,
+.-emu-layout body.-emu .sheet.scene-sheet .window-content,
+body.-emu .-emu-layout .sheet.scene-sheet .window-content,
+.-emu-layout body.-emu .window-app.sheet[id*="template-config"] .window-content,
+body.-emu .-emu-layout .window-app.sheet[id*="template-config"] .window-content,
+.-emu-layout body.-emu #wall-config .window-content,
+body.-emu .-emu-layout #wall-config .window-content,
+.-emu-layout body.-emu #healthestimate-style-form .window-content,
+body.-emu .-emu-layout #healthestimate-style-form .window-content,
+.-emu-layout body.-emu #midi-qol-settings .window-content,
+body.-emu .-emu-layout #midi-qol-settings .window-content,
+.-emu-layout body.-emu #mountup-settings-form .window-content,
+body.-emu .-emu-layout #mountup-settings-form .window-content,
+.-emu-layout body.-emu #narrator-config .window-content,
+body.-emu .-emu-layout #narrator-config .window-content,
+.-emu-layout body.-emu #turnmarker-settings-form .window-content,
+body.-emu .-emu-layout #turnmarker-settings-form .window-content {
+  padding: 0;
+}
 
-.-emu-layout body.-emu .window-app[id*="actor-flags-"] form, body.-emu .-emu-layout .window-app[id*="actor-flags-"] form, .-emu-layout body.-emu #default-token-config form, body.-emu .-emu-layout #default-token-config form, .-emu-layout body.-emu #drawing-config form, body.-emu .-emu-layout #drawing-config form, .-emu-layout body.-emu .sheet.scene-sheet form, body.-emu .-emu-layout .sheet.scene-sheet form, .-emu-layout body.-emu .window-app.sheet[id*="template-config"] form, body.-emu .-emu-layout .window-app.sheet[id*="template-config"] form, .-emu-layout body.-emu #wall-config form, body.-emu .-emu-layout #wall-config form, .-emu-layout body.-emu #healthestimate-style-form form, body.-emu .-emu-layout #healthestimate-style-form form, .-emu-layout body.-emu #midi-qol-settings form, body.-emu .-emu-layout #midi-qol-settings form, .-emu-layout body.-emu #mountup-settings-form form, body.-emu .-emu-layout #mountup-settings-form form, .-emu-layout body.-emu #narrator-config form, body.-emu .-emu-layout #narrator-config form, .-emu-layout body.-emu #turnmarker-settings-form form, body.-emu .-emu-layout #turnmarker-settings-form form {
+.-emu-layout body.-emu .window-app[id*="actor-flags-"] form,
+body.-emu .-emu-layout .window-app[id*="actor-flags-"] form,
+.-emu-layout body.-emu #default-token-config form,
+body.-emu .-emu-layout #default-token-config form,
+.-emu-layout body.-emu #drawing-config form,
+body.-emu .-emu-layout #drawing-config form,
+.-emu-layout body.-emu .sheet.scene-sheet form,
+body.-emu .-emu-layout .sheet.scene-sheet form,
+.-emu-layout body.-emu .window-app.sheet[id*="template-config"] form,
+body.-emu .-emu-layout .window-app.sheet[id*="template-config"] form,
+.-emu-layout body.-emu #wall-config form,
+body.-emu .-emu-layout #wall-config form,
+.-emu-layout body.-emu #healthestimate-style-form form,
+body.-emu .-emu-layout #healthestimate-style-form form,
+.-emu-layout body.-emu #midi-qol-settings form,
+body.-emu .-emu-layout #midi-qol-settings form,
+.-emu-layout body.-emu #mountup-settings-form form,
+body.-emu .-emu-layout #mountup-settings-form form,
+.-emu-layout body.-emu #narrator-config form,
+body.-emu .-emu-layout #narrator-config form,
+.-emu-layout body.-emu #turnmarker-settings-form form,
+body.-emu .-emu-layout #turnmarker-settings-form form {
   display: flex;
   flex: 1 1 auto;
   flex-direction: column;
   height: 100%;
   padding: var(--emu-space-sm);
-  position: relative; }
+  position: relative;
+}
 
-.-emu-layout body.-emu .window-app[id*="actor-flags-"] .window-content, body.-emu .-emu-layout .window-app[id*="actor-flags-"] .window-content, .-emu-layout body.-emu #default-token-config .window-content, body.-emu .-emu-layout #default-token-config .window-content, .-emu-layout body.-emu .sheet.scene-sheet .window-content, body.-emu .-emu-layout .sheet.scene-sheet .window-content, .-emu-layout body.-emu .window-app.sheet[id*="template-config"] .window-content, body.-emu .-emu-layout .window-app.sheet[id*="template-config"] .window-content, .-emu-layout body.-emu #wall-config .window-content, body.-emu .-emu-layout #wall-config .window-content, .-emu-layout body.-emu #healthestimate-style-form .window-content, body.-emu .-emu-layout #healthestimate-style-form .window-content, .-emu-layout body.-emu #midi-qol-settings .window-content, body.-emu .-emu-layout #midi-qol-settings .window-content, .-emu-layout body.-emu #mountup-settings-form .window-content, body.-emu .-emu-layout #mountup-settings-form .window-content, .-emu-layout body.-emu #narrator-config .window-content, body.-emu .-emu-layout #narrator-config .window-content, .-emu-layout body.-emu #turnmarker-settings-form .window-content, body.-emu .-emu-layout #turnmarker-settings-form .window-content {
-  overflow: hidden; }
+.-emu-layout body.-emu .window-app[id*="actor-flags-"] .window-content,
+body.-emu .-emu-layout .window-app[id*="actor-flags-"] .window-content,
+.-emu-layout body.-emu #default-token-config .window-content,
+body.-emu .-emu-layout #default-token-config .window-content,
+.-emu-layout body.-emu .sheet.scene-sheet .window-content,
+body.-emu .-emu-layout .sheet.scene-sheet .window-content,
+.-emu-layout body.-emu .window-app.sheet[id*="template-config"] .window-content,
+body.-emu .-emu-layout .window-app.sheet[id*="template-config"] .window-content,
+.-emu-layout body.-emu #wall-config .window-content,
+body.-emu .-emu-layout #wall-config .window-content,
+.-emu-layout body.-emu #healthestimate-style-form .window-content,
+body.-emu .-emu-layout #healthestimate-style-form .window-content,
+.-emu-layout body.-emu #midi-qol-settings .window-content,
+body.-emu .-emu-layout #midi-qol-settings .window-content,
+.-emu-layout body.-emu #mountup-settings-form .window-content,
+body.-emu .-emu-layout #mountup-settings-form .window-content,
+.-emu-layout body.-emu #narrator-config .window-content,
+body.-emu .-emu-layout #narrator-config .window-content,
+.-emu-layout body.-emu #turnmarker-settings-form .window-content,
+body.-emu .-emu-layout #turnmarker-settings-form .window-content {
+  overflow: hidden;
+}
 
-.-emu-layout body.-emu .window-app[id*="actor-flags-"] form, body.-emu .-emu-layout .window-app[id*="actor-flags-"] form, .-emu-layout body.-emu #default-token-config form, body.-emu .-emu-layout #default-token-config form, .-emu-layout body.-emu .sheet.scene-sheet form, body.-emu .-emu-layout .sheet.scene-sheet form, .-emu-layout body.-emu .window-app.sheet[id*="template-config"] form, body.-emu .-emu-layout .window-app.sheet[id*="template-config"] form, .-emu-layout body.-emu #wall-config form, body.-emu .-emu-layout #wall-config form, .-emu-layout body.-emu #healthestimate-style-form form, body.-emu .-emu-layout #healthestimate-style-form form, .-emu-layout body.-emu #midi-qol-settings form, body.-emu .-emu-layout #midi-qol-settings form, .-emu-layout body.-emu #mountup-settings-form form, body.-emu .-emu-layout #mountup-settings-form form, .-emu-layout body.-emu #narrator-config form, body.-emu .-emu-layout #narrator-config form, .-emu-layout body.-emu #turnmarker-settings-form form, body.-emu .-emu-layout #turnmarker-settings-form form {
+.-emu-layout body.-emu .window-app[id*="actor-flags-"] form,
+body.-emu .-emu-layout .window-app[id*="actor-flags-"] form,
+.-emu-layout body.-emu #default-token-config form,
+body.-emu .-emu-layout #default-token-config form,
+.-emu-layout body.-emu .sheet.scene-sheet form,
+body.-emu .-emu-layout .sheet.scene-sheet form,
+.-emu-layout body.-emu .window-app.sheet[id*="template-config"] form,
+body.-emu .-emu-layout .window-app.sheet[id*="template-config"] form,
+.-emu-layout body.-emu #wall-config form,
+body.-emu .-emu-layout #wall-config form,
+.-emu-layout body.-emu #healthestimate-style-form form,
+body.-emu .-emu-layout #healthestimate-style-form form,
+.-emu-layout body.-emu #midi-qol-settings form,
+body.-emu .-emu-layout #midi-qol-settings form,
+.-emu-layout body.-emu #mountup-settings-form form,
+body.-emu .-emu-layout #mountup-settings-form form,
+.-emu-layout body.-emu #narrator-config form,
+body.-emu .-emu-layout #narrator-config form,
+.-emu-layout body.-emu #turnmarker-settings-form form,
+body.-emu .-emu-layout #turnmarker-settings-form form {
   overflow-x: hidden;
-  overflow-y: auto; }
+  overflow-y: auto;
+}
 
-body.-emu .window-app[id*="actor-flags-"] form::after, body.-emu #default-token-config form::after, body.-emu .sheet.scene-sheet form::after, body.-emu .window-app.sheet[id*="template-config"] form::after, body.-emu #wall-config form::after, body.-emu #healthestimate-style-form form::after, body.-emu #midi-qol-settings form::after, body.-emu #mountup-settings-form form::after, body.-emu #narrator-config form::after, body.-emu #turnmarker-settings-form form::after {
+body.-emu .window-app[id*="actor-flags-"] form::after,
+body.-emu #default-token-config form::after,
+body.-emu .sheet.scene-sheet form::after,
+body.-emu .window-app.sheet[id*="template-config"] form::after,
+body.-emu #wall-config form::after,
+body.-emu #healthestimate-style-form form::after,
+body.-emu #midi-qol-settings form::after,
+body.-emu #mountup-settings-form form::after,
+body.-emu #narrator-config form::after,
+body.-emu #turnmarker-settings-form form::after {
   background-color: rgba(var(--color-background-lightest), 1);
   background-image: var(--emu-image-background-light, none);
   -webkit-border-before: 1px solid rgba(var(--color-border), 1);
-          border-block-start: 1px solid rgba(var(--color-border), 1); }
-  .-emu-layout body.-emu .window-app[id*="actor-flags-"] form::after, body.-emu .-emu-layout .window-app[id*="actor-flags-"] form::after, .-emu-layout body.-emu #default-token-config form::after, body.-emu .-emu-layout #default-token-config form::after, .-emu-layout body.-emu .sheet.scene-sheet form::after, body.-emu .-emu-layout .sheet.scene-sheet form::after, .-emu-layout body.-emu .window-app.sheet[id*="template-config"] form::after, body.-emu .-emu-layout .window-app.sheet[id*="template-config"] form::after, .-emu-layout body.-emu #wall-config form::after, body.-emu .-emu-layout #wall-config form::after, .-emu-layout body.-emu #healthestimate-style-form form::after, body.-emu .-emu-layout #healthestimate-style-form form::after, .-emu-layout body.-emu #midi-qol-settings form::after, body.-emu .-emu-layout #midi-qol-settings form::after, .-emu-layout body.-emu #mountup-settings-form form::after, body.-emu .-emu-layout #mountup-settings-form form::after, .-emu-layout body.-emu #narrator-config form::after, body.-emu .-emu-layout #narrator-config form::after, .-emu-layout body.-emu #turnmarker-settings-form form::after, body.-emu .-emu-layout #turnmarker-settings-form form::after {
-    bottom: calc(-1 * var(--emu-space-sm));
-    content: "";
-    flex: 0 0 auto;
-    height: 2.875rem;
-    -webkit-margin-before: -2.375rem;
-            margin-block-start: -2.375rem;
-    position: -webkit-sticky;
-    position: sticky;
-    width: 100%;
-    z-index: 5; }
-  .-emu-layout.-emu-compact body.-emu .window-app[id*="actor-flags-"] form::after, body.-emu .-emu-layout.-emu-compact .window-app[id*="actor-flags-"] form::after, .-emu-layout.-emu-compact body.-emu #default-token-config form::after, body.-emu .-emu-layout.-emu-compact #default-token-config form::after, .-emu-layout.-emu-compact body.-emu .sheet.scene-sheet form::after, body.-emu .-emu-layout.-emu-compact .sheet.scene-sheet form::after, .-emu-layout.-emu-compact body.-emu .window-app.sheet[id*="template-config"] form::after, body.-emu .-emu-layout.-emu-compact .window-app.sheet[id*="template-config"] form::after, .-emu-layout.-emu-compact body.-emu #wall-config form::after, body.-emu .-emu-layout.-emu-compact #wall-config form::after, .-emu-layout.-emu-compact body.-emu #healthestimate-style-form form::after, body.-emu .-emu-layout.-emu-compact #healthestimate-style-form form::after, .-emu-layout.-emu-compact body.-emu #midi-qol-settings form::after, body.-emu .-emu-layout.-emu-compact #midi-qol-settings form::after, .-emu-layout.-emu-compact body.-emu #mountup-settings-form form::after, body.-emu .-emu-layout.-emu-compact #mountup-settings-form form::after, .-emu-layout.-emu-compact body.-emu #narrator-config form::after, body.-emu .-emu-layout.-emu-compact #narrator-config form::after, .-emu-layout.-emu-compact body.-emu #turnmarker-settings-form form::after, body.-emu .-emu-layout.-emu-compact #turnmarker-settings-form form::after {
-    height: 2.375rem;
-    -webkit-margin-before: -1.875rem;
-            margin-block-start: -1.875rem; }
+  border-block-start: 1px solid rgba(var(--color-border), 1);
+}
+.-emu-layout body.-emu .window-app[id*="actor-flags-"] form::after,
+body.-emu .-emu-layout .window-app[id*="actor-flags-"] form::after,
+.-emu-layout body.-emu #default-token-config form::after,
+body.-emu .-emu-layout #default-token-config form::after,
+.-emu-layout body.-emu .sheet.scene-sheet form::after,
+body.-emu .-emu-layout .sheet.scene-sheet form::after,
+.-emu-layout body.-emu .window-app.sheet[id*="template-config"] form::after,
+body.-emu .-emu-layout .window-app.sheet[id*="template-config"] form::after,
+.-emu-layout body.-emu #wall-config form::after,
+body.-emu .-emu-layout #wall-config form::after,
+.-emu-layout body.-emu #healthestimate-style-form form::after,
+body.-emu .-emu-layout #healthestimate-style-form form::after,
+.-emu-layout body.-emu #midi-qol-settings form::after,
+body.-emu .-emu-layout #midi-qol-settings form::after,
+.-emu-layout body.-emu #mountup-settings-form form::after,
+body.-emu .-emu-layout #mountup-settings-form form::after,
+.-emu-layout body.-emu #narrator-config form::after,
+body.-emu .-emu-layout #narrator-config form::after,
+.-emu-layout body.-emu #turnmarker-settings-form form::after,
+body.-emu .-emu-layout #turnmarker-settings-form form::after {
+  bottom: calc(-1 * var(--emu-space-sm));
+  content: "";
+  flex: 0 0 auto;
+  height: 2.875rem;
+  -webkit-margin-before: -2.375rem;
+  margin-block-start: -2.375rem;
+  position: -webkit-sticky;
+  position: sticky;
+  width: 100%;
+  z-index: 5;
+}
+.-emu-layout.-emu-compact body.-emu .window-app[id*="actor-flags-"] form::after,
+body.-emu .-emu-layout.-emu-compact .window-app[id*="actor-flags-"] form::after,
+.-emu-layout.-emu-compact body.-emu #default-token-config form::after,
+body.-emu .-emu-layout.-emu-compact #default-token-config form::after,
+.-emu-layout.-emu-compact body.-emu .sheet.scene-sheet form::after,
+body.-emu .-emu-layout.-emu-compact .sheet.scene-sheet form::after,
+.-emu-layout.-emu-compact
+  body.-emu
+  .window-app.sheet[id*="template-config"]
+  form::after,
+body.-emu
+  .-emu-layout.-emu-compact
+  .window-app.sheet[id*="template-config"]
+  form::after,
+.-emu-layout.-emu-compact body.-emu #wall-config form::after,
+body.-emu .-emu-layout.-emu-compact #wall-config form::after,
+.-emu-layout.-emu-compact body.-emu #healthestimate-style-form form::after,
+body.-emu .-emu-layout.-emu-compact #healthestimate-style-form form::after,
+.-emu-layout.-emu-compact body.-emu #midi-qol-settings form::after,
+body.-emu .-emu-layout.-emu-compact #midi-qol-settings form::after,
+.-emu-layout.-emu-compact body.-emu #mountup-settings-form form::after,
+body.-emu .-emu-layout.-emu-compact #mountup-settings-form form::after,
+.-emu-layout.-emu-compact body.-emu #narrator-config form::after,
+body.-emu .-emu-layout.-emu-compact #narrator-config form::after,
+.-emu-layout.-emu-compact body.-emu #turnmarker-settings-form form::after,
+body.-emu .-emu-layout.-emu-compact #turnmarker-settings-form form::after {
+  height: 2.375rem;
+  -webkit-margin-before: -1.875rem;
+  margin-block-start: -1.875rem;
+}
 
-.-emu-layout body.-emu .window-app[id*="actor-flags-"] form .form-group:last-of-type, body.-emu .-emu-layout .window-app[id*="actor-flags-"] form .form-group:last-of-type, .-emu-layout body.-emu #default-token-config form .form-group:last-of-type, body.-emu .-emu-layout #default-token-config form .form-group:last-of-type, .-emu-layout body.-emu .sheet.scene-sheet form .form-group:last-of-type, body.-emu .-emu-layout .sheet.scene-sheet form .form-group:last-of-type, .-emu-layout body.-emu .window-app.sheet[id*="template-config"] form .form-group:last-of-type, body.-emu .-emu-layout .window-app.sheet[id*="template-config"] form .form-group:last-of-type, .-emu-layout body.-emu #wall-config form .form-group:last-of-type, body.-emu .-emu-layout #wall-config form .form-group:last-of-type, .-emu-layout body.-emu #healthestimate-style-form form .form-group:last-of-type, body.-emu .-emu-layout #healthestimate-style-form form .form-group:last-of-type, .-emu-layout body.-emu #midi-qol-settings form .form-group:last-of-type, body.-emu .-emu-layout #midi-qol-settings form .form-group:last-of-type, .-emu-layout body.-emu #mountup-settings-form form .form-group:last-of-type, body.-emu .-emu-layout #mountup-settings-form form .form-group:last-of-type, .-emu-layout body.-emu #narrator-config form .form-group:last-of-type, body.-emu .-emu-layout #narrator-config form .form-group:last-of-type, .-emu-layout body.-emu #turnmarker-settings-form form .form-group:last-of-type, body.-emu .-emu-layout #turnmarker-settings-form form .form-group:last-of-type {
+.-emu-layout
+  body.-emu
+  .window-app[id*="actor-flags-"]
+  form
+  .form-group:last-of-type,
+body.-emu
+  .-emu-layout
+  .window-app[id*="actor-flags-"]
+  form
+  .form-group:last-of-type,
+.-emu-layout body.-emu #default-token-config form .form-group:last-of-type,
+body.-emu .-emu-layout #default-token-config form .form-group:last-of-type,
+.-emu-layout body.-emu .sheet.scene-sheet form .form-group:last-of-type,
+body.-emu .-emu-layout .sheet.scene-sheet form .form-group:last-of-type,
+.-emu-layout
+  body.-emu
+  .window-app.sheet[id*="template-config"]
+  form
+  .form-group:last-of-type,
+body.-emu
+  .-emu-layout
+  .window-app.sheet[id*="template-config"]
+  form
+  .form-group:last-of-type,
+.-emu-layout body.-emu #wall-config form .form-group:last-of-type,
+body.-emu .-emu-layout #wall-config form .form-group:last-of-type,
+.-emu-layout body.-emu #healthestimate-style-form form .form-group:last-of-type,
+body.-emu .-emu-layout #healthestimate-style-form form .form-group:last-of-type,
+.-emu-layout body.-emu #midi-qol-settings form .form-group:last-of-type,
+body.-emu .-emu-layout #midi-qol-settings form .form-group:last-of-type,
+.-emu-layout body.-emu #mountup-settings-form form .form-group:last-of-type,
+body.-emu .-emu-layout #mountup-settings-form form .form-group:last-of-type,
+.-emu-layout body.-emu #narrator-config form .form-group:last-of-type,
+body.-emu .-emu-layout #narrator-config form .form-group:last-of-type,
+.-emu-layout body.-emu #turnmarker-settings-form form .form-group:last-of-type,
+body.-emu .-emu-layout #turnmarker-settings-form form .form-group:last-of-type {
   -webkit-margin-after: var(--emu-space-md);
-          margin-block-end: var(--emu-space-md); }
+  margin-block-end: var(--emu-space-md);
+}
 
-body.-emu .window-app[id*="actor-flags-"] form > button[type="submit"], body.-emu #default-token-config form > button[type="submit"], body.-emu .sheet.scene-sheet form > button[type="submit"], body.-emu .window-app.sheet[id*="template-config"] form > button[type="submit"], body.-emu #wall-config form > button[type="submit"], body.-emu #healthestimate-style-form form > button[type="submit"], body.-emu #midi-qol-settings form > button[type="submit"], body.-emu #mountup-settings-form form > button[type="submit"], body.-emu #narrator-config form > button[type="submit"], body.-emu #turnmarker-settings-form form > button[type="submit"] {
-  border-radius: var(--emu-border-radius-controls, 0); }
-  .-emu-layout body.-emu .window-app[id*="actor-flags-"] form > button[type="submit"], body.-emu .-emu-layout .window-app[id*="actor-flags-"] form > button[type="submit"], .-emu-layout body.-emu #default-token-config form > button[type="submit"], body.-emu .-emu-layout #default-token-config form > button[type="submit"], .-emu-layout body.-emu .sheet.scene-sheet form > button[type="submit"], body.-emu .-emu-layout .sheet.scene-sheet form > button[type="submit"], .-emu-layout body.-emu .window-app.sheet[id*="template-config"] form > button[type="submit"], body.-emu .-emu-layout .window-app.sheet[id*="template-config"] form > button[type="submit"], .-emu-layout body.-emu #wall-config form > button[type="submit"], body.-emu .-emu-layout #wall-config form > button[type="submit"], .-emu-layout body.-emu #healthestimate-style-form form > button[type="submit"], body.-emu .-emu-layout #healthestimate-style-form form > button[type="submit"], .-emu-layout body.-emu #midi-qol-settings form > button[type="submit"], body.-emu .-emu-layout #midi-qol-settings form > button[type="submit"], .-emu-layout body.-emu #mountup-settings-form form > button[type="submit"], body.-emu .-emu-layout #mountup-settings-form form > button[type="submit"], .-emu-layout body.-emu #narrator-config form > button[type="submit"], body.-emu .-emu-layout #narrator-config form > button[type="submit"], .-emu-layout body.-emu #turnmarker-settings-form form > button[type="submit"], body.-emu .-emu-layout #turnmarker-settings-form form > button[type="submit"] {
-    bottom: 0;
-    position: -webkit-sticky;
-    position: sticky;
-    z-index: 10; }
+body.-emu .window-app[id*="actor-flags-"] form > button[type="submit"],
+body.-emu #default-token-config form > button[type="submit"],
+body.-emu .sheet.scene-sheet form > button[type="submit"],
+body.-emu .window-app.sheet[id*="template-config"] form > button[type="submit"],
+body.-emu #wall-config form > button[type="submit"],
+body.-emu #healthestimate-style-form form > button[type="submit"],
+body.-emu #midi-qol-settings form > button[type="submit"],
+body.-emu #mountup-settings-form form > button[type="submit"],
+body.-emu #narrator-config form > button[type="submit"],
+body.-emu #turnmarker-settings-form form > button[type="submit"] {
+  border-radius: var(--emu-border-radius-controls, 0);
+}
+.-emu-layout
+  body.-emu
+  .window-app[id*="actor-flags-"]
+  form
+  > button[type="submit"],
+body.-emu
+  .-emu-layout
+  .window-app[id*="actor-flags-"]
+  form
+  > button[type="submit"],
+.-emu-layout body.-emu #default-token-config form > button[type="submit"],
+body.-emu .-emu-layout #default-token-config form > button[type="submit"],
+.-emu-layout body.-emu .sheet.scene-sheet form > button[type="submit"],
+body.-emu .-emu-layout .sheet.scene-sheet form > button[type="submit"],
+.-emu-layout
+  body.-emu
+  .window-app.sheet[id*="template-config"]
+  form
+  > button[type="submit"],
+body.-emu
+  .-emu-layout
+  .window-app.sheet[id*="template-config"]
+  form
+  > button[type="submit"],
+.-emu-layout body.-emu #wall-config form > button[type="submit"],
+body.-emu .-emu-layout #wall-config form > button[type="submit"],
+.-emu-layout body.-emu #healthestimate-style-form form > button[type="submit"],
+body.-emu .-emu-layout #healthestimate-style-form form > button[type="submit"],
+.-emu-layout body.-emu #midi-qol-settings form > button[type="submit"],
+body.-emu .-emu-layout #midi-qol-settings form > button[type="submit"],
+.-emu-layout body.-emu #mountup-settings-form form > button[type="submit"],
+body.-emu .-emu-layout #mountup-settings-form form > button[type="submit"],
+.-emu-layout body.-emu #narrator-config form > button[type="submit"],
+body.-emu .-emu-layout #narrator-config form > button[type="submit"],
+.-emu-layout body.-emu #turnmarker-settings-form form > button[type="submit"],
+body.-emu .-emu-layout #turnmarker-settings-form form > button[type="submit"] {
+  bottom: 0;
+  position: -webkit-sticky;
+  position: sticky;
+  z-index: 10;
+}
 
 :root {
   --color-black: 0, 0, 0;
@@ -1154,42 +6913,56 @@ body.-emu .window-app[id*="actor-flags-"] form > button[type="submit"], body.-em
   --emu-space-button-sm: 1.5rem;
   --emu-space-button-xs: 1.25rem;
   --emu-space-sidebar: 20rem;
-  scrollbar-color: rgba(var(--color-charcoal-300), 1) rgba(var(--color-black), 0.5);
-  scrollbar-width: thin; }
+  scrollbar-color: rgba(var(--color-charcoal-300), 1)
+    rgba(var(--color-black), 0.5);
+  scrollbar-width: thin;
+}
 
 ::-webkit-scrollbar {
-  width: var(--emu-space-sm); }
+  width: var(--emu-space-sm);
+}
 
 ::-webkit-scrollbar-track {
   box-shadow: inset 0 0 2px 0 rgba(var(--color-background-darkest), 0.5);
   border: none;
-  border-radius: 0; }
+  border-radius: 0;
+}
 
 ::-webkit-scrollbar-thumb {
   background-color: rgba(var(--color-background-light), 1);
   border: none;
   border-radius: var(--emu-border-radius-default, 0);
-  outline: none; }
+  outline: none;
+}
 
 *::before,
 *::after {
-  box-sizing: border-box; }
+  box-sizing: border-box;
+}
 
 @-webkit-keyframes emu-notification-flash {
   0% {
-    opacity: 0; }
+    opacity: 0;
+  }
   50% {
-    opacity: 1; }
+    opacity: 1;
+  }
   100% {
-    opacity: 0; } }
+    opacity: 0;
+  }
+}
 
 @keyframes emu-notification-flash {
   0% {
-    opacity: 0; }
+    opacity: 0;
+  }
   50% {
-    opacity: 1; }
+    opacity: 1;
+  }
   100% {
-    opacity: 0; } }
+    opacity: 0;
+  }
+}
 
 html.-emu-layout.-emu-compact {
   --emu-space-base: 0.125rem;
@@ -1201,619 +6974,1627 @@ html.-emu-layout.-emu-compact {
   --emu-space-button: 1.5rem;
   --emu-space-button-sm: 1.25rem;
   --emu-space-button-xs: 1.125rem;
-  --emu-space-sidebar: 17.875rem; }
+  --emu-space-sidebar: 17.875rem;
+}
 
 body {
   background-color: rgba(var(--color-background-darkest), 1);
   background-image: var(--emu-image-background-darkest, none);
-  box-shadow: none; }
-  .-emu-layout body {
-    font-size: var(--emu-font-size-md); }
-  body ::-moz-selection {
-    background-color: rgba(var(--color-gray-200), 1); }
-  body ::selection {
-    background-color: rgba(var(--color-gray-200), 1); }
+  box-shadow: none;
+}
+.-emu-layout body {
+  font-size: var(--emu-font-size-md);
+}
+body ::-moz-selection {
+  background-color: rgba(var(--color-gray-200), 1);
+}
+body ::selection {
+  background-color: rgba(var(--color-gray-200), 1);
+}
 
-.-emu-layout body.-emu .dialog button + button, .-emu-layout
-body.-emu #sidebar button + button, .-emu-layout
-body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) button + button {
+.-emu-layout body.-emu .dialog button + button,
+.-emu-layout body.-emu #sidebar button + button,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  button
+  + button {
   -webkit-margin-start: var(--emu-space-base);
-          margin-inline-start: var(--emu-space-base); }
+  margin-inline-start: var(--emu-space-base);
+}
 
-.-emu-layout body.-emu .dialog .directory .directory-list, .-emu-layout
-body.-emu #sidebar .directory .directory-list, .-emu-layout
-body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .directory .directory-list {
+.-emu-layout body.-emu .dialog .directory .directory-list,
+.-emu-layout body.-emu #sidebar .directory .directory-list,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .directory
+  .directory-list {
   flex: 1 1 auto;
   max-height: 100%;
   min-height: 0.0625rem;
-  overflow-y: auto; }
+  overflow-y: auto;
+}
 
 body.-emu .dialog .directory .directory-list .subdirectory,
 body.-emu #sidebar .directory .directory-list .subdirectory,
-body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .directory .directory-list .subdirectory {
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .directory
+  .directory-list
+  .subdirectory {
   background-color: rgba(var(--color-folder-subdirectory), 1);
   background-image: none;
   border: none;
   -webkit-border-start: rgba(var(--color-primary), 1) 4px solid;
-          border-inline-start: rgba(var(--color-primary), 1) 4px solid; }
-  .-emu-layout body.-emu .dialog .directory .directory-list .subdirectory, .-emu-layout
-  body.-emu #sidebar .directory .directory-list .subdirectory, .-emu-layout
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .directory .directory-list .subdirectory {
-    display: flex;
-    border-radius: 0 0 0 var(--emu-border-radius-default, 0);
-    flex-direction: column;
-    width: 100%; }
-  .-emu-layout body.-emu .dialog .directory .directory-list .subdirectory .directory-item.folder, .-emu-layout
-  body.-emu #sidebar .directory .directory-list .subdirectory .directory-item.folder, .-emu-layout
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .directory .directory-list .subdirectory .directory-item.folder {
-    -webkit-padding-after: var(--emu-space-base);
-            padding-block-end: var(--emu-space-base);
-    -webkit-padding-end: 0;
-            padding-inline-end: 0; }
-  .-emu-layout body.-emu .dialog .directory .directory-list .subdirectory .directory-item.folder + .directory-item.folder, .-emu-layout
-  body.-emu #sidebar .directory .directory-list .subdirectory .directory-item.folder + .directory-item.folder, .-emu-layout
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .directory .directory-list .subdirectory .directory-item.folder + .directory-item.folder {
-    -webkit-padding-before: 0;
-            padding-block-start: 0; }
-  .-emu-layout body.-emu .dialog .directory .directory-list .subdirectory .directory-item.folder + .directory-item:not(.folder), .-emu-layout
-  body.-emu #sidebar .directory .directory-list .subdirectory .directory-item.folder + .directory-item:not(.folder), .-emu-layout
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .directory .directory-list .subdirectory .directory-item.folder + .directory-item:not(.folder) {
-    -webkit-margin-before: 0;
-            margin-block-start: 0; }
-  .-emu-layout body.-emu .dialog .directory .directory-list .subdirectory .directory-item:not(.folder) + .directory-item:not(.folder), .-emu-layout
-  body.-emu #sidebar .directory .directory-list .subdirectory .directory-item:not(.folder) + .directory-item:not(.folder), .-emu-layout
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .directory .directory-list .subdirectory .directory-item:not(.folder) + .directory-item:not(.folder) {
-    -webkit-margin-before: 0;
-            margin-block-start: 0; }
-  body.-emu .dialog .directory .directory-list .subdirectory .subdirectory,
-  body.-emu #sidebar .directory .directory-list .subdirectory .subdirectory,
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .directory .directory-list .subdirectory .subdirectory {
-    -webkit-border-start: rgba(var(--color-orange-700), 1) 4px solid;
-            border-inline-start: rgba(var(--color-orange-700), 1) 4px solid; }
-    body.-emu .dialog .directory .directory-list .subdirectory .subdirectory .subdirectory,
-    body.-emu #sidebar .directory .directory-list .subdirectory .subdirectory .subdirectory,
-    body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .directory .directory-list .subdirectory .subdirectory .subdirectory {
-      -webkit-border-start: rgba(var(--color-orange-900), 1) 4px solid;
-              border-inline-start: rgba(var(--color-orange-900), 1) 4px solid; }
+  border-inline-start: rgba(var(--color-primary), 1) 4px solid;
+}
+.-emu-layout body.-emu .dialog .directory .directory-list .subdirectory,
+.-emu-layout body.-emu #sidebar .directory .directory-list .subdirectory,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .directory
+  .directory-list
+  .subdirectory {
+  display: flex;
+  border-radius: 0 0 0 var(--emu-border-radius-default, 0);
+  flex-direction: column;
+  width: 100%;
+}
+.-emu-layout
+  body.-emu
+  .dialog
+  .directory
+  .directory-list
+  .subdirectory
+  .directory-item.folder,
+.-emu-layout
+  body.-emu
+  #sidebar
+  .directory
+  .directory-list
+  .subdirectory
+  .directory-item.folder,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .directory
+  .directory-list
+  .subdirectory
+  .directory-item.folder {
+  -webkit-padding-after: var(--emu-space-base);
+  padding-block-end: var(--emu-space-base);
+  -webkit-padding-end: 0;
+  padding-inline-end: 0;
+}
+.-emu-layout
+  body.-emu
+  .dialog
+  .directory
+  .directory-list
+  .subdirectory
+  .directory-item.folder
+  + .directory-item.folder,
+.-emu-layout
+  body.-emu
+  #sidebar
+  .directory
+  .directory-list
+  .subdirectory
+  .directory-item.folder
+  + .directory-item.folder,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .directory
+  .directory-list
+  .subdirectory
+  .directory-item.folder
+  + .directory-item.folder {
+  -webkit-padding-before: 0;
+  padding-block-start: 0;
+}
+.-emu-layout
+  body.-emu
+  .dialog
+  .directory
+  .directory-list
+  .subdirectory
+  .directory-item.folder
+  + .directory-item:not(.folder),
+.-emu-layout
+  body.-emu
+  #sidebar
+  .directory
+  .directory-list
+  .subdirectory
+  .directory-item.folder
+  + .directory-item:not(.folder),
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .directory
+  .directory-list
+  .subdirectory
+  .directory-item.folder
+  + .directory-item:not(.folder) {
+  -webkit-margin-before: 0;
+  margin-block-start: 0;
+}
+.-emu-layout
+  body.-emu
+  .dialog
+  .directory
+  .directory-list
+  .subdirectory
+  .directory-item:not(.folder)
+  + .directory-item:not(.folder),
+.-emu-layout
+  body.-emu
+  #sidebar
+  .directory
+  .directory-list
+  .subdirectory
+  .directory-item:not(.folder)
+  + .directory-item:not(.folder),
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .directory
+  .directory-list
+  .subdirectory
+  .directory-item:not(.folder)
+  + .directory-item:not(.folder) {
+  -webkit-margin-before: 0;
+  margin-block-start: 0;
+}
+body.-emu .dialog .directory .directory-list .subdirectory .subdirectory,
+body.-emu #sidebar .directory .directory-list .subdirectory .subdirectory,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .directory
+  .directory-list
+  .subdirectory
+  .subdirectory {
+  -webkit-border-start: rgba(var(--color-orange-700), 1) 4px solid;
+  border-inline-start: rgba(var(--color-orange-700), 1) 4px solid;
+}
+body.-emu
+  .dialog
+  .directory
+  .directory-list
+  .subdirectory
+  .subdirectory
+  .subdirectory,
+body.-emu
+  #sidebar
+  .directory
+  .directory-list
+  .subdirectory
+  .subdirectory
+  .subdirectory,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .directory
+  .directory-list
+  .subdirectory
+  .subdirectory
+  .subdirectory {
+  -webkit-border-start: rgba(var(--color-orange-900), 1) 4px solid;
+  border-inline-start: rgba(var(--color-orange-900), 1) 4px solid;
+}
 
 body.-emu .dialog .directory .directory-item,
 body.-emu #sidebar .directory .directory-item,
-body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .directory .directory-item {
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .directory
+  .directory-item {
   background-color: rgba(var(--color-folder-directory), 1);
   background-image: none;
   -webkit-border-after: rgba(var(--color-border), 1) 1px solid;
-          border-block-end: rgba(var(--color-border), 1) 1px solid;
+  border-block-end: rgba(var(--color-border), 1) 1px solid;
   border-radius: var(--emu-border-radius-default, 0);
   box-shadow: none;
   color: rgba(var(--color-text-lightest), 1);
-  transition: background 0.3s cubic-bezier(0.075, 0.82, 0.165, 1), box-shadow 0.3s cubic-bezier(0.075, 0.82, 0.165, 1), color 0.3s cubic-bezier(0.075, 0.82, 0.165, 1); }
-  .-emu-layout body.-emu .dialog .directory .directory-item, .-emu-layout
-  body.-emu #sidebar .directory .directory-item, .-emu-layout
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .directory .directory-item {
-    align-items: center;
-    border: none;
-    cursor: pointer;
-    display: flex;
-    flex-wrap: nowrap;
-    height: auto;
-    line-height: 1;
-    margin: var(--emu-space-base) var(--emu-space-sm);
-    min-height: var(--emu-space-button);
-    padding: 0 var(--emu-space-sm);
-    position: relative;
-    width: auto; }
-  body.-emu .dialog .directory .directory-item:hover,
-  body.-emu #sidebar .directory .directory-item:hover,
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .directory .directory-item:hover {
-    background-color: rgba(var(--color-primary), 1);
-    background-image: none;
-    color: rgba(var(--color-text-lightest), 1); }
-  body.-emu .dialog .directory .directory-item:focus,
-  body.-emu #sidebar .directory .directory-item:focus,
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .directory .directory-item:focus {
-    background-image: none; }
-  body.-emu .dialog .directory .directory-item.entity,
-  body.-emu #sidebar .directory .directory-item.entity,
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .directory .directory-item.entity {
-    border: none; }
-  body.-emu .dialog .directory .directory-item.context,
-  body.-emu #sidebar .directory .directory-item.context,
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .directory .directory-item.context {
-    border: none;
-    box-shadow: none; }
-  body.-emu .dialog .directory .directory-item.folder,
-  body.-emu #sidebar .directory .directory-item.folder,
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .directory .directory-item.folder {
-    background: transparent; }
-    .-emu-layout body.-emu .dialog .directory .directory-item.folder, .-emu-layout
-    body.-emu #sidebar .directory .directory-item.folder, .-emu-layout
-    body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .directory .directory-item.folder {
-      cursor: default;
-      display: flex;
-      flex-direction: column;
-      margin: 0;
-      -webkit-padding-before: var(--emu-space-base);
-              padding-block-start: var(--emu-space-base);
-      -webkit-padding-after: 0;
-              padding-block-end: 0;
-      -webkit-padding-start: var(--emu-space-sm);
-              padding-inline-start: var(--emu-space-sm);
-      -webkit-padding-end: var(--emu-space-sm);
-              padding-inline-end: var(--emu-space-sm);
-      position: relative;
-      width: 100%; }
-    body.-emu .dialog .directory .directory-item.folder:hover, body.-emu .dialog .directory .directory-item.folder:focus,
-    body.-emu #sidebar .directory .directory-item.folder:hover,
-    body.-emu #sidebar .directory .directory-item.folder:focus,
-    body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .directory .directory-item.folder:hover,
-    body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .directory .directory-item.folder:focus {
-      background: transparent;
-      box-shadow: none; }
-    body.-emu .dialog .directory .directory-item.folder.collapsed > .folder-header,
-    body.-emu #sidebar .directory .directory-item.folder.collapsed > .folder-header,
-    body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .directory .directory-item.folder.collapsed > .folder-header {
-      -webkit-border-start: none;
-              border-inline-start: none;
-      border-radius: var(--emu-border-radius-default, 0); }
-      .-emu-layout body.-emu .dialog .directory .directory-item.folder.collapsed > .folder-header .create-folder, .-emu-layout
-      body.-emu #sidebar .directory .directory-item.folder.collapsed > .folder-header .create-folder, .-emu-layout
-      body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .directory .directory-item.folder.collapsed > .folder-header .create-folder {
-        display: none; }
-      .-emu-layout body.-emu .dialog .directory .directory-item.folder.collapsed > .folder-header h3 i::before, .-emu-layout
-      body.-emu #sidebar .directory .directory-item.folder.collapsed > .folder-header h3 i::before, .-emu-layout
-      body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .directory .directory-item.folder.collapsed > .folder-header h3 i::before {
-        content: "\f07b"; }
-    .-emu-layout body.-emu .dialog .directory .directory-item.folder.collapsed .subdirectory, .-emu-layout
-    body.-emu #sidebar .directory .directory-item.folder.collapsed .subdirectory, .-emu-layout
-    body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .directory .directory-item.folder.collapsed .subdirectory {
-      display: none; }
-    body.-emu .dialog .directory .directory-item.folder.collapsed .subdirectory .folder-header,
-    body.-emu #sidebar .directory .directory-item.folder.collapsed .subdirectory .folder-header,
-    body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .directory .directory-item.folder.collapsed .subdirectory .folder-header {
-      -webkit-border-start: none;
-              border-inline-start: none; }
-    body.-emu .dialog .directory .directory-item.folder .folder-header,
-    body.-emu #sidebar .directory .directory-item.folder .folder-header,
-    body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .directory .directory-item.folder .folder-header {
-      background-color: rgba(var(--color-folder-header), 1);
-      background-image: none;
-      border: 0;
-      -webkit-border-start: rgba(var(--color-primary), 1) 4px solid;
-              border-inline-start: rgba(var(--color-primary), 1) 4px solid;
-      border-radius: var(--emu-border-radius-default, 0) var(--emu-border-radius-default, 0) 0 0;
-      color: rgba(var(--color-text), 1);
-      transition: background 0.3s cubic-bezier(0.075, 0.82, 0.165, 1), box-shadow 0.3s cubic-bezier(0.075, 0.82, 0.165, 1), color 0.3s cubic-bezier(0.075, 0.82, 0.165, 1); }
-      .-emu-layout body.-emu .dialog .directory .directory-item.folder .folder-header, .-emu-layout
-      body.-emu #sidebar .directory .directory-item.folder .folder-header, .-emu-layout
-      body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .directory .directory-item.folder .folder-header {
-        align-items: center;
-        cursor: pointer;
-        display: flex;
-        flex-wrap: nowrap;
-        line-height: 1;
-        min-height: var(--emu-space-button);
-        padding: var(--emu-space-base) var(--emu-space-sm);
-        position: relative;
-        width: 100%; }
-      body.-emu .dialog .directory .directory-item.folder .folder-header:hover,
-      body.-emu #sidebar .directory .directory-item.folder .folder-header:hover,
-      body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .directory .directory-item.folder .folder-header:hover {
-        background-color: rgba(var(--color-primary), 1);
-        background-image: none;
-        color: rgba(var(--color-text-lightest), 1); }
-      body.-emu .dialog .directory .directory-item.folder .folder-header h3,
-      body.-emu #sidebar .directory .directory-item.folder .folder-header h3,
-      body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .directory .directory-item.folder .folder-header h3 {
-        -webkit-border-after: 0;
-                border-block-end: 0;
-        color: inherit; }
-        .-emu-layout body.-emu .dialog .directory .directory-item.folder .folder-header h3, .-emu-layout
-        body.-emu #sidebar .directory .directory-item.folder .folder-header h3, .-emu-layout
-        body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .directory .directory-item.folder .folder-header h3 {
-          overflow: hidden;
-          text-overflow: ellipsis;
-          white-space: nowrap;
-          flex: 1 1 auto;
-          font-size: var(--emu-font-size-lg);
-          font-weight: normal;
-          line-height: 1;
-          margin: 0;
-          position: relative;
-          text-align: start;
-          text-shadow: none; }
-    .-emu-layout body.-emu .dialog .directory .directory-item.folder .subdirectory .directory-item.folder.collapsed .folder-header, .-emu-layout
-    body.-emu #sidebar .directory .directory-item.folder .subdirectory .directory-item.folder.collapsed .folder-header, .-emu-layout
-    body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .directory .directory-item.folder .subdirectory .directory-item.folder.collapsed .folder-header {
-      border-radius: var(--emu-border-radius-default, 0) 0 0 var(--emu-border-radius-default, 0); }
-    .-emu-layout body.-emu .dialog .directory .directory-item.folder .subdirectory .directory-item.folder .folder-header, .-emu-layout
-    body.-emu #sidebar .directory .directory-item.folder .subdirectory .directory-item.folder .folder-header, .-emu-layout
-    body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .directory .directory-item.folder .subdirectory .directory-item.folder .folder-header {
-      border-radius: var(--emu-border-radius-default, 0) 0 0 0; }
-    body.-emu .dialog .directory .directory-item.folder .subdirectory .folder-header,
-    body.-emu #sidebar .directory .directory-item.folder .subdirectory .folder-header,
-    body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .directory .directory-item.folder .subdirectory .folder-header {
-      border-color: rgba(var(--color-orange-700), 1); }
-    body.-emu .dialog .directory .directory-item.folder .subdirectory .subdirectory .folder-header,
-    body.-emu #sidebar .directory .directory-item.folder .subdirectory .subdirectory .folder-header,
-    body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .directory .directory-item.folder .subdirectory .subdirectory .folder-header {
-      border-color: rgba(var(--color-orange-900), 1); }
-    body.-emu .dialog .directory .directory-item.folder .folder-header.context,
-    body.-emu .dialog .directory .directory-item.folder .directory-item.context,
-    body.-emu #sidebar .directory .directory-item.folder .folder-header.context,
-    body.-emu #sidebar .directory .directory-item.folder .directory-item.context,
-    body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .directory .directory-item.folder .folder-header.context,
-    body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .directory .directory-item.folder .directory-item.context {
-      background-color: rgba(var(--color-primary), 1) !important;
-      color: rgba(var(--color-text-lightest), 1); }
-  body.-emu .dialog .directory .directory-item img,
-  body.-emu #sidebar .directory .directory-item img,
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .directory .directory-item img {
-    border-radius: var(--emu-border-radius-images, 0); }
-    .-emu-layout body.-emu .dialog .directory .directory-item img, .-emu-layout
-    body.-emu #sidebar .directory .directory-item img, .-emu-layout
-    body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .directory .directory-item img {
-      width: var(--emu-space-button);
-      height: var(--emu-space-button);
-      cursor: move;
-      flex: 0 0 auto;
-      margin: 0;
-      -webkit-margin-before: var(--emu-space-base);
-              margin-block-start: var(--emu-space-base);
-      -webkit-margin-after: var(--emu-space-base);
-              margin-block-end: var(--emu-space-base);
-      -webkit-margin-end: var(--emu-space-sm);
-              margin-inline-end: var(--emu-space-sm); }
-  body.-emu .dialog .directory .directory-item h3,
-  body.-emu .dialog .directory .directory-item h4,
-  body.-emu #sidebar .directory .directory-item h3,
-  body.-emu #sidebar .directory .directory-item h4,
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .directory .directory-item h3,
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .directory .directory-item h4 {
-    color: inherit;
-    text-shadow: none; }
-    .-emu-layout body.-emu .dialog .directory .directory-item h3, .-emu-layout
-    body.-emu .dialog .directory .directory-item h4, .-emu-layout
-    body.-emu #sidebar .directory .directory-item h3, .-emu-layout
-    body.-emu #sidebar .directory .directory-item h4, .-emu-layout
-    body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .directory .directory-item h3, .-emu-layout
-    body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .directory .directory-item h4 {
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
-      flex: 1 1 auto;
-      font-size: var(--emu-font-size-lg);
-      font-weight: normal;
-      line-height: 1;
-      margin: 0;
-      padding: 0;
-      position: relative;
-      text-align: start; }
-    body.-emu .dialog .directory .directory-item h3 > a,
-    body.-emu .dialog .directory .directory-item h4 > a,
-    body.-emu #sidebar .directory .directory-item h3 > a,
-    body.-emu #sidebar .directory .directory-item h4 > a,
-    body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .directory .directory-item h3 > a,
-    body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .directory .directory-item h4 > a {
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
-      background-color: transparent;
-      border-radius: 0;
-      color: inherit;
-      text-shadow: none;
-      transition: color 0.3s cubic-bezier(0.075, 0.82, 0.165, 1); }
-      .-emu-layout body.-emu .dialog .directory .directory-item h3 > a, .-emu-layout
-      body.-emu .dialog .directory .directory-item h4 > a, .-emu-layout
-      body.-emu #sidebar .directory .directory-item h3 > a, .-emu-layout
-      body.-emu #sidebar .directory .directory-item h4 > a, .-emu-layout
-      body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .directory .directory-item h3 > a, .-emu-layout
-      body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .directory .directory-item h4 > a {
-        cursor: pointer;
-        display: block;
-        flex: 1 1 auto;
-        font-size: var(--emu-font-size-lg);
-        line-height: var(--emu-space-button);
-        padding: 0;
-        position: relative;
-        text-shadow: none; }
+  transition: background 0.3s cubic-bezier(0.075, 0.82, 0.165, 1),
+    box-shadow 0.3s cubic-bezier(0.075, 0.82, 0.165, 1),
+    color 0.3s cubic-bezier(0.075, 0.82, 0.165, 1);
+}
+.-emu-layout body.-emu .dialog .directory .directory-item,
+.-emu-layout body.-emu #sidebar .directory .directory-item,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .directory
+  .directory-item {
+  align-items: center;
+  border: none;
+  cursor: pointer;
+  display: flex;
+  flex-wrap: nowrap;
+  height: auto;
+  line-height: 1;
+  margin: var(--emu-space-base) var(--emu-space-sm);
+  min-height: var(--emu-space-button);
+  padding: 0 var(--emu-space-sm);
+  position: relative;
+  width: auto;
+}
+body.-emu .dialog .directory .directory-item:hover,
+body.-emu #sidebar .directory .directory-item:hover,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .directory
+  .directory-item:hover {
+  background-color: rgba(var(--color-primary), 1);
+  background-image: none;
+  color: rgba(var(--color-text-lightest), 1);
+}
+body.-emu .dialog .directory .directory-item:focus,
+body.-emu #sidebar .directory .directory-item:focus,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .directory
+  .directory-item:focus {
+  background-image: none;
+}
+body.-emu .dialog .directory .directory-item.entity,
+body.-emu #sidebar .directory .directory-item.entity,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .directory
+  .directory-item.entity {
+  border: none;
+}
+body.-emu .dialog .directory .directory-item.context,
+body.-emu #sidebar .directory .directory-item.context,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .directory
+  .directory-item.context {
+  border: none;
+  box-shadow: none;
+}
+body.-emu .dialog .directory .directory-item.folder,
+body.-emu #sidebar .directory .directory-item.folder,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .directory
+  .directory-item.folder {
+  background: transparent;
+}
+.-emu-layout body.-emu .dialog .directory .directory-item.folder,
+.-emu-layout body.-emu #sidebar .directory .directory-item.folder,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .directory
+  .directory-item.folder {
+  cursor: default;
+  display: flex;
+  flex-direction: column;
+  margin: 0;
+  -webkit-padding-before: var(--emu-space-base);
+  padding-block-start: var(--emu-space-base);
+  -webkit-padding-after: 0;
+  padding-block-end: 0;
+  -webkit-padding-start: var(--emu-space-sm);
+  padding-inline-start: var(--emu-space-sm);
+  -webkit-padding-end: var(--emu-space-sm);
+  padding-inline-end: var(--emu-space-sm);
+  position: relative;
+  width: 100%;
+}
+body.-emu .dialog .directory .directory-item.folder:hover,
+body.-emu .dialog .directory .directory-item.folder:focus,
+body.-emu #sidebar .directory .directory-item.folder:hover,
+body.-emu #sidebar .directory .directory-item.folder:focus,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .directory
+  .directory-item.folder:hover,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .directory
+  .directory-item.folder:focus {
+  background: transparent;
+  box-shadow: none;
+}
+body.-emu .dialog .directory .directory-item.folder.collapsed > .folder-header,
+body.-emu #sidebar .directory .directory-item.folder.collapsed > .folder-header,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .directory
+  .directory-item.folder.collapsed
+  > .folder-header {
+  -webkit-border-start: none;
+  border-inline-start: none;
+  border-radius: var(--emu-border-radius-default, 0);
+}
+.-emu-layout
+  body.-emu
+  .dialog
+  .directory
+  .directory-item.folder.collapsed
+  > .folder-header
+  .create-folder,
+.-emu-layout
+  body.-emu
+  #sidebar
+  .directory
+  .directory-item.folder.collapsed
+  > .folder-header
+  .create-folder,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .directory
+  .directory-item.folder.collapsed
+  > .folder-header
+  .create-folder {
+  display: none;
+}
+.-emu-layout
+  body.-emu
+  .dialog
+  .directory
+  .directory-item.folder.collapsed
+  > .folder-header
+  h3
+  i::before,
+.-emu-layout
+  body.-emu
+  #sidebar
+  .directory
+  .directory-item.folder.collapsed
+  > .folder-header
+  h3
+  i::before,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .directory
+  .directory-item.folder.collapsed
+  > .folder-header
+  h3
+  i::before {
+  content: "\f07b";
+}
+.-emu-layout
+  body.-emu
+  .dialog
+  .directory
+  .directory-item.folder.collapsed
+  .subdirectory,
+.-emu-layout
+  body.-emu
+  #sidebar
+  .directory
+  .directory-item.folder.collapsed
+  .subdirectory,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .directory
+  .directory-item.folder.collapsed
+  .subdirectory {
+  display: none;
+}
+body.-emu
+  .dialog
+  .directory
+  .directory-item.folder.collapsed
+  .subdirectory
+  .folder-header,
+body.-emu
+  #sidebar
+  .directory
+  .directory-item.folder.collapsed
+  .subdirectory
+  .folder-header,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .directory
+  .directory-item.folder.collapsed
+  .subdirectory
+  .folder-header {
+  -webkit-border-start: none;
+  border-inline-start: none;
+}
+body.-emu .dialog .directory .directory-item.folder .folder-header,
+body.-emu #sidebar .directory .directory-item.folder .folder-header,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .directory
+  .directory-item.folder
+  .folder-header {
+  background-color: rgba(var(--color-folder-header), 1);
+  background-image: none;
+  border: 0;
+  -webkit-border-start: rgba(var(--color-primary), 1) 4px solid;
+  border-inline-start: rgba(var(--color-primary), 1) 4px solid;
+  border-radius: var(--emu-border-radius-default, 0)
+    var(--emu-border-radius-default, 0) 0 0;
+  color: rgba(var(--color-text), 1);
+  transition: background 0.3s cubic-bezier(0.075, 0.82, 0.165, 1),
+    box-shadow 0.3s cubic-bezier(0.075, 0.82, 0.165, 1),
+    color 0.3s cubic-bezier(0.075, 0.82, 0.165, 1);
+}
+.-emu-layout body.-emu .dialog .directory .directory-item.folder .folder-header,
+.-emu-layout
+  body.-emu
+  #sidebar
+  .directory
+  .directory-item.folder
+  .folder-header,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .directory
+  .directory-item.folder
+  .folder-header {
+  align-items: center;
+  cursor: pointer;
+  display: flex;
+  flex-wrap: nowrap;
+  line-height: 1;
+  min-height: var(--emu-space-button);
+  padding: var(--emu-space-base) var(--emu-space-sm);
+  position: relative;
+  width: 100%;
+}
+body.-emu .dialog .directory .directory-item.folder .folder-header:hover,
+body.-emu #sidebar .directory .directory-item.folder .folder-header:hover,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .directory
+  .directory-item.folder
+  .folder-header:hover {
+  background-color: rgba(var(--color-primary), 1);
+  background-image: none;
+  color: rgba(var(--color-text-lightest), 1);
+}
+body.-emu .dialog .directory .directory-item.folder .folder-header h3,
+body.-emu #sidebar .directory .directory-item.folder .folder-header h3,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .directory
+  .directory-item.folder
+  .folder-header
+  h3 {
+  -webkit-border-after: 0;
+  border-block-end: 0;
+  color: inherit;
+}
+.-emu-layout
+  body.-emu
+  .dialog
+  .directory
+  .directory-item.folder
+  .folder-header
+  h3,
+.-emu-layout
+  body.-emu
+  #sidebar
+  .directory
+  .directory-item.folder
+  .folder-header
+  h3,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .directory
+  .directory-item.folder
+  .folder-header
+  h3 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 1 1 auto;
+  font-size: var(--emu-font-size-lg);
+  font-weight: normal;
+  line-height: 1;
+  margin: 0;
+  position: relative;
+  text-align: start;
+  text-shadow: none;
+}
+.-emu-layout
+  body.-emu
+  .dialog
+  .directory
+  .directory-item.folder
+  .subdirectory
+  .directory-item.folder.collapsed
+  .folder-header,
+.-emu-layout
+  body.-emu
+  #sidebar
+  .directory
+  .directory-item.folder
+  .subdirectory
+  .directory-item.folder.collapsed
+  .folder-header,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .directory
+  .directory-item.folder
+  .subdirectory
+  .directory-item.folder.collapsed
+  .folder-header {
+  border-radius: var(--emu-border-radius-default, 0) 0 0
+    var(--emu-border-radius-default, 0);
+}
+.-emu-layout
+  body.-emu
+  .dialog
+  .directory
+  .directory-item.folder
+  .subdirectory
+  .directory-item.folder
+  .folder-header,
+.-emu-layout
+  body.-emu
+  #sidebar
+  .directory
+  .directory-item.folder
+  .subdirectory
+  .directory-item.folder
+  .folder-header,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .directory
+  .directory-item.folder
+  .subdirectory
+  .directory-item.folder
+  .folder-header {
+  border-radius: var(--emu-border-radius-default, 0) 0 0 0;
+}
+body.-emu
+  .dialog
+  .directory
+  .directory-item.folder
+  .subdirectory
+  .folder-header,
+body.-emu
+  #sidebar
+  .directory
+  .directory-item.folder
+  .subdirectory
+  .folder-header,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .directory
+  .directory-item.folder
+  .subdirectory
+  .folder-header {
+  border-color: rgba(var(--color-orange-700), 1);
+}
+body.-emu
+  .dialog
+  .directory
+  .directory-item.folder
+  .subdirectory
+  .subdirectory
+  .folder-header,
+body.-emu
+  #sidebar
+  .directory
+  .directory-item.folder
+  .subdirectory
+  .subdirectory
+  .folder-header,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .directory
+  .directory-item.folder
+  .subdirectory
+  .subdirectory
+  .folder-header {
+  border-color: rgba(var(--color-orange-900), 1);
+}
+body.-emu .dialog .directory .directory-item.folder .folder-header.context,
+body.-emu .dialog .directory .directory-item.folder .directory-item.context,
+body.-emu #sidebar .directory .directory-item.folder .folder-header.context,
+body.-emu #sidebar .directory .directory-item.folder .directory-item.context,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .directory
+  .directory-item.folder
+  .folder-header.context,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .directory
+  .directory-item.folder
+  .directory-item.context {
+  background-color: rgba(var(--color-primary), 1) !important;
+  color: rgba(var(--color-text-lightest), 1);
+}
+body.-emu .dialog .directory .directory-item img,
+body.-emu #sidebar .directory .directory-item img,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .directory
+  .directory-item
+  img {
+  border-radius: var(--emu-border-radius-images, 0);
+}
+.-emu-layout body.-emu .dialog .directory .directory-item img,
+.-emu-layout body.-emu #sidebar .directory .directory-item img,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .directory
+  .directory-item
+  img {
+  width: var(--emu-space-button);
+  height: var(--emu-space-button);
+  cursor: move;
+  flex: 0 0 auto;
+  margin: 0;
+  -webkit-margin-before: var(--emu-space-base);
+  margin-block-start: var(--emu-space-base);
+  -webkit-margin-after: var(--emu-space-base);
+  margin-block-end: var(--emu-space-base);
+  -webkit-margin-end: var(--emu-space-sm);
+  margin-inline-end: var(--emu-space-sm);
+}
+body.-emu .dialog .directory .directory-item h3,
+body.-emu .dialog .directory .directory-item h4,
+body.-emu #sidebar .directory .directory-item h3,
+body.-emu #sidebar .directory .directory-item h4,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .directory
+  .directory-item
+  h3,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .directory
+  .directory-item
+  h4 {
+  color: inherit;
+  text-shadow: none;
+}
+.-emu-layout body.-emu .dialog .directory .directory-item h3,
+.-emu-layout body.-emu .dialog .directory .directory-item h4,
+.-emu-layout body.-emu #sidebar .directory .directory-item h3,
+.-emu-layout body.-emu #sidebar .directory .directory-item h4,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .directory
+  .directory-item
+  h3,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .directory
+  .directory-item
+  h4 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 1 1 auto;
+  font-size: var(--emu-font-size-lg);
+  font-weight: normal;
+  line-height: 1;
+  margin: 0;
+  padding: 0;
+  position: relative;
+  text-align: start;
+}
+body.-emu .dialog .directory .directory-item h3 > a,
+body.-emu .dialog .directory .directory-item h4 > a,
+body.-emu #sidebar .directory .directory-item h3 > a,
+body.-emu #sidebar .directory .directory-item h4 > a,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .directory
+  .directory-item
+  h3
+  > a,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .directory
+  .directory-item
+  h4
+  > a {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  background-color: transparent;
+  border-radius: 0;
+  color: inherit;
+  text-shadow: none;
+  transition: color 0.3s cubic-bezier(0.075, 0.82, 0.165, 1);
+}
+.-emu-layout body.-emu .dialog .directory .directory-item h3 > a,
+.-emu-layout body.-emu .dialog .directory .directory-item h4 > a,
+.-emu-layout body.-emu #sidebar .directory .directory-item h3 > a,
+.-emu-layout body.-emu #sidebar .directory .directory-item h4 > a,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .directory
+  .directory-item
+  h3
+  > a,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .directory
+  .directory-item
+  h4
+  > a {
+  cursor: pointer;
+  display: block;
+  flex: 1 1 auto;
+  font-size: var(--emu-font-size-lg);
+  line-height: var(--emu-space-button);
+  padding: 0;
+  position: relative;
+  text-shadow: none;
+}
 
-.-emu-layout body.-emu .dialog input[type="text"] + input[type="color"], .-emu-layout
-body.-emu #sidebar input[type="text"] + input[type="color"], .-emu-layout
-body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) input[type="text"] + input[type="color"] {
+.-emu-layout body.-emu .dialog input[type="text"] + input[type="color"],
+.-emu-layout body.-emu #sidebar input[type="text"] + input[type="color"],
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  input[type="text"]
+  + input[type="color"] {
   -webkit-margin-start: var(--emu-space-base);
-          margin-inline-start: var(--emu-space-base); }
+  margin-inline-start: var(--emu-space-base);
+}
 
 body.-emu .dialog select,
 body.-emu #sidebar select,
 body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) select {
-  box-shadow: none; }
+  box-shadow: none;
+}
 
 body.-emu .dialog fieldset,
 body.-emu #sidebar fieldset,
 body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) fieldset {
-  border: none; }
-  .-emu-layout body.-emu .dialog fieldset, .-emu-layout
-  body.-emu #sidebar fieldset, .-emu-layout
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) fieldset {
-    margin: 0;
-    padding: 0; }
+  border: none;
+}
+.-emu-layout body.-emu .dialog fieldset,
+.-emu-layout body.-emu #sidebar fieldset,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  fieldset {
+  margin: 0;
+  padding: 0;
+}
 
 body.-emu .dialog form h3.form-header,
 body.-emu #sidebar form h3.form-header,
-body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) form h3.form-header {
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  form
+  h3.form-header {
   border: none;
   -webkit-border-after: rgba(var(--color-border), 1) 1px solid;
-          border-block-end: rgba(var(--color-border), 1) 1px solid;
-  color: rgba(var(--color-text), 1); }
-  .-emu-layout body.-emu .dialog form h3.form-header, .-emu-layout
-  body.-emu #sidebar form h3.form-header, .-emu-layout
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) form h3.form-header {
-    font-family: inherit;
-    font-size: var(--emu-font-size-lg);
-    -webkit-margin-before: var(--emu-space-md);
-            margin-block-start: var(--emu-space-md);
-    -webkit-margin-after: var(--emu-space-base);
-            margin-block-end: var(--emu-space-base);
-    padding: var(--emu-space-base); }
+  border-block-end: rgba(var(--color-border), 1) 1px solid;
+  color: rgba(var(--color-text), 1);
+}
+.-emu-layout body.-emu .dialog form h3.form-header,
+.-emu-layout body.-emu #sidebar form h3.form-header,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  form
+  h3.form-header {
+  font-family: inherit;
+  font-size: var(--emu-font-size-lg);
+  -webkit-margin-before: var(--emu-space-md);
+  margin-block-start: var(--emu-space-md);
+  -webkit-margin-after: var(--emu-space-base);
+  margin-block-end: var(--emu-space-base);
+  padding: var(--emu-space-base);
+}
 
 body.-emu .dialog form .form-group,
 body.-emu #sidebar form .form-group,
 body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) form .form-group {
-  color: rgba(var(--color-text), 1); }
-  .-emu-layout body.-emu .dialog form .form-group, .-emu-layout
-  body.-emu #sidebar form .form-group, .-emu-layout
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) form .form-group {
-    align-items: center;
-    display: flex;
-    flex-wrap: wrap;
-    font-size: var(--emu-font-size-lg);
-    height: auto;
-    justify-content: space-between;
-    margin: 0;
-    padding: var(--emu-space-sm); }
-    .-emu-layout body.-emu .dialog form .form-group:nth-of-type(even), .-emu-layout
-    body.-emu #sidebar form .form-group:nth-of-type(even), .-emu-layout
-    body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) form .form-group:nth-of-type(even) {
-      background-color: rgba(var(--color-background-light), 0.1); }
-  .-emu-layout body.-emu .dialog form .form-group.initial-position .form-fields, .-emu-layout
-  body.-emu #sidebar form .form-group.initial-position .form-fields, .-emu-layout
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) form .form-group.initial-position .form-fields {
-    align-items: center;
-    display: inline-flex;
-    width: 1px; }
-  .-emu-layout body.-emu .dialog form .form-group.initial-position .form-fields input, .-emu-layout
-  body.-emu #sidebar form .form-group.initial-position .form-fields input, .-emu-layout
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) form .form-group.initial-position .form-fields input {
-    flex: 1 1 auto; }
-    .-emu-layout body.-emu .dialog form .form-group.initial-position .form-fields input[type="text"], .-emu-layout
-    body.-emu #sidebar form .form-group.initial-position .form-fields input[type="text"], .-emu-layout
-    body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) form .form-group.initial-position .form-fields input[type="text"] {
-      width: 1px; }
-  .-emu-layout body.-emu .dialog form .form-group.initial-position .form-fields label, .-emu-layout
-  body.-emu #sidebar form .form-group.initial-position .form-fields label, .-emu-layout
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) form .form-group.initial-position .form-fields label {
-    flex: 0 0 auto;
-    -webkit-padding-start: var(--emu-space-sm);
-            padding-inline-start: var(--emu-space-sm);
-    -webkit-padding-end: var(--emu-space-base);
-            padding-inline-end: var(--emu-space-base); }
-  .-emu-layout body.-emu .dialog form .form-group.stacked, .-emu-layout
-  body.-emu #sidebar form .form-group.stacked, .-emu-layout
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) form .form-group.stacked {
-    padding: 0;
-    -webkit-padding-before: var(--emu-space-sm);
-            padding-block-start: var(--emu-space-sm); }
-  .-emu-layout body.-emu .dialog form .form-group.stacked textarea, .-emu-layout
-  body.-emu #sidebar form .form-group.stacked textarea, .-emu-layout
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) form .form-group.stacked textarea {
-    -webkit-margin-after: var(--emu-space-base);
-            margin-block-end: var(--emu-space-base); }
-  .-emu-layout body.-emu .dialog form .form-group.hidden, .-emu-layout
-  body.-emu #sidebar form .form-group.hidden, .-emu-layout
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) form .form-group.hidden {
-    display: none; }
-  .-emu-layout body.-emu .dialog form .form-group .form-fields, .-emu-layout
-  body.-emu #sidebar form .form-group .form-fields, .-emu-layout
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) form .form-group .form-fields {
-    display: flex;
-    flex: 1 1 auto; }
-  .-emu-layout body.-emu .dialog form .form-group .form-fields input, .-emu-layout
-  body.-emu .dialog form .form-group .form-fields select, .-emu-layout
-  body.-emu #sidebar form .form-group .form-fields input, .-emu-layout
-  body.-emu #sidebar form .form-group .form-fields select, .-emu-layout
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) form .form-group .form-fields input, .-emu-layout
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) form .form-group .form-fields select {
-    flex: 1 1 100%; }
-  .-emu-layout body.-emu .dialog form .form-group .form-fields input[type="checkbox"], .-emu-layout
-  body.-emu .dialog form .form-group .form-fields select[type="checkbox"], .-emu-layout
-  body.-emu #sidebar form .form-group .form-fields input[type="checkbox"], .-emu-layout
-  body.-emu #sidebar form .form-group .form-fields select[type="checkbox"], .-emu-layout
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) form .form-group .form-fields input[type="checkbox"], .-emu-layout
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) form .form-group .form-fields select[type="checkbox"] {
-    -webkit-filter: initial;
-    flex: 0 0 auto;
-    width: var(--emu-space-button-xs); }
-  .-emu-layout body.-emu .dialog form .form-group .form-fields input[type="radio"], .-emu-layout
-  body.-emu .dialog form .form-group .form-fields select[type="radio"], .-emu-layout
-  body.-emu #sidebar form .form-group .form-fields input[type="radio"], .-emu-layout
-  body.-emu #sidebar form .form-group .form-fields select[type="radio"], .-emu-layout
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) form .form-group .form-fields input[type="radio"], .-emu-layout
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) form .form-group .form-fields select[type="radio"] {
-    flex: 0 0 auto;
-    -webkit-margin-end: var(--emu-space-sm);
-            margin-inline-end: var(--emu-space-sm);
-    width: auto; }
-  .-emu-layout body.-emu .dialog form .form-group .form-fields input + input, .-emu-layout
-  body.-emu .dialog form .form-group .form-fields input + select, .-emu-layout
-  body.-emu .dialog form .form-group .form-fields select + input, .-emu-layout
-  body.-emu .dialog form .form-group .form-fields select + select, .-emu-layout
-  body.-emu #sidebar form .form-group .form-fields input + input, .-emu-layout
-  body.-emu #sidebar form .form-group .form-fields input + select, .-emu-layout
-  body.-emu #sidebar form .form-group .form-fields select + input, .-emu-layout
-  body.-emu #sidebar form .form-group .form-fields select + select, .-emu-layout
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) form .form-group .form-fields input + input, .-emu-layout
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) form .form-group .form-fields input + select, .-emu-layout
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) form .form-group .form-fields select + input, .-emu-layout
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) form .form-group .form-fields select + select {
-    flex: 1 1 25%;
-    -webkit-margin-start: var(--emu-space-base);
-            margin-inline-start: var(--emu-space-base); }
-  .-emu-layout body.-emu .dialog form .form-group .form-fields button, .-emu-layout
-  body.-emu #sidebar form .form-group .form-fields button, .-emu-layout
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) form .form-group .form-fields button {
-    -webkit-margin-start: var(--emu-space-base);
-            margin-inline-start: var(--emu-space-base);
-    order: initial;
-    width: auto; }
-  .-emu-layout body.-emu .dialog form .form-group .form-fields button.file-picker > i, .-emu-layout body.-emu .dialog form .form-group .form-fields button.grid-config > i, .-emu-layout body.-emu .dialog form .form-group .form-fields button.capture-position > i, .-emu-layout
-  body.-emu #sidebar form .form-group .form-fields button.file-picker > i, .-emu-layout
-  body.-emu #sidebar form .form-group .form-fields button.grid-config > i, .-emu-layout
-  body.-emu #sidebar form .form-group .form-fields button.capture-position > i, .-emu-layout
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) form .form-group .form-fields button.file-picker > i, .-emu-layout
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) form .form-group .form-fields button.grid-config > i, .-emu-layout
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) form .form-group .form-fields button.capture-position > i {
-    -webkit-margin-end: 0;
-            margin-inline-end: 0; }
-  .-emu-layout body.-emu .dialog form .form-group .form-fields button + input, .-emu-layout
-  body.-emu #sidebar form .form-group .form-fields button + input, .-emu-layout
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) form .form-group .form-fields button + input {
-    order: -1; }
-  .-emu-layout body.-emu .dialog form .form-group .form-fields button.file-picker + input[type="text"], .-emu-layout
-  body.-emu #sidebar form .form-group .form-fields button.file-picker + input[type="text"], .-emu-layout
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) form .form-group .form-fields button.file-picker + input[type="text"] {
-    margin-right: 0 !important; }
-  .-emu-layout body.-emu .dialog form .form-group .form-fields + .notes, .-emu-layout
-  body.-emu .dialog form .form-group .form-fields + .hint, .-emu-layout
-  body.-emu .dialog form .form-group .range-value + .notes, .-emu-layout
-  body.-emu .dialog form .form-group .range-value + .hint, .-emu-layout
-  body.-emu .dialog form .form-group input[type="checkbox"] + .notes, .-emu-layout
-  body.-emu .dialog form .form-group input[type="checkbox"] + .hint, .-emu-layout
-  body.-emu #sidebar form .form-group .form-fields + .notes, .-emu-layout
-  body.-emu #sidebar form .form-group .form-fields + .hint, .-emu-layout
-  body.-emu #sidebar form .form-group .range-value + .notes, .-emu-layout
-  body.-emu #sidebar form .form-group .range-value + .hint, .-emu-layout
-  body.-emu #sidebar form .form-group input[type="checkbox"] + .notes, .-emu-layout
-  body.-emu #sidebar form .form-group input[type="checkbox"] + .hint, .-emu-layout
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) form .form-group .form-fields + .notes, .-emu-layout
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) form .form-group .form-fields + .hint, .-emu-layout
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) form .form-group .range-value + .notes, .-emu-layout
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) form .form-group .range-value + .hint, .-emu-layout
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) form .form-group input[type="checkbox"] + .notes, .-emu-layout
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) form .form-group input[type="checkbox"] + .hint {
-    -webkit-margin-before: var(--emu-space-sm);
-            margin-block-start: var(--emu-space-sm); }
-  .-emu-layout body.-emu .dialog form .form-group input, .-emu-layout
-  body.-emu .dialog form .form-group select, .-emu-layout
-  body.-emu #sidebar form .form-group input, .-emu-layout
-  body.-emu #sidebar form .form-group select, .-emu-layout
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) form .form-group input, .-emu-layout
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) form .form-group select {
-    flex: 1 1 auto;
-    width: 1px; }
-  .-emu-layout body.-emu .dialog form .form-group input[type="checkbox"], .-emu-layout
-  body.-emu .dialog form .form-group select[type="checkbox"], .-emu-layout
-  body.-emu #sidebar form .form-group input[type="checkbox"], .-emu-layout
-  body.-emu #sidebar form .form-group select[type="checkbox"], .-emu-layout
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) form .form-group input[type="checkbox"], .-emu-layout
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) form .form-group select[type="checkbox"] {
-    -webkit-filter: initial;
-    flex: 0 0 auto;
-    width: var(--emu-space-button-xs); }
-  .-emu-layout body.-emu .dialog form .form-group input[type="radio"], .-emu-layout
-  body.-emu .dialog form .form-group select[type="radio"], .-emu-layout
-  body.-emu #sidebar form .form-group input[type="radio"], .-emu-layout
-  body.-emu #sidebar form .form-group select[type="radio"], .-emu-layout
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) form .form-group input[type="radio"], .-emu-layout
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) form .form-group select[type="radio"] {
-    flex: 0 0 auto;
-    -webkit-margin-end: var(--emu-space-sm);
-            margin-inline-end: var(--emu-space-sm);
-    width: auto; }
-  .-emu-layout body.-emu .dialog form .form-group input + .notes, .-emu-layout
-  body.-emu .dialog form .form-group select + .notes, .-emu-layout
-  body.-emu #sidebar form .form-group input + .notes, .-emu-layout
-  body.-emu #sidebar form .form-group select + .notes, .-emu-layout
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) form .form-group input + .notes, .-emu-layout
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) form .form-group select + .notes {
-    -webkit-margin-before: var(--emu-space-sm);
-            margin-block-start: var(--emu-space-sm); }
-  .-emu-layout body.-emu .dialog form .form-group input + input, .-emu-layout
-  body.-emu .dialog form .form-group select + input, .-emu-layout
-  body.-emu #sidebar form .form-group input + input, .-emu-layout
-  body.-emu #sidebar form .form-group select + input, .-emu-layout
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) form .form-group input + input, .-emu-layout
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) form .form-group select + input {
-    flex: 1 1 25%;
-    -webkit-margin-start: var(--emu-space-base);
-            margin-inline-start: var(--emu-space-base); }
-  .-emu-layout body.-emu .dialog form .form-group input + input[type="checkbox"], .-emu-layout body.-emu .dialog form .form-group input + input[type="radio"], .-emu-layout
-  body.-emu .dialog form .form-group select + input[type="checkbox"], .-emu-layout
-  body.-emu .dialog form .form-group select + input[type="radio"], .-emu-layout
-  body.-emu #sidebar form .form-group input + input[type="checkbox"], .-emu-layout
-  body.-emu #sidebar form .form-group input + input[type="radio"], .-emu-layout
-  body.-emu #sidebar form .form-group select + input[type="checkbox"], .-emu-layout
-  body.-emu #sidebar form .form-group select + input[type="radio"], .-emu-layout
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) form .form-group input + input[type="checkbox"], .-emu-layout
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) form .form-group input + input[type="radio"], .-emu-layout
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) form .form-group select + input[type="checkbox"], .-emu-layout
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) form .form-group select + input[type="radio"] {
-    flex: 0 0 auto; }
-  .-emu-layout body.-emu .dialog form .form-group > label, .-emu-layout
-  body.-emu #sidebar form .form-group > label, .-emu-layout
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) form .form-group > label {
-    flex: 0 0 40%; }
-  .-emu-layout body.-emu .dialog form .form-group label, .-emu-layout
-  body.-emu #sidebar form .form-group label, .-emu-layout
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) form .form-group label {
-    align-items: center;
-    display: inline-flex;
-    font-size: var(--emu-font-size-md);
-    font-weight: normal;
-    line-height: initial;
-    margin: 0;
-    -webkit-padding-end: var(--emu-space-base);
-            padding-inline-end: var(--emu-space-base); }
-  .-emu-layout body.-emu .dialog form .form-group label.checkbox, .-emu-layout
-  body.-emu #sidebar form .form-group label.checkbox, .-emu-layout
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) form .form-group label.checkbox {
-    height: auto; }
-  .-emu-layout body.-emu .dialog form .form-group label.checkbox input[type="checkbox"], .-emu-layout
-  body.-emu #sidebar form .form-group label.checkbox input[type="checkbox"], .-emu-layout
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) form .form-group label.checkbox input[type="checkbox"] {
-    -webkit-margin-start: var(--emu-space-base);
-            margin-inline-start: var(--emu-space-base); }
-  .-emu-layout body.-emu .dialog form .form-group label.checkbox + input[type="range"], .-emu-layout
-  body.-emu .dialog form .form-group label.checkbox + select, .-emu-layout
-  body.-emu #sidebar form .form-group label.checkbox + input[type="range"], .-emu-layout
-  body.-emu #sidebar form .form-group label.checkbox + select, .-emu-layout
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) form .form-group label.checkbox + input[type="range"], .-emu-layout
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) form .form-group label.checkbox + select {
-    -webkit-margin-start: var(--emu-space-base);
-            margin-inline-start: var(--emu-space-base); }
-  body.-emu .dialog form .form-group label .units,
-  body.-emu #sidebar form .form-group label .units,
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) form .form-group label .units {
-    color: rgba(var(--color-text), 1); }
-    .-emu-layout body.-emu .dialog form .form-group label .units, .-emu-layout
-    body.-emu #sidebar form .form-group label .units, .-emu-layout
-    body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) form .form-group label .units {
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
-      display: block;
-      font-size: var(--emu-font-size-sm);
-      line-height: initial;
-      margin: 0 var(--emu-space-base); }
-  .-emu-layout body.-emu .dialog form .form-group label > i, .-emu-layout
-  body.-emu #sidebar form .form-group label > i, .-emu-layout
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) form .form-group label > i {
-    -webkit-margin-end: var(--emu-space-base);
-            margin-inline-end: var(--emu-space-base); }
-  .-emu-layout body.-emu .dialog form .form-group + button[type="submit"], .-emu-layout
-  body.-emu #sidebar form .form-group + button[type="submit"], .-emu-layout
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) form .form-group + button[type="submit"] {
-    -webkit-margin-before: var(--emu-space-sm);
-            margin-block-start: var(--emu-space-sm); }
+  color: rgba(var(--color-text), 1);
+}
+.-emu-layout body.-emu .dialog form .form-group,
+.-emu-layout body.-emu #sidebar form .form-group,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  form
+  .form-group {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  font-size: var(--emu-font-size-lg);
+  height: auto;
+  justify-content: space-between;
+  margin: 0;
+  padding: var(--emu-space-sm);
+}
+.-emu-layout body.-emu .dialog form .form-group:nth-of-type(even),
+.-emu-layout body.-emu #sidebar form .form-group:nth-of-type(even),
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  form
+  .form-group:nth-of-type(even) {
+  background-color: rgba(var(--color-background-light), 0.1);
+}
+.-emu-layout body.-emu .dialog form .form-group.initial-position .form-fields,
+.-emu-layout body.-emu #sidebar form .form-group.initial-position .form-fields,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  form
+  .form-group.initial-position
+  .form-fields {
+  align-items: center;
+  display: inline-flex;
+  width: 1px;
+}
+.-emu-layout
+  body.-emu
+  .dialog
+  form
+  .form-group.initial-position
+  .form-fields
+  input,
+.-emu-layout
+  body.-emu
+  #sidebar
+  form
+  .form-group.initial-position
+  .form-fields
+  input,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  form
+  .form-group.initial-position
+  .form-fields
+  input {
+  flex: 1 1 auto;
+}
+.-emu-layout
+  body.-emu
+  .dialog
+  form
+  .form-group.initial-position
+  .form-fields
+  input[type="text"],
+.-emu-layout
+  body.-emu
+  #sidebar
+  form
+  .form-group.initial-position
+  .form-fields
+  input[type="text"],
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  form
+  .form-group.initial-position
+  .form-fields
+  input[type="text"] {
+  width: 1px;
+}
+.-emu-layout
+  body.-emu
+  .dialog
+  form
+  .form-group.initial-position
+  .form-fields
+  label,
+.-emu-layout
+  body.-emu
+  #sidebar
+  form
+  .form-group.initial-position
+  .form-fields
+  label,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  form
+  .form-group.initial-position
+  .form-fields
+  label {
+  flex: 0 0 auto;
+  -webkit-padding-start: var(--emu-space-sm);
+  padding-inline-start: var(--emu-space-sm);
+  -webkit-padding-end: var(--emu-space-base);
+  padding-inline-end: var(--emu-space-base);
+}
+.-emu-layout body.-emu .dialog form .form-group.stacked,
+.-emu-layout body.-emu #sidebar form .form-group.stacked,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  form
+  .form-group.stacked {
+  padding: 0;
+  -webkit-padding-before: var(--emu-space-sm);
+  padding-block-start: var(--emu-space-sm);
+}
+.-emu-layout body.-emu .dialog form .form-group.stacked textarea,
+.-emu-layout body.-emu #sidebar form .form-group.stacked textarea,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  form
+  .form-group.stacked
+  textarea {
+  -webkit-margin-after: var(--emu-space-base);
+  margin-block-end: var(--emu-space-base);
+}
+.-emu-layout body.-emu .dialog form .form-group.hidden,
+.-emu-layout body.-emu #sidebar form .form-group.hidden,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  form
+  .form-group.hidden {
+  display: none;
+}
+.-emu-layout body.-emu .dialog form .form-group .form-fields,
+.-emu-layout body.-emu #sidebar form .form-group .form-fields,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  form
+  .form-group
+  .form-fields {
+  display: flex;
+  flex: 1 1 auto;
+}
+.-emu-layout body.-emu .dialog form .form-group .form-fields input,
+.-emu-layout body.-emu .dialog form .form-group .form-fields select,
+.-emu-layout body.-emu #sidebar form .form-group .form-fields input,
+.-emu-layout body.-emu #sidebar form .form-group .form-fields select,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  form
+  .form-group
+  .form-fields
+  input,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  form
+  .form-group
+  .form-fields
+  select {
+  flex: 1 1 100%;
+}
+.-emu-layout
+  body.-emu
+  .dialog
+  form
+  .form-group
+  .form-fields
+  input[type="checkbox"],
+.-emu-layout
+  body.-emu
+  .dialog
+  form
+  .form-group
+  .form-fields
+  select[type="checkbox"],
+.-emu-layout
+  body.-emu
+  #sidebar
+  form
+  .form-group
+  .form-fields
+  input[type="checkbox"],
+.-emu-layout
+  body.-emu
+  #sidebar
+  form
+  .form-group
+  .form-fields
+  select[type="checkbox"],
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  form
+  .form-group
+  .form-fields
+  input[type="checkbox"],
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  form
+  .form-group
+  .form-fields
+  select[type="checkbox"] {
+  -webkit-filter: initial;
+  flex: 0 0 auto;
+  width: var(--emu-space-button-xs);
+}
+.-emu-layout
+  body.-emu
+  .dialog
+  form
+  .form-group
+  .form-fields
+  input[type="radio"],
+.-emu-layout
+  body.-emu
+  .dialog
+  form
+  .form-group
+  .form-fields
+  select[type="radio"],
+.-emu-layout
+  body.-emu
+  #sidebar
+  form
+  .form-group
+  .form-fields
+  input[type="radio"],
+.-emu-layout
+  body.-emu
+  #sidebar
+  form
+  .form-group
+  .form-fields
+  select[type="radio"],
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  form
+  .form-group
+  .form-fields
+  input[type="radio"],
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  form
+  .form-group
+  .form-fields
+  select[type="radio"] {
+  flex: 0 0 auto;
+  -webkit-margin-end: var(--emu-space-sm);
+  margin-inline-end: var(--emu-space-sm);
+  width: auto;
+}
+.-emu-layout body.-emu .dialog form .form-group .form-fields input + input,
+.-emu-layout body.-emu .dialog form .form-group .form-fields input + select,
+.-emu-layout body.-emu .dialog form .form-group .form-fields select + input,
+.-emu-layout body.-emu .dialog form .form-group .form-fields select + select,
+.-emu-layout body.-emu #sidebar form .form-group .form-fields input + input,
+.-emu-layout body.-emu #sidebar form .form-group .form-fields input + select,
+.-emu-layout body.-emu #sidebar form .form-group .form-fields select + input,
+.-emu-layout body.-emu #sidebar form .form-group .form-fields select + select,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  form
+  .form-group
+  .form-fields
+  input
+  + input,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  form
+  .form-group
+  .form-fields
+  input
+  + select,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  form
+  .form-group
+  .form-fields
+  select
+  + input,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  form
+  .form-group
+  .form-fields
+  select
+  + select {
+  flex: 1 1 25%;
+  -webkit-margin-start: var(--emu-space-base);
+  margin-inline-start: var(--emu-space-base);
+}
+.-emu-layout body.-emu .dialog form .form-group .form-fields button,
+.-emu-layout body.-emu #sidebar form .form-group .form-fields button,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  form
+  .form-group
+  .form-fields
+  button {
+  -webkit-margin-start: var(--emu-space-base);
+  margin-inline-start: var(--emu-space-base);
+  order: initial;
+  width: auto;
+}
+.-emu-layout
+  body.-emu
+  .dialog
+  form
+  .form-group
+  .form-fields
+  button.file-picker
+  > i,
+.-emu-layout
+  body.-emu
+  .dialog
+  form
+  .form-group
+  .form-fields
+  button.grid-config
+  > i,
+.-emu-layout
+  body.-emu
+  .dialog
+  form
+  .form-group
+  .form-fields
+  button.capture-position
+  > i,
+.-emu-layout
+  body.-emu
+  #sidebar
+  form
+  .form-group
+  .form-fields
+  button.file-picker
+  > i,
+.-emu-layout
+  body.-emu
+  #sidebar
+  form
+  .form-group
+  .form-fields
+  button.grid-config
+  > i,
+.-emu-layout
+  body.-emu
+  #sidebar
+  form
+  .form-group
+  .form-fields
+  button.capture-position
+  > i,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  form
+  .form-group
+  .form-fields
+  button.file-picker
+  > i,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  form
+  .form-group
+  .form-fields
+  button.grid-config
+  > i,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  form
+  .form-group
+  .form-fields
+  button.capture-position
+  > i {
+  -webkit-margin-end: 0;
+  margin-inline-end: 0;
+}
+.-emu-layout body.-emu .dialog form .form-group .form-fields button + input,
+.-emu-layout body.-emu #sidebar form .form-group .form-fields button + input,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  form
+  .form-group
+  .form-fields
+  button
+  + input {
+  order: -1;
+}
+.-emu-layout
+  body.-emu
+  .dialog
+  form
+  .form-group
+  .form-fields
+  button.file-picker
+  + input[type="text"],
+.-emu-layout
+  body.-emu
+  #sidebar
+  form
+  .form-group
+  .form-fields
+  button.file-picker
+  + input[type="text"],
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  form
+  .form-group
+  .form-fields
+  button.file-picker
+  + input[type="text"] {
+  margin-right: 0 !important;
+}
+.-emu-layout body.-emu .dialog form .form-group .form-fields + .notes,
+.-emu-layout body.-emu .dialog form .form-group .form-fields + .hint,
+.-emu-layout body.-emu .dialog form .form-group .range-value + .notes,
+.-emu-layout body.-emu .dialog form .form-group .range-value + .hint,
+.-emu-layout body.-emu .dialog form .form-group input[type="checkbox"] + .notes,
+.-emu-layout body.-emu .dialog form .form-group input[type="checkbox"] + .hint,
+.-emu-layout body.-emu #sidebar form .form-group .form-fields + .notes,
+.-emu-layout body.-emu #sidebar form .form-group .form-fields + .hint,
+.-emu-layout body.-emu #sidebar form .form-group .range-value + .notes,
+.-emu-layout body.-emu #sidebar form .form-group .range-value + .hint,
+.-emu-layout
+  body.-emu
+  #sidebar
+  form
+  .form-group
+  input[type="checkbox"]
+  + .notes,
+.-emu-layout body.-emu #sidebar form .form-group input[type="checkbox"] + .hint,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  form
+  .form-group
+  .form-fields
+  + .notes,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  form
+  .form-group
+  .form-fields
+  + .hint,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  form
+  .form-group
+  .range-value
+  + .notes,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  form
+  .form-group
+  .range-value
+  + .hint,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  form
+  .form-group
+  input[type="checkbox"]
+  + .notes,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  form
+  .form-group
+  input[type="checkbox"]
+  + .hint {
+  -webkit-margin-before: var(--emu-space-sm);
+  margin-block-start: var(--emu-space-sm);
+}
+.-emu-layout body.-emu .dialog form .form-group input,
+.-emu-layout body.-emu .dialog form .form-group select,
+.-emu-layout body.-emu #sidebar form .form-group input,
+.-emu-layout body.-emu #sidebar form .form-group select,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  form
+  .form-group
+  input,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  form
+  .form-group
+  select {
+  flex: 1 1 auto;
+  width: 1px;
+}
+.-emu-layout body.-emu .dialog form .form-group input[type="checkbox"],
+.-emu-layout body.-emu .dialog form .form-group select[type="checkbox"],
+.-emu-layout body.-emu #sidebar form .form-group input[type="checkbox"],
+.-emu-layout body.-emu #sidebar form .form-group select[type="checkbox"],
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  form
+  .form-group
+  input[type="checkbox"],
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  form
+  .form-group
+  select[type="checkbox"] {
+  -webkit-filter: initial;
+  flex: 0 0 auto;
+  width: var(--emu-space-button-xs);
+}
+.-emu-layout body.-emu .dialog form .form-group input[type="radio"],
+.-emu-layout body.-emu .dialog form .form-group select[type="radio"],
+.-emu-layout body.-emu #sidebar form .form-group input[type="radio"],
+.-emu-layout body.-emu #sidebar form .form-group select[type="radio"],
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  form
+  .form-group
+  input[type="radio"],
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  form
+  .form-group
+  select[type="radio"] {
+  flex: 0 0 auto;
+  -webkit-margin-end: var(--emu-space-sm);
+  margin-inline-end: var(--emu-space-sm);
+  width: auto;
+}
+.-emu-layout body.-emu .dialog form .form-group input + .notes,
+.-emu-layout body.-emu .dialog form .form-group select + .notes,
+.-emu-layout body.-emu #sidebar form .form-group input + .notes,
+.-emu-layout body.-emu #sidebar form .form-group select + .notes,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  form
+  .form-group
+  input
+  + .notes,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  form
+  .form-group
+  select
+  + .notes {
+  -webkit-margin-before: var(--emu-space-sm);
+  margin-block-start: var(--emu-space-sm);
+}
+.-emu-layout body.-emu .dialog form .form-group input + input,
+.-emu-layout body.-emu .dialog form .form-group select + input,
+.-emu-layout body.-emu #sidebar form .form-group input + input,
+.-emu-layout body.-emu #sidebar form .form-group select + input,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  form
+  .form-group
+  input
+  + input,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  form
+  .form-group
+  select
+  + input {
+  flex: 1 1 25%;
+  -webkit-margin-start: var(--emu-space-base);
+  margin-inline-start: var(--emu-space-base);
+}
+.-emu-layout body.-emu .dialog form .form-group input + input[type="checkbox"],
+.-emu-layout body.-emu .dialog form .form-group input + input[type="radio"],
+.-emu-layout body.-emu .dialog form .form-group select + input[type="checkbox"],
+.-emu-layout body.-emu .dialog form .form-group select + input[type="radio"],
+.-emu-layout body.-emu #sidebar form .form-group input + input[type="checkbox"],
+.-emu-layout body.-emu #sidebar form .form-group input + input[type="radio"],
+.-emu-layout
+  body.-emu
+  #sidebar
+  form
+  .form-group
+  select
+  + input[type="checkbox"],
+.-emu-layout body.-emu #sidebar form .form-group select + input[type="radio"],
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  form
+  .form-group
+  input
+  + input[type="checkbox"],
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  form
+  .form-group
+  input
+  + input[type="radio"],
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  form
+  .form-group
+  select
+  + input[type="checkbox"],
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  form
+  .form-group
+  select
+  + input[type="radio"] {
+  flex: 0 0 auto;
+}
+.-emu-layout body.-emu .dialog form .form-group > label,
+.-emu-layout body.-emu #sidebar form .form-group > label,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  form
+  .form-group
+  > label {
+  flex: 0 0 40%;
+}
+.-emu-layout body.-emu .dialog form .form-group label,
+.-emu-layout body.-emu #sidebar form .form-group label,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  form
+  .form-group
+  label {
+  align-items: center;
+  display: inline-flex;
+  font-size: var(--emu-font-size-md);
+  font-weight: normal;
+  line-height: initial;
+  margin: 0;
+  -webkit-padding-end: var(--emu-space-base);
+  padding-inline-end: var(--emu-space-base);
+}
+.-emu-layout body.-emu .dialog form .form-group label.checkbox,
+.-emu-layout body.-emu #sidebar form .form-group label.checkbox,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  form
+  .form-group
+  label.checkbox {
+  height: auto;
+}
+.-emu-layout
+  body.-emu
+  .dialog
+  form
+  .form-group
+  label.checkbox
+  input[type="checkbox"],
+.-emu-layout
+  body.-emu
+  #sidebar
+  form
+  .form-group
+  label.checkbox
+  input[type="checkbox"],
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  form
+  .form-group
+  label.checkbox
+  input[type="checkbox"] {
+  -webkit-margin-start: var(--emu-space-base);
+  margin-inline-start: var(--emu-space-base);
+}
+.-emu-layout
+  body.-emu
+  .dialog
+  form
+  .form-group
+  label.checkbox
+  + input[type="range"],
+.-emu-layout body.-emu .dialog form .form-group label.checkbox + select,
+.-emu-layout
+  body.-emu
+  #sidebar
+  form
+  .form-group
+  label.checkbox
+  + input[type="range"],
+.-emu-layout body.-emu #sidebar form .form-group label.checkbox + select,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  form
+  .form-group
+  label.checkbox
+  + input[type="range"],
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  form
+  .form-group
+  label.checkbox
+  + select {
+  -webkit-margin-start: var(--emu-space-base);
+  margin-inline-start: var(--emu-space-base);
+}
+body.-emu .dialog form .form-group label .units,
+body.-emu #sidebar form .form-group label .units,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  form
+  .form-group
+  label
+  .units {
+  color: rgba(var(--color-text), 1);
+}
+.-emu-layout body.-emu .dialog form .form-group label .units,
+.-emu-layout body.-emu #sidebar form .form-group label .units,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  form
+  .form-group
+  label
+  .units {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  display: block;
+  font-size: var(--emu-font-size-sm);
+  line-height: initial;
+  margin: 0 var(--emu-space-base);
+}
+.-emu-layout body.-emu .dialog form .form-group label > i,
+.-emu-layout body.-emu #sidebar form .form-group label > i,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  form
+  .form-group
+  label
+  > i {
+  -webkit-margin-end: var(--emu-space-base);
+  margin-inline-end: var(--emu-space-base);
+}
+.-emu-layout body.-emu .dialog form .form-group + button[type="submit"],
+.-emu-layout body.-emu #sidebar form .form-group + button[type="submit"],
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  form
+  .form-group
+  + button[type="submit"] {
+  -webkit-margin-before: var(--emu-space-sm);
+  margin-block-start: var(--emu-space-sm);
+}
 
 body.-emu .dialog form .notes,
 body.-emu .dialog form .hint,
@@ -1821,95 +8602,169 @@ body.-emu #sidebar form .notes,
 body.-emu #sidebar form .hint,
 body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) form .notes,
 body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) form .hint {
-  color: rgba(var(--color-text-darker), 1); }
-  .-emu-layout body.-emu .dialog form .notes, .-emu-layout
-  body.-emu .dialog form .hint, .-emu-layout
-  body.-emu #sidebar form .notes, .-emu-layout
-  body.-emu #sidebar form .hint, .-emu-layout
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) form .notes, .-emu-layout
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) form .hint {
-    flex: 0 0 auto;
-    font-size: var(--emu-font-size-md);
-    font-style: italic;
-    line-height: initial;
-    margin: 0;
-    width: 100%; }
-    .-emu-layout body.-emu .dialog form .notes:empty, .-emu-layout
-    body.-emu .dialog form .hint:empty, .-emu-layout
-    body.-emu #sidebar form .notes:empty, .-emu-layout
-    body.-emu #sidebar form .hint:empty, .-emu-layout
-    body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) form .notes:empty, .-emu-layout
-    body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) form .hint:empty {
-      display: none; }
-    .-emu-layout body.-emu .dialog form .notes:first-child, .-emu-layout
-    body.-emu .dialog form .hint:first-child, .-emu-layout
-    body.-emu #sidebar form .notes:first-child, .-emu-layout
-    body.-emu #sidebar form .hint:first-child, .-emu-layout
-    body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) form .notes:first-child, .-emu-layout
-    body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) form .hint:first-child {
-      margin-bottom: var(--emu-space-base); }
-  .-emu-layout body.-emu .dialog form .notes + .form-group, .-emu-layout
-  body.-emu .dialog form .hint + .form-group, .-emu-layout
-  body.-emu #sidebar form .notes + .form-group, .-emu-layout
-  body.-emu #sidebar form .hint + .form-group, .-emu-layout
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) form .notes + .form-group, .-emu-layout
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) form .hint + .form-group {
-    -webkit-margin-before: var(--emu-space-sm);
-            margin-block-start: var(--emu-space-sm); }
+  color: rgba(var(--color-text-darker), 1);
+}
+.-emu-layout body.-emu .dialog form .notes,
+.-emu-layout body.-emu .dialog form .hint,
+.-emu-layout body.-emu #sidebar form .notes,
+.-emu-layout body.-emu #sidebar form .hint,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  form
+  .notes,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  form
+  .hint {
+  flex: 0 0 auto;
+  font-size: var(--emu-font-size-md);
+  font-style: italic;
+  line-height: initial;
+  margin: 0;
+  width: 100%;
+}
+.-emu-layout body.-emu .dialog form .notes:empty,
+.-emu-layout body.-emu .dialog form .hint:empty,
+.-emu-layout body.-emu #sidebar form .notes:empty,
+.-emu-layout body.-emu #sidebar form .hint:empty,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  form
+  .notes:empty,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  form
+  .hint:empty {
+  display: none;
+}
+.-emu-layout body.-emu .dialog form .notes:first-child,
+.-emu-layout body.-emu .dialog form .hint:first-child,
+.-emu-layout body.-emu #sidebar form .notes:first-child,
+.-emu-layout body.-emu #sidebar form .hint:first-child,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  form
+  .notes:first-child,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  form
+  .hint:first-child {
+  margin-bottom: var(--emu-space-base);
+}
+.-emu-layout body.-emu .dialog form .notes + .form-group,
+.-emu-layout body.-emu .dialog form .hint + .form-group,
+.-emu-layout body.-emu #sidebar form .notes + .form-group,
+.-emu-layout body.-emu #sidebar form .hint + .form-group,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  form
+  .notes
+  + .form-group,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  form
+  .hint
+  + .form-group {
+  -webkit-margin-before: var(--emu-space-sm);
+  margin-block-start: var(--emu-space-sm);
+}
 
 body.-emu .dialog img,
 body.-emu #sidebar img,
 body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) img {
   border: none;
-  border-radius: var(--emu-border-radius-images, 0); }
-  .-emu-layout body.-emu .dialog img, .-emu-layout
-  body.-emu #sidebar img, .-emu-layout
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) img {
-    position: relative; }
+  border-radius: var(--emu-border-radius-images, 0);
+}
+.-emu-layout body.-emu .dialog img,
+.-emu-layout body.-emu #sidebar img,
+.-emu-layout body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) img {
+  position: relative;
+}
 
 body.-emu .dialog table,
 body.-emu #sidebar table,
 body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) table {
   background-color: rgba(var(--color-black), 0.05);
-  border: none; }
-  .-emu-layout body.-emu .dialog table, .-emu-layout
-  body.-emu #sidebar table, .-emu-layout
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) table {
-    margin: var(--emu-space-base) 0; }
-  body.-emu .dialog table thead,
-  body.-emu #sidebar table thead,
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) table thead {
-    background-color: rgba(var(--color-black), 0.2);
-    -webkit-border-after: rgba(var(--color-border), 1) 1px solid;
-            border-block-end: rgba(var(--color-border), 1) 1px solid;
-    color: rgba(var(--color-text-lightest), 1);
-    text-shadow: none; }
-  body.-emu .dialog table tr:nth-child(even),
-  body.-emu #sidebar table tr:nth-child(even),
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) table tr:nth-child(even) {
-    background-color: rgba(var(--color-white), 0.1); }
-  .-emu-layout body.-emu .dialog table td:first-child, .-emu-layout
-  body.-emu #sidebar table td:first-child, .-emu-layout
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) table td:first-child {
-    -webkit-padding-start: var(--emu-space-base);
-            padding-inline-start: var(--emu-space-base); }
-  .-emu-layout body.-emu .dialog table td, .-emu-layout
-  body.-emu .dialog table th, .-emu-layout
-  body.-emu #sidebar table td, .-emu-layout
-  body.-emu #sidebar table th, .-emu-layout
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) table td, .-emu-layout
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) table th {
-    padding: var(--emu-space-xs) 0; }
+  border: none;
+}
+.-emu-layout body.-emu .dialog table,
+.-emu-layout body.-emu #sidebar table,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  table {
+  margin: var(--emu-space-base) 0;
+}
+body.-emu .dialog table thead,
+body.-emu #sidebar table thead,
+body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) table thead {
+  background-color: rgba(var(--color-black), 0.2);
+  -webkit-border-after: rgba(var(--color-border), 1) 1px solid;
+  border-block-end: rgba(var(--color-border), 1) 1px solid;
+  color: rgba(var(--color-text-lightest), 1);
+  text-shadow: none;
+}
+body.-emu .dialog table tr:nth-child(even),
+body.-emu #sidebar table tr:nth-child(even),
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  table
+  tr:nth-child(even) {
+  background-color: rgba(var(--color-white), 0.1);
+}
+.-emu-layout body.-emu .dialog table td:first-child,
+.-emu-layout body.-emu #sidebar table td:first-child,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  table
+  td:first-child {
+  -webkit-padding-start: var(--emu-space-base);
+  padding-inline-start: var(--emu-space-base);
+}
+.-emu-layout body.-emu .dialog table td,
+.-emu-layout body.-emu .dialog table th,
+.-emu-layout body.-emu #sidebar table td,
+.-emu-layout body.-emu #sidebar table th,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  table
+  td,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  table
+  th {
+  padding: var(--emu-space-xs) 0;
+}
 
-.-emu-layout body.-emu .dialog .tabs ~ .tab, .-emu-layout
-body.-emu .dialog .sheet-tabs ~ .tab, .-emu-layout
-body.-emu #sidebar .tabs ~ .tab, .-emu-layout
-body.-emu #sidebar .sheet-tabs ~ .tab, .-emu-layout
-body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .tabs ~ .tab, .-emu-layout
-body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .sheet-tabs ~ .tab {
+.-emu-layout body.-emu .dialog .tabs ~ .tab,
+.-emu-layout body.-emu .dialog .sheet-tabs ~ .tab,
+.-emu-layout body.-emu #sidebar .tabs ~ .tab,
+.-emu-layout body.-emu #sidebar .sheet-tabs ~ .tab,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .tabs
+  ~ .tab,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .sheet-tabs
+  ~ .tab {
   flex: 1 1 auto;
   overflow-y: auto;
-  overflow-x: hidden; }
+  overflow-x: hidden;
+}
 
 body.-emu .dialog h1,
 body.-emu .dialog h2,
@@ -1923,69 +8778,80 @@ body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) h1,
 body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) h2,
 body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) h3,
 body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) h4 {
-  font-weight: normal; }
-  .-emu-layout body.-emu .dialog h1, .-emu-layout
-  body.-emu .dialog h2, .-emu-layout
-  body.-emu .dialog h3, .-emu-layout
-  body.-emu .dialog h4, .-emu-layout
-  body.-emu #sidebar h1, .-emu-layout
-  body.-emu #sidebar h2, .-emu-layout
-  body.-emu #sidebar h3, .-emu-layout
-  body.-emu #sidebar h4, .-emu-layout
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) h1, .-emu-layout
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) h2, .-emu-layout
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) h3, .-emu-layout
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) h4 {
-    margin: 0;
-    -webkit-margin-after: var(--emu-space-base);
-            margin-block-end: var(--emu-space-base);
-    position: relative; }
+  font-weight: normal;
+}
+.-emu-layout body.-emu .dialog h1,
+.-emu-layout body.-emu .dialog h2,
+.-emu-layout body.-emu .dialog h3,
+.-emu-layout body.-emu .dialog h4,
+.-emu-layout body.-emu #sidebar h1,
+.-emu-layout body.-emu #sidebar h2,
+.-emu-layout body.-emu #sidebar h3,
+.-emu-layout body.-emu #sidebar h4,
+.-emu-layout body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) h1,
+.-emu-layout body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) h2,
+.-emu-layout body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) h3,
+.-emu-layout body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) h4 {
+  margin: 0;
+  -webkit-margin-after: var(--emu-space-base);
+  margin-block-end: var(--emu-space-base);
+  position: relative;
+}
 
 body.-emu .dialog h1,
 body.-emu #sidebar h1,
 body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) h1 {
   -webkit-border-after: 2px solid rgba(var(--color-border), 1);
-          border-block-end: 2px solid rgba(var(--color-border), 1); }
-  .-emu-layout body.-emu .dialog h1, .-emu-layout
-  body.-emu #sidebar h1, .-emu-layout
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) h1 {
-    font-size: var(--emu-font-size-xxl); }
+  border-block-end: 2px solid rgba(var(--color-border), 1);
+}
+.-emu-layout body.-emu .dialog h1,
+.-emu-layout body.-emu #sidebar h1,
+.-emu-layout body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) h1 {
+  font-size: var(--emu-font-size-xxl);
+}
 
 body.-emu .dialog h2,
 body.-emu #sidebar h2,
 body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) h2 {
   -webkit-border-after: rgba(var(--color-border), 1) 1px solid;
-          border-block-end: rgba(var(--color-border), 1) 1px solid; }
-  .-emu-layout body.-emu .dialog h2, .-emu-layout
-  body.-emu #sidebar h2, .-emu-layout
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) h2 {
-    font-size: var(--emu-font-size-xl); }
+  border-block-end: rgba(var(--color-border), 1) 1px solid;
+}
+.-emu-layout body.-emu .dialog h2,
+.-emu-layout body.-emu #sidebar h2,
+.-emu-layout body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) h2 {
+  font-size: var(--emu-font-size-xl);
+}
 
-.-emu-layout body.-emu .dialog h3, .-emu-layout
-body.-emu #sidebar h3, .-emu-layout
-body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) h3 {
-  font-size: var(--emu-font-size-lg); }
+.-emu-layout body.-emu .dialog h3,
+.-emu-layout body.-emu #sidebar h3,
+.-emu-layout body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) h3 {
+  font-size: var(--emu-font-size-lg);
+}
 
 body.-emu .dialog a,
 body.-emu #sidebar a,
 body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) a {
-  text-shadow: none; }
-  body.-emu .dialog a:hover,
-  body.-emu #sidebar a:hover,
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) a:hover {
-    color: rgba(var(--color-primary), 1); }
+  text-shadow: none;
+}
+body.-emu .dialog a:hover,
+body.-emu #sidebar a:hover,
+body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) a:hover {
+  color: rgba(var(--color-primary), 1);
+}
 
 body.-emu .dialog a[href],
 body.-emu #sidebar a[href],
 body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) a[href] {
   color: rgba(var(--color-primary), 1);
   text-decoration: none;
-  text-shadow: none; }
-  body.-emu .dialog a[href]:hover,
-  body.-emu #sidebar a[href]:hover,
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) a[href]:hover {
-    text-decoration: underline;
-    text-shadow: none; }
+  text-shadow: none;
+}
+body.-emu .dialog a[href]:hover,
+body.-emu #sidebar a[href]:hover,
+body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) a[href]:hover {
+  text-decoration: underline;
+  text-shadow: none;
+}
 
 body.-emu .dialog a.entity-link,
 body.-emu .dialog a.inline-roll,
@@ -1998,136 +8864,198 @@ body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) a.inline-roll {
   border: none;
   border-radius: var(--emu-border-radius-controls, 0);
   color: rgba(var(--color-text), 1);
-  text-shadow: none; }
-  .-emu-layout body.-emu .dialog a.entity-link, .-emu-layout
-  body.-emu .dialog a.inline-roll, .-emu-layout
-  body.-emu #sidebar a.entity-link, .-emu-layout
-  body.-emu #sidebar a.inline-roll, .-emu-layout
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) a.entity-link, .-emu-layout
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) a.inline-roll {
-    padding: var(--emu-space-pf) var(--emu-space-xs);
-    -webkit-padding-start: var(--emu-space-base);
-            padding-inline-start: var(--emu-space-base); }
-  body.-emu .dialog a.entity-link:hover,
-  body.-emu .dialog a.inline-roll:hover,
-  body.-emu #sidebar a.entity-link:hover,
-  body.-emu #sidebar a.inline-roll:hover,
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) a.entity-link:hover,
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) a.inline-roll:hover {
-    color: rgba(var(--color-primary), 1); }
-  body.-emu .dialog a.entity-link > i,
-  body.-emu .dialog a.inline-roll > i,
-  body.-emu #sidebar a.entity-link > i,
-  body.-emu #sidebar a.inline-roll > i,
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) a.entity-link > i,
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) a.inline-roll > i {
-    color: inherit; }
-    .-emu-layout body.-emu .dialog a.entity-link > i, .-emu-layout
-    body.-emu .dialog a.inline-roll > i, .-emu-layout
-    body.-emu #sidebar a.entity-link > i, .-emu-layout
-    body.-emu #sidebar a.inline-roll > i, .-emu-layout
-    body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) a.entity-link > i, .-emu-layout
-    body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) a.inline-roll > i {
-      -webkit-margin-end: var(--emu-space-xs);
-              margin-inline-end: var(--emu-space-xs); }
+  text-shadow: none;
+}
+.-emu-layout body.-emu .dialog a.entity-link,
+.-emu-layout body.-emu .dialog a.inline-roll,
+.-emu-layout body.-emu #sidebar a.entity-link,
+.-emu-layout body.-emu #sidebar a.inline-roll,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  a.entity-link,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  a.inline-roll {
+  padding: var(--emu-space-pf) var(--emu-space-xs);
+  -webkit-padding-start: var(--emu-space-base);
+  padding-inline-start: var(--emu-space-base);
+}
+body.-emu .dialog a.entity-link:hover,
+body.-emu .dialog a.inline-roll:hover,
+body.-emu #sidebar a.entity-link:hover,
+body.-emu #sidebar a.inline-roll:hover,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  a.entity-link:hover,
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  a.inline-roll:hover {
+  color: rgba(var(--color-primary), 1);
+}
+body.-emu .dialog a.entity-link > i,
+body.-emu .dialog a.inline-roll > i,
+body.-emu #sidebar a.entity-link > i,
+body.-emu #sidebar a.inline-roll > i,
+body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) a.entity-link > i,
+body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) a.inline-roll > i {
+  color: inherit;
+}
+.-emu-layout body.-emu .dialog a.entity-link > i,
+.-emu-layout body.-emu .dialog a.inline-roll > i,
+.-emu-layout body.-emu #sidebar a.entity-link > i,
+.-emu-layout body.-emu #sidebar a.inline-roll > i,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  a.entity-link
+  > i,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  a.inline-roll
+  > i {
+  -webkit-margin-end: var(--emu-space-xs);
+  margin-inline-end: var(--emu-space-xs);
+}
 
-.-emu-layout body.-emu .dialog p, .-emu-layout
-body.-emu #sidebar p, .-emu-layout
-body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) p {
-  margin: var(--emu-space-base) 0; }
+.-emu-layout body.-emu .dialog p,
+.-emu-layout body.-emu #sidebar p,
+.-emu-layout body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) p {
+  margin: var(--emu-space-base) 0;
+}
 
-.-emu-layout body.-emu .dialog ul, .-emu-layout
-body.-emu .dialog ol, .-emu-layout
-body.-emu #sidebar ul, .-emu-layout
-body.-emu #sidebar ol, .-emu-layout
-body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) ul, .-emu-layout
-body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) ol {
+.-emu-layout body.-emu .dialog ul,
+.-emu-layout body.-emu .dialog ol,
+.-emu-layout body.-emu #sidebar ul,
+.-emu-layout body.-emu #sidebar ol,
+.-emu-layout body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) ul,
+.-emu-layout body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) ol {
   margin: var(--emu-space-base) 0;
   -webkit-margin-after: var(--emu-space-base);
-          margin-block-end: var(--emu-space-base); }
+  margin-block-end: var(--emu-space-base);
+}
 
-.-emu-layout body.-emu .dialog dl, .-emu-layout
-body.-emu #sidebar dl, .-emu-layout
-body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) dl {
-  margin: var(--emu-space-base) 0; }
+.-emu-layout body.-emu .dialog dl,
+.-emu-layout body.-emu #sidebar dl,
+.-emu-layout body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) dl {
+  margin: var(--emu-space-base) 0;
+}
 
-.-emu-layout body.-emu .dialog dd, .-emu-layout
-body.-emu #sidebar dd, .-emu-layout
-body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) dd {
+.-emu-layout body.-emu .dialog dd,
+.-emu-layout body.-emu #sidebar dd,
+.-emu-layout body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) dd {
   -webkit-padding-end: var(--emu-space-base);
-          padding-inline-end: var(--emu-space-base);
-  margin: var(--emu-space-base) 0; }
+  padding-inline-end: var(--emu-space-base);
+  margin: var(--emu-space-base) 0;
+}
 
 body.-emu .dialog hr,
 body.-emu #sidebar hr,
 body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) hr {
   border: none;
   -webkit-border-before: rgba(var(--color-border), 1) 1px solid;
-          border-block-start: rgba(var(--color-border), 1) 1px solid;
+  border-block-start: rgba(var(--color-border), 1) 1px solid;
   -webkit-border-after: none;
-          border-block-end: none; }
+  border-block-end: none;
+}
 
 body.-emu .dialog button[hidden],
 body.-emu #sidebar button[hidden],
 body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) button[hidden] {
-  display: none; }
+  display: none;
+}
 
 body.-emu .dialog blockquote,
 body.-emu #sidebar blockquote,
 body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) blockquote {
   -webkit-border-start: 3px solid rgba(var(--color-border), 1);
-          border-inline-start: 3px solid rgba(var(--color-border), 1); }
-  .-emu-layout body.-emu .dialog blockquote, .-emu-layout
-  body.-emu #sidebar blockquote, .-emu-layout
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) blockquote {
-    margin: var(--emu-space-base) 0 var(--emu-space-base) var(--emu-space-md);
-    -webkit-padding-start: 1.5rem;
-            padding-inline-start: 1.5rem; }
-    .-emu-layout body.-emu .dialog blockquote em, .-emu-layout
-    body.-emu #sidebar blockquote em, .-emu-layout
-    body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) blockquote em {
-      font-style: normal; }
+  border-inline-start: 3px solid rgba(var(--color-border), 1);
+}
+.-emu-layout body.-emu .dialog blockquote,
+.-emu-layout body.-emu #sidebar blockquote,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  blockquote {
+  margin: var(--emu-space-base) 0 var(--emu-space-base) var(--emu-space-md);
+  -webkit-padding-start: 1.5rem;
+  padding-inline-start: 1.5rem;
+}
+.-emu-layout body.-emu .dialog blockquote em,
+.-emu-layout body.-emu #sidebar blockquote em,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  blockquote
+  em {
+  font-style: normal;
+}
 
 body.-emu .dialog section.secret,
 body.-emu #sidebar section.secret,
 body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) section.secret {
   background-color: rgba(var(--color-background-light), 0.2);
   -webkit-border-before: rgba(var(--color-border), 1) 1px solid;
-          border-block-start: rgba(var(--color-border), 1) 1px solid;
+  border-block-start: rgba(var(--color-border), 1) 1px solid;
   -webkit-border-after: rgba(var(--color-border), 1) 1px solid;
-          border-block-end: rgba(var(--color-border), 1) 1px solid; }
-  .-emu-layout body.-emu .dialog section.secret, .-emu-layout
-  body.-emu #sidebar section.secret, .-emu-layout
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) section.secret {
-    padding: 0 var(--emu-space-base); }
+  border-block-end: rgba(var(--color-border), 1) 1px solid;
+}
+.-emu-layout body.-emu .dialog section.secret,
+.-emu-layout body.-emu #sidebar section.secret,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  section.secret {
+  padding: 0 var(--emu-space-base);
+}
 
 body.-emu .dialog .tox-toolbar__primary,
 body.-emu #sidebar .tox-toolbar__primary,
-body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .tox-toolbar__primary {
-  background: transparent; }
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .tox-toolbar__primary {
+  background: transparent;
+}
 
 body.-emu .dialog .tox.tox-tinymce .tox-edit-area__iframe,
 body.-emu #sidebar .tox.tox-tinymce .tox-edit-area__iframe,
-body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .tox.tox-tinymce .tox-edit-area__iframe {
-  background-color: rgba(var(--color-white), 1); }
-  .-emu-layout body.-emu .dialog .tox.tox-tinymce .tox-edit-area__iframe, .-emu-layout
-  body.-emu #sidebar .tox.tox-tinymce .tox-edit-area__iframe, .-emu-layout
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .tox.tox-tinymce .tox-edit-area__iframe {
-    padding: var(--emu-space-base); }
+body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .tox.tox-tinymce
+  .tox-edit-area__iframe {
+  background-color: rgba(var(--color-white), 1);
+}
+.-emu-layout body.-emu .dialog .tox.tox-tinymce .tox-edit-area__iframe,
+.-emu-layout body.-emu #sidebar .tox.tox-tinymce .tox-edit-area__iframe,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .tox.tox-tinymce
+  .tox-edit-area__iframe {
+  padding: var(--emu-space-base);
+}
 
 body.-emu .dialog .tox .tox-tbtn,
 body.-emu #sidebar .tox .tox-tbtn,
 body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .tox .tox-tbtn {
   background: transparent;
-  color: rgba(var(--color-text), 1); }
-  .-emu-layout body.-emu .dialog .tox .tox-tbtn, .-emu-layout
-  body.-emu #sidebar .tox .tox-tbtn, .-emu-layout
-  body.-emu .window-app:not([id*="actor-"]):not([id*="item-"]) .tox .tox-tbtn {
-    font-size: var(--emu-font-size-sm);
-    height: var(--emu-space-button-sm);
-    -webkit-margin-before: var(--emu-space-xs);
-            margin-block-start: var(--emu-space-xs);
-    padding: 0 var(--emu-space-base); }
+  color: rgba(var(--color-text), 1);
+}
+.-emu-layout body.-emu .dialog .tox .tox-tbtn,
+.-emu-layout body.-emu #sidebar .tox .tox-tbtn,
+.-emu-layout
+  body.-emu
+  .window-app:not([id*="actor-"]):not([id*="item-"])
+  .tox
+  .tox-tbtn {
+  font-size: var(--emu-font-size-sm);
+  height: var(--emu-space-button-sm);
+  -webkit-margin-before: var(--emu-space-xs);
+  margin-block-start: var(--emu-space-xs);
+  padding: 0 var(--emu-space-base);
+}
 
 body.-emu #context-menu {
   background-color: rgba(var(--color-background-lightest), 1);
@@ -2135,384 +9063,502 @@ body.-emu #context-menu {
   border: rgba(var(--color-border), 1) 1px solid;
   border-radius: var(--emu-border-radius-default, 0);
   box-shadow: 0 2px 4px rgba(var(--color-black), 1);
-  color: rgba(var(--color-text), 1); }
-  .-emu-layout body.-emu #context-menu {
-    left: 0;
-    position: absolute;
-    max-width: 20rem;
-    min-width: 9.5rem;
-    width: 100%;
-    z-index: 1070; }
-    .-emu-layout body.-emu #context-menu.expand-down {
-      top: 100%; }
-    .-emu-layout body.-emu #context-menu.expand-up {
-      bottom: 100%; }
-  body.-emu #context-menu ol.context-items .context-item {
-    text-shadow: none; }
-    .-emu-layout body.-emu #context-menu ol.context-items .context-item {
-      cursor: pointer;
-      line-height: initial;
-      padding: var(--emu-space-base);
-      text-align: left; }
-    body.-emu #context-menu ol.context-items .context-item:first-child {
-      border-radius: var(--emu-border-radius-default, 0) var(--emu-border-radius-default, 0) 0 0; }
-    body.-emu #context-menu ol.context-items .context-item:last-child {
-      border-radius: 0 0 var(--emu-border-radius-default, 0) var(--emu-border-radius-default, 0); }
-    body.-emu #context-menu ol.context-items .context-item:hover {
-      background-color: rgba(var(--color-primary), 1);
-      color: rgba(var(--color-text-lightest), 1); }
-  .window-app body.-emu #context-menu {
-    z-index: 101; }
+  color: rgba(var(--color-text), 1);
+}
+.-emu-layout body.-emu #context-menu {
+  left: 0;
+  position: absolute;
+  max-width: 20rem;
+  min-width: 9.5rem;
+  width: 100%;
+  z-index: 1070;
+}
+.-emu-layout body.-emu #context-menu.expand-down {
+  top: 100%;
+}
+.-emu-layout body.-emu #context-menu.expand-up {
+  bottom: 100%;
+}
+body.-emu #context-menu ol.context-items .context-item {
+  text-shadow: none;
+}
+.-emu-layout body.-emu #context-menu ol.context-items .context-item {
+  cursor: pointer;
+  line-height: initial;
+  padding: var(--emu-space-base);
+  text-align: left;
+}
+body.-emu #context-menu ol.context-items .context-item:first-child {
+  border-radius: var(--emu-border-radius-default, 0)
+    var(--emu-border-radius-default, 0) 0 0;
+}
+body.-emu #context-menu ol.context-items .context-item:last-child {
+  border-radius: 0 0 var(--emu-border-radius-default, 0)
+    var(--emu-border-radius-default, 0);
+}
+body.-emu #context-menu ol.context-items .context-item:hover {
+  background-color: rgba(var(--color-primary), 1);
+  color: rgba(var(--color-text-lightest), 1);
+}
+.window-app body.-emu #context-menu {
+  z-index: 101;
+}
 
 .-emu-layout body.-emu .dialog.window-app > .window-content {
-  padding: 0; }
+  padding: 0;
+}
 
 .-emu-layout body.-emu .dialog div.dialog-content {
   padding: 0 var(--emu-space-sm);
   -webkit-padding-before: var(--emu-space-sm);
-          padding-block-start: var(--emu-space-sm); }
+  padding-block-start: var(--emu-space-sm);
+}
 
-.-emu-layout body.-emu .dialog div.dialog-content h4:first-child, .-emu-layout
-body.-emu .dialog div.dialog-content p:first-child {
+.-emu-layout body.-emu .dialog div.dialog-content h4:first-child,
+.-emu-layout body.-emu .dialog div.dialog-content p:first-child {
   -webkit-margin-before: var(--emu-space-base);
-          margin-block-start: var(--emu-space-base); }
+  margin-block-start: var(--emu-space-base);
+}
 
 .-emu-layout body.-emu .dialog div.dialog-content > p {
   margin: 0;
   -webkit-margin-after: var(--emu-space-sm);
-          margin-block-end: var(--emu-space-sm); }
+  margin-block-end: var(--emu-space-sm);
+}
 
 .-emu-layout body.-emu .dialog form.dialog-content {
   -webkit-padding-before: var(--emu-space-md);
-          padding-block-start: var(--emu-space-md); }
+  padding-block-start: var(--emu-space-md);
+}
 
 body.-emu .dialog .dialog-content {
-  color: rgba(var(--color-text), 1); }
-  .-emu-layout body.-emu .dialog .dialog-content {
-    font-size: var(--emu-font-size-lg);
-    padding: var(--emu-space-sm); }
-  .-emu-layout body.-emu .dialog .dialog-content > p + .form-group {
-    -webkit-margin-before: var(--emu-space-md);
-            margin-block-start: var(--emu-space-md); }
-  .-emu-layout body.-emu .dialog .dialog-content > .form-group {
-    padding: 0; }
-  .-emu-layout body.-emu .dialog .dialog-content > .form-group + .dialog-buttons {
-    padding: 0;
-    -webkit-padding-before: var(--emu-space-sm);
-            padding-block-start: var(--emu-space-sm); }
-  .-emu-layout body.-emu .dialog .dialog-content > h3 {
-    -webkit-margin-before: 0;
-            margin-block-start: 0; }
-  .-emu-layout body.-emu .dialog .dialog-content > h3:first-child {
-    -webkit-margin-before: var(--emu-space-md);
-            margin-block-start: var(--emu-space-md); }
-  .-emu-layout body.-emu .dialog .dialog-content > p:first-child {
-    -webkit-margin-before: var(--emu-space-sm);
-            margin-block-start: var(--emu-space-sm); }
+  color: rgba(var(--color-text), 1);
+}
+.-emu-layout body.-emu .dialog .dialog-content {
+  font-size: var(--emu-font-size-lg);
+  padding: var(--emu-space-sm);
+}
+.-emu-layout body.-emu .dialog .dialog-content > p + .form-group {
+  -webkit-margin-before: var(--emu-space-md);
+  margin-block-start: var(--emu-space-md);
+}
+.-emu-layout body.-emu .dialog .dialog-content > .form-group {
+  padding: 0;
+}
+.-emu-layout body.-emu .dialog .dialog-content > .form-group + .dialog-buttons {
+  padding: 0;
+  -webkit-padding-before: var(--emu-space-sm);
+  padding-block-start: var(--emu-space-sm);
+}
+.-emu-layout body.-emu .dialog .dialog-content > h3 {
+  -webkit-margin-before: 0;
+  margin-block-start: 0;
+}
+.-emu-layout body.-emu .dialog .dialog-content > h3:first-child {
+  -webkit-margin-before: var(--emu-space-md);
+  margin-block-start: var(--emu-space-md);
+}
+.-emu-layout body.-emu .dialog .dialog-content > p:first-child {
+  -webkit-margin-before: var(--emu-space-sm);
+  margin-block-start: var(--emu-space-sm);
+}
 
 .-emu-layout body.-emu .dialog .dialog-buttons {
   display: flex;
   flex: 0 0 auto;
-  padding: var(--emu-space-sm); }
+  padding: var(--emu-space-sm);
+}
 
 body.-emu .dialog .dialog-buttons:empty {
-  display: none; }
+  display: none;
+}
 
 .-emu-layout body.-emu .dialog #entity-create label {
-  flex: 0 0 30%; }
+  flex: 0 0 30%;
+}
 
 .-emu-layout body.-emu #hotbar {
-  bottom: var(--emu-space-sm);
-  left: 13.5rem;
+  bottom: 0.4em;
+  left: 14.5rem;
   position: fixed;
   width: auto;
   height: auto;
   display: flex;
   pointer-events: none;
   transition: opacity 0.3s cubic-bezier(0.075, 0.82, 0.165, 1);
-  z-index: 10; }
-  .-emu-layout body.-emu #hotbar:hover {
-    z-index: 11; }
+  z-index: 10;
+}
+.-emu-layout body.-emu #hotbar:hover {
+  z-index: 11;
+}
 
 .-emu-layout.-emu-players body.-emu #hotbar {
-  left: var(--emu-space-sm); }
+  left: var(--emu-space-sm);
+}
 
 .-emu-layout.-emu-players.-emu-compact body.-emu #hotbar {
-  left: var(--emu-space-sm); }
+  left: var(--emu-space-sm);
+}
 
 .-emu-layout.-emu-compact body.-emu #hotbar {
-  left: 11rem; }
+  left: 11.125rem;
+  bottom: 0.28rem;
+}
 
 .-emu-layout.-emu-subtle-layout body.-emu #hotbar {
-  opacity: var(--emu-subtle-opacity, 0.3); }
-  .-emu-layout.-emu-subtle-layout body.-emu #hotbar:hover {
-    opacity: 1; }
-    .-emu-layout.-emu-subtle-layout body.-emu #hotbar:hover #action-bar {
-      opacity: 1; }
-  .-emu-layout.-emu-subtle-layout body.-emu #hotbar::before {
-    content: "";
-    bottom: calc(-1 * var(--emu-space-sm));
-    left: calc(-1 * var(--emu-space-sm));
-    right: calc(-1 * var(--emu-space-sm));
-    top: calc(-1 * var(--emu-space-sm));
-    position: absolute; }
+  opacity: var(--emu-subtle-opacity, 0.3);
+}
+.-emu-layout.-emu-subtle-layout body.-emu #hotbar:hover {
+  opacity: 1;
+}
+.-emu-layout.-emu-subtle-layout body.-emu #hotbar:hover #action-bar {
+  opacity: 1;
+}
+.-emu-layout.-emu-subtle-layout body.-emu #hotbar::before {
+  content: "";
+  bottom: calc(-1 * var(--emu-space-sm));
+  left: calc(-1 * var(--emu-space-sm));
+  right: calc(-1 * var(--emu-space-sm));
+  top: calc(-1 * var(--emu-space-sm));
+  position: absolute;
+}
 
 body.-emu #hotbar #action-bar {
-  transition: opacity 0.3s cubic-bezier(0.075, 0.82, 0.165, 1); }
-  .-emu-layout body.-emu #hotbar #action-bar {
-    display: flex;
-    flex: 1 1 auto;
-    flex-wrap: nowrap;
-    height: auto;
-    margin: 0;
-    pointer-events: all;
-    position: relative; }
-  .-emu-layout.-emu-subtle-layout body.-emu #hotbar #action-bar {
-    opacity: 0; }
+  transition: opacity 0.3s cubic-bezier(0.075, 0.82, 0.165, 1);
+}
+.-emu-layout body.-emu #hotbar #action-bar {
+  display: flex;
+  flex: 1 1 auto;
+  flex-wrap: nowrap;
+  height: auto;
+  margin: 0;
+  pointer-events: all;
+  position: relative;
+}
+.-emu-layout.-emu-subtle-layout body.-emu #hotbar #action-bar {
+  opacity: 0;
+}
 
 body.-emu #hotbar #macro-list {
   border: none;
-  border-radius: var(--emu-border-radius-default, 0); }
-  .-emu-layout body.-emu #hotbar #macro-list {
-    display: flex;
-    flex: 0 0 auto;
-    float: left;
-    height: auto;
-    position: relative;
-    width: auto; }
+  border-radius: var(--emu-border-radius-default, 0);
+}
+.-emu-layout body.-emu #hotbar #macro-list {
+  display: flex;
+  flex: 0 0 auto;
+  float: left;
+  height: auto;
+  position: relative;
+  width: auto;
+}
 
 body.-emu #hotbar .bar-controls {
   background: transparent;
   border: rgba(var(--color-border), 1) 1px solid;
   border-radius: var(--emu-border-radius-default, 0);
-  box-shadow: none; }
-  .-emu-layout body.-emu #hotbar .bar-controls {
-    width: 2.5rem;
-    height: 3.5rem;
-    display: flex;
-    flex-direction: column;
-    margin: 0;
-    position: relative; }
-  .-emu-layout.-emu-compact body.-emu #hotbar .bar-controls {
-    width: 2rem;
-    height: 2.5rem; }
-  .-emu-layout body.-emu #hotbar .bar-controls:first-child {
-    flex: 0 0 auto;
-    flex-direction: column;
-    -webkit-margin-end: var(--emu-space-base);
-            margin-inline-end: var(--emu-space-base); }
-  .-emu-layout body.-emu #hotbar .bar-controls:first-child #macro-directory, .-emu-layout
-  body.-emu #hotbar .bar-controls:first-child #bar-toggle {
-    flex: 1 1 auto; }
-  body.-emu #hotbar .bar-controls:first-child #macro-directory:first-of-type,
-  body.-emu #hotbar .bar-controls:first-child #bar-toggle:first-of-type {
-    border: none;
-    -webkit-border-after: rgba(var(--color-border), 1) 1px solid;
-            border-block-end: rgba(var(--color-border), 1) 1px solid;
-    border-radius: var(--emu-border-radius-default, 0) var(--emu-border-radius-default, 0) 0 0; }
-  body.-emu #hotbar .bar-controls:first-child #macro-directory:last-of-type,
-  body.-emu #hotbar .bar-controls:first-child #bar-toggle:last-of-type {
-    border: none;
-    border-radius: 0 0 var(--emu-border-radius-default, 0) var(--emu-border-radius-default, 0); }
-  .-emu-layout body.-emu #hotbar .bar-controls:last-child {
-    float: left;
-    -webkit-margin-start: var(--emu-space-base);
-            margin-inline-start: var(--emu-space-base); }
-  body.-emu #hotbar .bar-controls .page-control:first-of-type {
-    border-radius: var(--emu-border-radius-default, 0) var(--emu-border-radius-default, 0) 0 0; }
-  body.-emu #hotbar .bar-controls .page-control:last-of-type {
-    border-radius: 0 0 var(--emu-border-radius-default, 0) var(--emu-border-radius-default, 0); }
-  body.-emu #hotbar .bar-controls .page-control,
-  body.-emu #hotbar .bar-controls #macro-directory,
-  body.-emu #hotbar .bar-controls #bar-toggle {
-    background-color: rgba(var(--color-background), var(--emu-background-opacity-hotbar, 0.8));
-    background-image: var(--emu-image-background-controls, none);
-    color: rgba(var(--color-text-lightest), 1);
-    transition: box-shadow 0.3s cubic-bezier(0.075, 0.82, 0.165, 1); }
-    .-emu-layout body.-emu #hotbar .bar-controls .page-control, .-emu-layout
-    body.-emu #hotbar .bar-controls #macro-directory, .-emu-layout
-    body.-emu #hotbar .bar-controls #bar-toggle {
-      align-items: center;
-      cursor: pointer;
-      display: flex;
-      flex: 0 0 auto;
-      font-size: var(--emu-font-size-lg);
-      justify-content: center;
-      line-height: initial;
-      position: relative; }
-    body.-emu #hotbar .bar-controls .page-control:first-of-type,
-    body.-emu #hotbar .bar-controls #macro-directory:first-of-type,
-    body.-emu #hotbar .bar-controls #bar-toggle:first-of-type {
-      -webkit-border-after: rgba(var(--color-border), 1) 1px solid;
-              border-block-end: rgba(var(--color-border), 1) 1px solid; }
-    body.-emu #hotbar .bar-controls .page-control:last-of-type,
-    body.-emu #hotbar .bar-controls #macro-directory:last-of-type,
-    body.-emu #hotbar .bar-controls #bar-toggle:last-of-type {
-      -webkit-border-before: rgba(var(--color-border), 1) 1px solid;
-              border-block-start: rgba(var(--color-border), 1) 1px solid; }
-  .-emu-layout.-emu-compact body.-emu #hotbar .bar-controls .page-control {
-    font-size: var(--emu-font-size-xs); }
-  body.-emu #hotbar .bar-controls .page-number {
-    background-color: rgba(var(--color-background), var(--emu-background-opacity-hotbar, 0.8));
-    background-image: var(--emu-image-background-controls, none);
-    color: rgba(var(--color-text-lightest), 1); }
-    .-emu-layout body.-emu #hotbar .bar-controls .page-number {
-      display: flex;
-      flex: 1 1 auto;
-      font-size: var(--emu-font-size-md);
-      justify-content: center;
-      line-height: initial; }
+  box-shadow: none;
+}
+.-emu-layout body.-emu #hotbar .bar-controls {
+  width: 2.5rem;
+  height: 3.5rem;
+  display: flex;
+  flex-direction: column;
+  margin: 0;
+  position: relative;
+}
+.-emu-layout.-emu-compact body.-emu #hotbar .bar-controls {
+  width: 2rem;
+  height: 2.5rem;
+}
+.-emu-layout body.-emu #hotbar .bar-controls:first-child {
+  flex: 0 0 auto;
+  flex-direction: column;
+  -webkit-margin-end: var(--emu-space-base);
+  margin-inline-end: var(--emu-space-base);
+}
+.-emu-layout body.-emu #hotbar .bar-controls:first-child #macro-directory,
+.-emu-layout body.-emu #hotbar .bar-controls:first-child #bar-toggle {
+  flex: 1 1 auto;
+}
+body.-emu #hotbar .bar-controls:first-child #macro-directory:first-of-type,
+body.-emu #hotbar .bar-controls:first-child #bar-toggle:first-of-type {
+  border: none;
+  -webkit-border-after: rgba(var(--color-border), 1) 1px solid;
+  border-block-end: rgba(var(--color-border), 1) 1px solid;
+  border-radius: var(--emu-border-radius-default, 0)
+    var(--emu-border-radius-default, 0) 0 0;
+}
+body.-emu #hotbar .bar-controls:first-child #macro-directory:last-of-type,
+body.-emu #hotbar .bar-controls:first-child #bar-toggle:last-of-type {
+  border: none;
+  border-radius: 0 0 var(--emu-border-radius-default, 0)
+    var(--emu-border-radius-default, 0);
+}
+.-emu-layout body.-emu #hotbar .bar-controls:last-child {
+  float: left;
+  -webkit-margin-start: var(--emu-space-base);
+  margin-inline-start: var(--emu-space-base);
+}
+body.-emu #hotbar .bar-controls .page-control:first-of-type {
+  border-radius: var(--emu-border-radius-default, 0)
+    var(--emu-border-radius-default, 0) 0 0;
+}
+body.-emu #hotbar .bar-controls .page-control:last-of-type {
+  border-radius: 0 0 var(--emu-border-radius-default, 0)
+    var(--emu-border-radius-default, 0);
+}
+body.-emu #hotbar .bar-controls .page-control,
+body.-emu #hotbar .bar-controls #macro-directory,
+body.-emu #hotbar .bar-controls #bar-toggle {
+  background-color: rgba(
+    var(--color-background),
+    var(--emu-background-opacity-hotbar, 0.8)
+  );
+  background-image: var(--emu-image-background-controls, none);
+  color: rgba(var(--color-text-lightest), 1);
+  transition: box-shadow 0.3s cubic-bezier(0.075, 0.82, 0.165, 1);
+}
+.-emu-layout body.-emu #hotbar .bar-controls .page-control,
+.-emu-layout body.-emu #hotbar .bar-controls #macro-directory,
+.-emu-layout body.-emu #hotbar .bar-controls #bar-toggle {
+  align-items: center;
+  cursor: pointer;
+  display: flex;
+  flex: 0 0 auto;
+  font-size: var(--emu-font-size-lg);
+  justify-content: center;
+  line-height: initial;
+  position: relative;
+}
+body.-emu #hotbar .bar-controls .page-control:first-of-type,
+body.-emu #hotbar .bar-controls #macro-directory:first-of-type,
+body.-emu #hotbar .bar-controls #bar-toggle:first-of-type {
+  -webkit-border-after: rgba(var(--color-border), 1) 1px solid;
+  border-block-end: rgba(var(--color-border), 1) 1px solid;
+}
+body.-emu #hotbar .bar-controls .page-control:last-of-type,
+body.-emu #hotbar .bar-controls #macro-directory:last-of-type,
+body.-emu #hotbar .bar-controls #bar-toggle:last-of-type {
+  -webkit-border-before: rgba(var(--color-border), 1) 1px solid;
+  border-block-start: rgba(var(--color-border), 1) 1px solid;
+}
+.-emu-layout.-emu-compact body.-emu #hotbar .bar-controls .page-control {
+  font-size: var(--emu-font-size-xs);
+}
+body.-emu #hotbar .bar-controls .page-number {
+  background-color: rgba(
+    var(--color-background),
+    var(--emu-background-opacity-hotbar, 0.8)
+  );
+  background-image: var(--emu-image-background-controls, none);
+  color: rgba(var(--color-text-lightest), 1);
+}
+.-emu-layout body.-emu #hotbar .bar-controls .page-number {
+  display: flex;
+  flex: 1 1 auto;
+  font-size: var(--emu-font-size-md);
+  justify-content: center;
+  line-height: initial;
+}
 
 body.-emu #hotbar .macro {
-  background-color: rgba(var(--color-background), var(--emu-background-opacity-hotbar, 0.8));
+  background-color: rgba(
+    var(--color-background),
+    var(--emu-background-opacity-hotbar, 0.8)
+  );
   background-image: var(--emu-image-background-controls, none);
   border: rgba(var(--color-border), 1) 1px solid;
   border-radius: 0;
   box-shadow: none;
   color: rgba(var(--color-text-lightest), 1);
-  transition: border 0.3s cubic-bezier(0.075, 0.82, 0.165, 1), box-shadow 0.3s cubic-bezier(0.075, 0.82, 0.165, 1); }
-  .-emu-layout body.-emu #hotbar .macro {
-    width: 3.5rem;
-    height: 3.5rem;
-    cursor: pointer;
-    display: flex;
-    flex: 0 0 auto;
-    justify-content: center;
-    -webkit-margin-start: -1px;
-            margin-inline-start: -1px;
-    position: relative; }
-  .-emu-layout.-emu-compact body.-emu #hotbar .macro {
-    width: 2.5rem;
-    height: 2.5rem; }
-  body.-emu #hotbar .macro:first-child {
-    border-radius: var(--emu-border-radius-default, 0) 0 0 var(--emu-border-radius-default, 0); }
-    .-emu-layout body.-emu #hotbar .macro:first-child {
-      -webkit-margin-start: 0;
-              margin-inline-start: 0; }
-  body.-emu #hotbar .macro:last-child {
-    border-radius: 0 var(--emu-border-radius-default, 0) var(--emu-border-radius-default, 0) 0; }
-  body.-emu #hotbar .macro.active {
-    background-color: rgba(var(--color-background), var(--emu-background-opacity-hotbar, 0.8)); }
-  body.-emu #hotbar .macro .macro-key {
-    background: transparent;
-    color: rgba(var(--color-text-lightest), 1);
-    font-weight: 600;
-    text-shadow: 2px 2px 2px rgba(var(--color-black), 1); }
-    .-emu-layout body.-emu #hotbar .macro .macro-key {
-      top: var(--emu-space-xs);
-      right: var(--emu-space-base);
-      position: absolute;
-      padding: 0;
-      z-index: 1; }
-  body.-emu #hotbar .macro .macro-icon {
-    border: none; }
-    .-emu-layout body.-emu #hotbar .macro .macro-icon {
-      width: 3.125rem;
-      height: 3.125rem;
-      max-height: 100%;
-      max-width: 100%;
-      -o-object-fit: cover;
-         object-fit: cover;
-      -o-object-position: 50% 50%;
-         object-position: 50% 50%;
-      position: relative; }
-    .-emu-layout.-emu-compact body.-emu #hotbar .macro .macro-icon {
-      width: 2.125rem;
-      height: 2.125rem; }
-  body.-emu #hotbar .macro .tooltip {
-    background-color: rgba(var(--color-background-darkest), 1);
-    border: none;
-    border-radius: var(--emu-border-radius-default, 0);
-    color: rgba(var(--color-text-lightest), 1); }
-    .-emu-layout body.-emu #hotbar .macro .tooltip {
-      font-size: var(--emu-font-size-md);
-      height: auto;
-      left: 0;
-      line-height: auto;
-      -webkit-margin-after: var(--emu-space-base);
-              margin-block-end: var(--emu-space-base);
-      min-width: 3.5rem;
-      padding: var(--emu-space-base) var(--emu-space-sm); }
+  transition: border 0.3s cubic-bezier(0.075, 0.82, 0.165, 1),
+    box-shadow 0.3s cubic-bezier(0.075, 0.82, 0.165, 1);
+}
+.-emu-layout body.-emu #hotbar .macro {
+  width: 3.5rem;
+  height: 3.5rem;
+  cursor: pointer;
+  display: flex;
+  flex: 0 0 auto;
+  justify-content: center;
+  -webkit-margin-start: -1px;
+  margin-inline-start: -1px;
+  position: relative;
+}
+.-emu-layout.-emu-compact body.-emu #hotbar .macro {
+  width: 2.5rem;
+  height: 2.5rem;
+}
+body.-emu #hotbar .macro:first-child {
+  border-radius: var(--emu-border-radius-default, 0) 0 0
+    var(--emu-border-radius-default, 0);
+}
+.-emu-layout body.-emu #hotbar .macro:first-child {
+  -webkit-margin-start: 0;
+  margin-inline-start: 0;
+}
+body.-emu #hotbar .macro:last-child {
+  border-radius: 0 var(--emu-border-radius-default, 0)
+    var(--emu-border-radius-default, 0) 0;
+}
+body.-emu #hotbar .macro.active {
+  background-color: rgba(
+    var(--color-background),
+    var(--emu-background-opacity-hotbar, 0.8)
+  );
+}
+body.-emu #hotbar .macro .macro-key {
+  background: transparent;
+  color: rgba(var(--color-text-lightest), 1);
+  font-weight: 600;
+  text-shadow: 2px 2px 2px rgba(var(--color-black), 1);
+}
+.-emu-layout body.-emu #hotbar .macro .macro-key {
+  top: var(--emu-space-xs);
+  right: var(--emu-space-base);
+  position: absolute;
+  padding: 0;
+  z-index: 1;
+}
+body.-emu #hotbar .macro .macro-icon {
+  border: none;
+}
+.-emu-layout body.-emu #hotbar .macro .macro-icon {
+  width: 3.125rem;
+  height: 3.125rem;
+  max-height: 100%;
+  max-width: 100%;
+  -o-object-fit: cover;
+  object-fit: cover;
+  -o-object-position: 50% 50%;
+  object-position: 50% 50%;
+  position: relative;
+}
+.-emu-layout.-emu-compact body.-emu #hotbar .macro .macro-icon {
+  width: 2.125rem;
+  height: 2.125rem;
+}
+body.-emu #hotbar .macro .tooltip {
+  background-color: rgba(var(--color-background-darkest), 1);
+  border: none;
+  border-radius: var(--emu-border-radius-default, 0);
+  color: rgba(var(--color-text-lightest), 1);
+}
+.-emu-layout body.-emu #hotbar .macro .tooltip {
+  font-size: var(--emu-font-size-md);
+  height: auto;
+  left: 0;
+  line-height: auto;
+  -webkit-margin-after: var(--emu-space-base);
+  margin-block-end: var(--emu-space-base);
+  min-width: 3.5rem;
+  padding: var(--emu-space-base) var(--emu-space-sm);
+}
 
 body.-emu #hud input[type="text"] {
   background: rgba(var(--color-background-lightest), 1);
-  border: rgba(var(--color-border), 1) 1px solid; }
-  .-emu-layout body.-emu #hud input[type="text"] {
-    font-size: var(--emu-font-size-xl);
-    height: var(--emu-space-button-lg); }
+  border: rgba(var(--color-border), 1) 1px solid;
+}
+.-emu-layout body.-emu #hud input[type="text"] {
+  font-size: var(--emu-font-size-xl);
+  height: var(--emu-space-button-lg);
+}
 
 .-emu-layout body.-emu #hud .attribute {
   flex: 0 0 auto;
   margin: 0;
   -webkit-margin-after: var(--emu-space-base);
-          margin-block-end: var(--emu-space-base); }
+  margin-block-end: var(--emu-space-base);
+}
 
 .-emu-layout body.-emu #hud .attribute.elevation {
   width: var(--emu-space-button-lg);
   height: var(--emu-space-button-lg);
   flex: 0 0 auto;
-  padding: 0; }
-  .-emu-layout body.-emu #hud .attribute.elevation > input {
-    height: 100%; }
+  padding: 0;
+}
+.-emu-layout body.-emu #hud .attribute.elevation > input {
+  height: 100%;
+}
 
 body.-emu #hud .attribute.elevation > i {
   color: rgba(var(--color-primary), 1);
-  text-shadow: 2px 2px 2px rgba(var(--color-black), 1); }
-  .-emu-layout body.-emu #hud .attribute.elevation > i {
-    z-index: 1; }
+  text-shadow: 2px 2px 2px rgba(var(--color-black), 1);
+}
+.-emu-layout body.-emu #hud .attribute.elevation > i {
+  z-index: 1;
+}
 
 body.-emu #hud .attribute.bar1 input[type="text"] {
-  border-color: rgba(var(--color-positive), 1); }
+  border-color: rgba(var(--color-positive), 1);
+}
 
 .-emu-layout body.-emu #hud .attribute.bar2 {
   -webkit-margin-after: 0;
-          margin-block-end: 0; }
+  margin-block-end: 0;
+}
 
 body.-emu #hud .attribute.bar2 input[type="text"] {
-  border-color: rgba(var(--color-neutral), 1); }
+  border-color: rgba(var(--color-neutral), 1);
+}
 
 .-emu-layout body.-emu #hud .attribute:last-child {
   -webkit-margin-after: 0;
-          margin-block-end: 0; }
+  margin-block-end: 0;
+}
 
 body.-emu #hud .control-icon {
-  background-color: rgba(var(--color-background-darkest), var(--emu-background-opacity-hud, 0.8));
+  background-color: rgba(
+    var(--color-background-darkest),
+    var(--emu-background-opacity-hud, 0.8)
+  );
   background-image: var(--emu-image-background-controls, none);
   border: none;
   border-radius: var(--emu-border-radius-controls, 0);
   box-shadow: none;
   color: rgba(var(--color-text-lightest), 1);
-  transition: background 0.3s cubic-bezier(0.075, 0.82, 0.165, 1), box-shadow 0.3s cubic-bezier(0.075, 0.82, 0.165, 1), color 0.3s cubic-bezier(0.075, 0.82, 0.165, 1), opacity 0.3s cubic-bezier(0.075, 0.82, 0.165, 1); }
-  .-emu-layout body.-emu #hud .control-icon {
-    width: var(--emu-space-button-lg);
-    height: var(--emu-space-button-lg);
-    align-items: center;
-    cursor: pointer;
-    display: flex;
-    justify-content: center;
-    flex: 0 0 auto;
-    font-size: var(--emu-font-size-lg);
-    line-height: initial;
-    margin: 0;
-    -webkit-margin-after: var(--emu-space-base);
-            margin-block-end: var(--emu-space-base);
-    pointer-events: all;
-    position: relative; }
-    .-emu-layout body.-emu #hud .control-icon > i {
-      margin: 0;
-      position: relative; }
-    .-emu-layout body.-emu #hud .control-icon img {
-      margin: 0;
-      opacity: 1; }
-  body.-emu #hud .control-icon:hover {
-    background-image: none; }
-  body.-emu #hud .control-icon:focus {
-    background-image: none; }
-  .-emu-layout body.-emu #hud .control-icon:last-child {
-    -webkit-margin-after: 0;
-            margin-block-end: 0; }
-  body.-emu #hud .control-icon.active {
-    background-image: none; }
+  transition: background 0.3s cubic-bezier(0.075, 0.82, 0.165, 1),
+    box-shadow 0.3s cubic-bezier(0.075, 0.82, 0.165, 1),
+    color 0.3s cubic-bezier(0.075, 0.82, 0.165, 1),
+    opacity 0.3s cubic-bezier(0.075, 0.82, 0.165, 1);
+}
+.-emu-layout body.-emu #hud .control-icon {
+  width: var(--emu-space-button-lg);
+  height: var(--emu-space-button-lg);
+  align-items: center;
+  cursor: pointer;
+  display: flex;
+  justify-content: center;
+  flex: 0 0 auto;
+  font-size: var(--emu-font-size-lg);
+  line-height: initial;
+  margin: 0;
+  -webkit-margin-after: var(--emu-space-base);
+  margin-block-end: var(--emu-space-base);
+  pointer-events: all;
+  position: relative;
+}
+.-emu-layout body.-emu #hud .control-icon > i {
+  margin: 0;
+  position: relative;
+}
+.-emu-layout body.-emu #hud .control-icon img {
+  margin: 0;
+  opacity: 1;
+}
+body.-emu #hud .control-icon:hover {
+  background-image: none;
+}
+body.-emu #hud .control-icon:focus {
+  background-image: none;
+}
+.-emu-layout body.-emu #hud .control-icon:last-child {
+  -webkit-margin-after: 0;
+  margin-block-end: 0;
+}
+body.-emu #hud .control-icon.active {
+  background-image: none;
+}
 
 body.-emu #hud #token-hud .status-effects {
   background-color: rgba(var(--color-background-darkest), 1);
@@ -2520,70 +9566,86 @@ body.-emu #hud #token-hud .status-effects {
   border: rgba(var(--color-border), 1) 1px solid;
   border-radius: var(--emu-border-radius-default, 0);
   box-shadow: none;
-  color: rgba(var(--color-text-lightest), 1); }
-  .-emu-layout body.-emu #hud #token-hud .status-effects {
-    padding: var(--emu-space-base);
-    left: 3rem; }
-    .-emu-layout body.-emu #hud #token-hud .status-effects .effect-control {
-      opacity: 0.4; }
-      .-emu-layout body.-emu #hud #token-hud .status-effects .effect-control:hover {
-        opacity: 0.6; }
-      .-emu-layout body.-emu #hud #token-hud .status-effects .effect-control.active {
-        opacity: 1; }
+  color: rgba(var(--color-text-lightest), 1);
+}
+.-emu-layout body.-emu #hud #token-hud .status-effects {
+  padding: var(--emu-space-base);
+  left: 3rem;
+}
+.-emu-layout body.-emu #hud #token-hud .status-effects .effect-control {
+  opacity: 0.4;
+}
+.-emu-layout body.-emu #hud #token-hud .status-effects .effect-control:hover {
+  opacity: 0.6;
+}
+.-emu-layout body.-emu #hud #token-hud .status-effects .effect-control.active {
+  opacity: 1;
+}
 
 body.-emu #loading {
   background-color: rgba(var(--color-background), 1);
   border: none;
   border-radius: var(--emu-border-radius-default, 0);
-  box-shadow: none; }
-  .-emu-layout body.-emu #loading {
-    top: var(--emu-space-sm);
-    left: 9.25rem;
-    position: fixed;
-    width: calc(100% - 37.5rem);
-    height: 1.5rem;
-    display: none;
-    pointer-events: none;
-    z-index: 10; }
-    .-emu-layout body.-emu #loading::after {
-      top: 0;
-      right: 0;
-      bottom: 0;
-      left: 0;
-      position: absolute;
-      box-shadow: inset 0 0 0 1px rgba(var(--color-white), 1), 0 1px 2px 0 rgba(var(--color-black), 0.3);
-      content: ""; }
-  .-emu-layout.-emu-compact body.-emu #loading {
-    left: 7rem; }
-  body.-emu #loading #loading-bar {
-    background-color: rgba(var(--color-primary), 1);
-    border: none;
-    border-radius: var(--emu-border-radius-default, 0); }
-    .-emu-layout body.-emu #loading #loading-bar {
-      height: 100%;
-      margin: 0;
-      min-width: 25%;
-      position: relative; }
-  body.-emu #loading #context,
-  body.-emu #loading #progress {
-    background: transparent;
-    color: rgba(var(--color-text-lightest), 1);
-    text-shadow: none; }
-    .-emu-layout body.-emu #loading #context, .-emu-layout
-    body.-emu #loading #progress {
-      top: 0;
-      position: absolute;
-      align-items: center;
-      display: flex;
-      height: 100%;
-      font-size: var(--emu-font-size-md);
-      line-height: initial;
-      margin: 0 var(--emu-space-md);
-      padding: 0; }
-  .-emu-layout body.-emu #loading #context {
-    left: 0; }
-  .-emu-layout body.-emu #loading #progress {
-    right: 0; }
+  box-shadow: none;
+}
+.-emu-layout body.-emu #loading {
+  top: var(--emu-space-sm);
+  left: 9.25rem;
+  position: fixed;
+  width: calc(100% - 37.5rem);
+  height: 1.5rem;
+  display: none;
+  pointer-events: none;
+  z-index: 10;
+}
+.-emu-layout body.-emu #loading::after {
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  position: absolute;
+  box-shadow: inset 0 0 0 1px rgba(var(--color-white), 1),
+    0 1px 2px 0 rgba(var(--color-black), 0.3);
+  content: "";
+}
+.-emu-layout.-emu-compact body.-emu #loading {
+  left: 7rem;
+}
+body.-emu #loading #loading-bar {
+  background-color: rgba(var(--color-primary), 1);
+  border: none;
+  border-radius: var(--emu-border-radius-default, 0);
+}
+.-emu-layout body.-emu #loading #loading-bar {
+  height: 100%;
+  margin: 0;
+  min-width: 25%;
+  position: relative;
+}
+body.-emu #loading #context,
+body.-emu #loading #progress {
+  background: transparent;
+  color: rgba(var(--color-text-lightest), 1);
+  text-shadow: none;
+}
+.-emu-layout body.-emu #loading #context,
+.-emu-layout body.-emu #loading #progress {
+  top: 0;
+  position: absolute;
+  align-items: center;
+  display: flex;
+  height: 100%;
+  font-size: var(--emu-font-size-md);
+  line-height: initial;
+  margin: 0 var(--emu-space-md);
+  padding: 0;
+}
+.-emu-layout body.-emu #loading #context {
+  left: 0;
+}
+.-emu-layout body.-emu #loading #progress {
+  right: 0;
+}
 
 .-emu-layout body.-emu #logo {
   top: var(--emu-space-sm);
@@ -2593,246 +9655,311 @@ body.-emu #loading {
   height: auto !important;
   max-height: 2.75rem;
   max-width: 5.5rem;
-  width: auto; }
+  width: auto;
+}
 
 .-emu-layout.-emu-compact body.-emu #logo {
   max-height: 2.125rem;
-  max-width: 4.25rem; }
+  max-width: 4.25rem;
+}
 
 .-emu-layout.-emu-logo body.-emu #logo {
-  display: block !important; }
+  display: block !important;
+}
 
 body.-emu #menu {
   background: transparent;
   border-radius: var(--emu-border-radius-default, 0);
-  box-shadow: none; }
-  .-emu-layout body.-emu #menu {
-    top: 0;
-    left: 0;
-    position: fixed;
-    width: 100%;
-    height: 100%;
-    align-items: center;
-    display: flex;
-    justify-content: center;
-    z-index: 1070; }
-  body.-emu #menu #menu-items {
-    background-color: rgba(var(--color-background-darkest), 1);
-    background-image: var(--emu-image-background-darkest, none);
-    box-shadow: 0 2px 4px rgba(var(--color-black), 1); }
-    .-emu-layout body.-emu #menu #menu-items {
-      display: flex;
-      flex-direction: column;
-      padding: var(--emu-space-sm); }
-    .-emu-layout body.-emu #menu #menu-items li {
-      font-size: var(--emu-font-size-xl);
-      -webkit-margin-after: var(--emu-space-sm);
-              margin-block-end: var(--emu-space-sm); }
-    .-emu-layout body.-emu #menu #menu-items li:last-child {
-      -webkit-margin-after: 0;
-              margin-block-end: 0; }
-    .-emu-layout body.-emu #menu #menu-items li i, .-emu-layout
-    body.-emu #menu #menu-items li h4 {
-      flex: initial;
-      font-size: inherit;
-      line-height: 1; }
+  box-shadow: none;
+}
+.-emu-layout body.-emu #menu {
+  top: 0;
+  left: 0;
+  position: fixed;
+  width: 100%;
+  height: 100%;
+  align-items: center;
+  display: flex;
+  justify-content: center;
+  z-index: 1070;
+}
+body.-emu #menu #menu-items {
+  background-color: rgba(var(--color-background-darkest), 1);
+  background-image: var(--emu-image-background-darkest, none);
+  box-shadow: 0 2px 4px rgba(var(--color-black), 1);
+}
+.-emu-layout body.-emu #menu #menu-items {
+  display: flex;
+  flex-direction: column;
+  padding: var(--emu-space-sm);
+}
+.-emu-layout body.-emu #menu #menu-items li {
+  font-size: var(--emu-font-size-xl);
+  -webkit-margin-after: var(--emu-space-sm);
+  margin-block-end: var(--emu-space-sm);
+}
+.-emu-layout body.-emu #menu #menu-items li:last-child {
+  -webkit-margin-after: 0;
+  margin-block-end: 0;
+}
+.-emu-layout body.-emu #menu #menu-items li i,
+.-emu-layout body.-emu #menu #menu-items li h4 {
+  flex: initial;
+  font-size: inherit;
+  line-height: 1;
+}
 
 body.-emu #notifications {
-  border-radius: 0; }
-  .-emu-layout body.-emu #notifications {
-    top: 7.5rem;
-    left: 9.25rem;
-    position: fixed;
-    width: calc(100% - 32.5rem);
-    z-index: 1070; }
-  .-emu-layout.-emu-compact body.-emu #notifications {
-    left: 7rem;
-    top: 6rem; }
+  border-radius: 0;
+}
+.-emu-layout body.-emu #notifications {
+  top: 7.5rem;
+  left: 9.25rem;
+  position: fixed;
+  width: calc(100% - 32.5rem);
+  z-index: 1070;
+}
+.-emu-layout.-emu-compact body.-emu #notifications {
+  left: 7rem;
+  top: 6rem;
+}
 
 body.-emu .notification {
   background-color: rgba(var(--color-charcoal-900), 1);
   border: rgba(var(--color-border), 1) 1px solid;
   border-radius: var(--emu-border-radius-default, 0);
   box-shadow: 0 2px 4px rgba(var(--color-black), 1);
-  color: rgba(var(--color-white), 1); }
-  .-emu-layout body.-emu .notification {
-    line-height: initial;
-    -webkit-margin-after: var(--emu-space-sm);
-            margin-block-end: var(--emu-space-sm);
-    padding: var(--emu-space-sm);
-    -webkit-padding-end: var(--emu-space-xl);
-            padding-inline-end: var(--emu-space-xl); }
-  .-emu-layout body.-emu .notification::before {
-    -webkit-margin-end: var(--emu-space-sm);
-            margin-inline-end: var(--emu-space-sm); }
-  body.-emu .notification.info {
-    background-color: rgba(var(--color-neutral), 1);
-    border-color: rgba(var(--color-blue-800), 1); }
-  body.-emu .notification.warning {
-    background-color: rgba(var(--color-warning), 1);
-    border-color: rgba(var(--color-yellow-800), 1);
-    color: rgba(var(--color-charcoal-900), 1); }
-  body.-emu .notification.error {
-    background-color: rgba(var(--color-negative), 1);
-    border-color: rgba(var(--color-red-800), 1); }
-  .-emu-layout body.-emu .notification .close {
-    top: var(--emu-space-sm);
-    right: var(--emu-space-sm);
-    position: absolute;
-    line-height: 1;
-    margin: 0;
-    -webkit-margin-before: var(--emu-space-xs);
-            margin-block-start: var(--emu-space-xs); }
+  color: rgba(var(--color-white), 1);
+}
+.-emu-layout body.-emu .notification {
+  line-height: initial;
+  -webkit-margin-after: var(--emu-space-sm);
+  margin-block-end: var(--emu-space-sm);
+  padding: var(--emu-space-sm);
+  -webkit-padding-end: var(--emu-space-xl);
+  padding-inline-end: var(--emu-space-xl);
+}
+.-emu-layout body.-emu .notification::before {
+  -webkit-margin-end: var(--emu-space-sm);
+  margin-inline-end: var(--emu-space-sm);
+}
+body.-emu .notification.info {
+  background-color: rgba(var(--color-neutral), 1);
+  border-color: rgba(var(--color-blue-800), 1);
+}
+body.-emu .notification.warning {
+  background-color: rgba(var(--color-warning), 1);
+  border-color: rgba(var(--color-yellow-800), 1);
+  color: rgba(var(--color-charcoal-900), 1);
+}
+body.-emu .notification.error {
+  background-color: rgba(var(--color-negative), 1);
+  border-color: rgba(var(--color-red-800), 1);
+}
+.-emu-layout body.-emu .notification .close {
+  top: var(--emu-space-sm);
+  right: var(--emu-space-sm);
+  position: absolute;
+  line-height: 1;
+  margin: 0;
+  -webkit-margin-before: var(--emu-space-xs);
+  margin-block-start: var(--emu-space-xs);
+}
 
 body.-emu #pause {
-  background: transparent; }
-  .-emu-layout body.-emu #pause {
-    top: auto;
-    bottom: 12.5rem;
-    left: 0;
-    position: fixed;
-    width: 100%;
-    height: auto;
-    align-items: center;
-    display: none;
-    flex-direction: column;
-    pointer-events: none;
-    z-index: 10; }
-    .-emu-layout body.-emu #pause.paused {
-      display: flex; }
-  .-emu-layout body.-emu #pause img {
-    -webkit-animation-duration: 5s;
-            animation-duration: 5s;
-    -webkit-animation-iteration-count: infinite;
-            animation-iteration-count: infinite;
-    -webkit-animation-name: pause-rotation;
-            animation-name: pause-rotation;
-    -webkit-animation-timing-function: linear;
-            animation-timing-function: linear;
-    opacity: 1; }
+  background: transparent;
+}
+.-emu-layout body.-emu #pause {
+  top: auto;
+  bottom: 12.5rem;
+  left: 0;
+  position: fixed;
+  width: 100%;
+  height: auto;
+  align-items: center;
+  display: none;
+  flex-direction: column;
+  pointer-events: none;
+  z-index: 10;
+}
+.-emu-layout body.-emu #pause.paused {
+  display: flex;
+}
+.-emu-layout body.-emu #pause img {
+  -webkit-animation-duration: 5s;
+  animation-duration: 5s;
+  -webkit-animation-iteration-count: infinite;
+  animation-iteration-count: infinite;
+  -webkit-animation-name: pause-rotation;
+  animation-name: pause-rotation;
+  -webkit-animation-timing-function: linear;
+  animation-timing-function: linear;
+  opacity: 1;
+}
 
 @-webkit-keyframes pause-rotation {
   0% {
-    transform: rotate(0deg); }
+    transform: rotate(0deg);
+  }
   100% {
-    transform: rotate(360deg); } }
+    transform: rotate(360deg);
+  }
+}
 
 @keyframes pause-rotation {
   0% {
-    transform: rotate(0deg); }
+    transform: rotate(0deg);
+  }
   100% {
-    transform: rotate(360deg); } }
-  body.-emu #pause h3 {
-    color: rgba(var(--color-text-lightest), 1); }
-    .-emu-layout body.-emu #pause h3 {
-      font-size: var(--emu-font-size-xxl); }
+    transform: rotate(360deg);
+  }
+}
+body.-emu #pause h3 {
+  color: rgba(var(--color-text-lightest), 1);
+}
+.-emu-layout body.-emu #pause h3 {
+  font-size: var(--emu-font-size-xxl);
+}
 
 body.-emu #players {
-  background-color: rgba(var(--color-background), var(--emu-background-opacity-players, 0.8));
+  background-color: rgba(
+    var(--color-background),
+    var(--emu-background-opacity-players, 0.8)
+  );
   background-image: var(--emu-image-background, none);
   border: rgba(var(--color-border), 1) 1px solid;
   border-radius: var(--emu-border-radius-default, 0);
   box-shadow: none;
-  transition: opacity 0.3s cubic-bezier(0.075, 0.82, 0.165, 1); }
-  .-emu-layout body.-emu #players {
-    bottom: var(--emu-space-sm);
-    left: var(--emu-space-sm);
-    position: fixed;
-    display: block;
-    width: 12.5rem;
-    z-index: 10; }
-    .-emu-layout body.-emu #players.hidden {
-      display: none; }
-  .-emu-layout.-emu-compact body.-emu #players {
-    width: 10.5rem; }
-  .-emu-layout.-emu-subtle-layout body.-emu #players {
-    opacity: var(--emu-subtle-opacity, 0.3); }
-    .-emu-layout.-emu-subtle-layout body.-emu #players:hover {
-      opacity: 1; }
-      .-emu-layout.-emu-subtle-layout body.-emu #players:hover > h3 {
-        border-width: 1px; }
-      .-emu-layout.-emu-subtle-layout body.-emu #players:hover > ol {
-        max-height: 43.75rem;
-        overflow: visible;
-        padding: var(--emu-space-sm); }
-  .-emu-layout.-emu-players body.-emu #players {
-    display: none; }
-  body.-emu #players > h3 {
-    -webkit-border-after: rgba(var(--color-border), 1) 1px solid;
-            border-block-end: rgba(var(--color-border), 1) 1px solid;
-    border-radius: var(--emu-border-radius-default, 0) var(--emu-border-radius-default, 0) 0 0;
-    color: rgba(var(--color-text-lightest), 1);
-    transition: color 0.3s cubic-bezier(0.075, 0.82, 0.165, 1); }
-    .-emu-layout body.-emu #players > h3 {
-      cursor: pointer;
-      display: flex;
-      font-size: var(--emu-font-size-md);
-      font-weight: normal;
-      margin: 0;
-      padding: var(--emu-space-sm);
-      position: relative;
-      text-transform: uppercase; }
-    .-emu-layout.-emu-subtle-layout body.-emu #players > h3 {
-      border-width: 0; }
-    body.-emu #players > h3:hover, body.-emu #players > h3:active {
-      background-color: rgba(var(--color-primary), 1);
-      color: rgba(var(--color-text-lightest), 1); }
-    body.-emu #players > h3 .players-mode {
-      color: inherit; }
-      .-emu-layout body.-emu #players > h3 .players-mode {
-        flex: 1 1 auto;
-        font-size: var(--emu-font-size-lg);
-        text-align: right;
-        position: relative; }
-    .-emu-layout body.-emu #players > h3 > i {
-      position: relative; }
-    .-emu-layout body.-emu #players > h3 > i:first-of-type {
-      -webkit-margin-end: var(--emu-space-sm);
-              margin-inline-end: var(--emu-space-sm); }
-    .-emu-layout body.-emu #players > h3 > i:last-of-type {
-      -webkit-margin-start: var(--emu-space-sm);
-              margin-inline-start: var(--emu-space-sm); }
-  .-emu-layout body.-emu #players > ol {
-    padding: var(--emu-space-sm); }
-  .-emu-layout.-emu-subtle-layout body.-emu #players > ol {
-    max-height: 0;
-    overflow: hidden;
-    padding: 0; }
-  .-emu-layout body.-emu #players > ol .player {
-    align-items: center;
-    border: none;
-    display: flex;
-    flex-wrap: nowrap;
-    line-height: initial;
-    margin: 0;
-    padding: var(--emu-space-xs) 0;
-    position: relative;
-    width: 100%; }
-  body.-emu #players > ol .player.context .player-name {
-    color: rgba(var(--color-primary), 1);
-    text-shadow: none; }
-  body.-emu #players > ol .player-name {
-    color: rgba(var(--color-text-lightest), 1);
-    text-shadow: none; }
-    .-emu-layout body.-emu #players > ol .player-name {
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
-      flex: 1 1 auto;
-      position: relative; }
-    body.-emu #players > ol .player-name.self {
-      color: rgba(var(--color-text-lightest), 1); }
-  .-emu-layout body.-emu #players > ol .player-active {
-    width: 0.5rem;
-    height: 0.5rem;
-    border-radius: 50%;
-    flex: 0 0 auto;
-    margin: 0;
-    -webkit-margin-end: var(--emu-space-sm);
-            margin-inline-end: var(--emu-space-sm);
-    position: relative; }
-  body.-emu #players > ol .player-active.active {
-    box-shadow: 0 1px 2px 0 rgba(var(--color-black), 0.3); }
+  transition: opacity 0.3s cubic-bezier(0.075, 0.82, 0.165, 1);
+}
+.-emu-layout body.-emu #players {
+  bottom: var(--emu-space-base);
+  left: var(--emu-space-base);
+  position: fixed;
+  display: block;
+  width: 12.5rem;
+  z-index: 10;
+}
+.-emu-layout body.-emu #players.hidden {
+  display: none;
+}
+.-emu-layout.-emu-compact body.-emu #players {
+  width: 10.5rem;
+  left: -0.55rem;
+}
+.-emu-layout.-emu-subtle-layout body.-emu #players {
+  opacity: var(--emu-subtle-opacity, 0.3);
+}
+.-emu-layout.-emu-subtle-layout body.-emu #players:hover {
+  opacity: 1;
+}
+.-emu-layout.-emu-subtle-layout body.-emu #players:hover > h3 {
+  border-width: 1px;
+}
+.-emu-layout.-emu-subtle-layout body.-emu #players:hover > ol {
+  max-height: 43.75rem;
+  overflow: visible;
+  padding: var(--emu-space-sm);
+}
+.-emu-layout.-emu-players body.-emu #players {
+  display: none;
+}
+body.-emu #players > h3 {
+  -webkit-border-after: rgba(var(--color-border), 1) 1px solid;
+  border-block-end: rgba(var(--color-border), 1) 1px solid;
+  border-radius: var(--emu-border-radius-default, 0)
+    var(--emu-border-radius-default, 0) 0 0;
+  color: rgba(var(--color-text-lightest), 1);
+  transition: color 0.3s cubic-bezier(0.075, 0.82, 0.165, 1);
+}
+.-emu-layout body.-emu #players > h3 {
+  cursor: pointer;
+  display: flex;
+  font-size: var(--emu-font-size-md);
+  font-weight: normal;
+  margin: 0;
+  padding: var(--emu-space-sm);
+  position: relative;
+  text-transform: uppercase;
+}
+.-emu-layout.-emu-subtle-layout body.-emu #players > h3 {
+  border-width: 0;
+}
+body.-emu #players > h3:hover,
+body.-emu #players > h3:active {
+  background-color: rgba(var(--color-primary), 1);
+  color: rgba(var(--color-text-lightest), 1);
+}
+body.-emu #players > h3 .players-mode {
+  color: inherit;
+}
+.-emu-layout body.-emu #players > h3 .players-mode {
+  flex: 1 1 auto;
+  font-size: var(--emu-font-size-lg);
+  text-align: right;
+  position: relative;
+}
+.-emu-layout body.-emu #players > h3 > i {
+  position: relative;
+}
+.-emu-layout body.-emu #players > h3 > i:first-of-type {
+  -webkit-margin-end: var(--emu-space-sm);
+  margin-inline-end: var(--emu-space-sm);
+}
+.-emu-layout body.-emu #players > h3 > i:last-of-type {
+  -webkit-margin-start: var(--emu-space-sm);
+  margin-inline-start: var(--emu-space-sm);
+}
+.-emu-layout body.-emu #players > ol {
+  padding: var(--emu-space-sm);
+}
+.-emu-layout.-emu-subtle-layout body.-emu #players > ol {
+  max-height: 0;
+  overflow: hidden;
+  padding: 0;
+}
+.-emu-layout body.-emu #players > ol .player {
+  align-items: center;
+  border: none;
+  display: flex;
+  flex-wrap: nowrap;
+  line-height: initial;
+  margin: 0;
+  padding: var(--emu-space-xs) 0;
+  position: relative;
+  width: 100%;
+}
+body.-emu #players > ol .player.context .player-name {
+  color: rgba(var(--color-primary), 1);
+  text-shadow: none;
+}
+body.-emu #players > ol .player-name {
+  color: rgba(var(--color-text-lightest), 1);
+  text-shadow: none;
+}
+.-emu-layout body.-emu #players > ol .player-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 1 1 auto;
+  position: relative;
+}
+body.-emu #players > ol .player-name.self {
+  color: rgba(var(--color-text-lightest), 1);
+}
+.-emu-layout body.-emu #players > ol .player-active {
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 50%;
+  flex: 0 0 auto;
+  margin: 0;
+  -webkit-margin-end: var(--emu-space-sm);
+  margin-inline-end: var(--emu-space-sm);
+  position: relative;
+}
+body.-emu #players > ol .player-active.active {
+  box-shadow: 0 1px 2px 0 rgba(var(--color-black), 0.3);
+}
 
 .-emu-layout body.-emu #controls {
   top: var(--emu-space-sm);
@@ -2841,27 +9968,44 @@ body.-emu #players {
   box-shadow: none;
   display: block;
   transition: opacity 0.3s cubic-bezier(0.075, 0.82, 0.165, 1);
-  z-index: 10; }
+  z-index: 10;
+}
 
 .-emu-layout.-emu-logo body.-emu #controls {
-  top: 3.75rem; }
+  top: 3.75rem;
+}
 
 .-emu-layout.-emu-logo.-emu-compact body.-emu #controls {
-  top: 2.5rem; }
+  top: 2.5rem;
+}
 
 .-emu-layout.-emu-subtle-layout body.-emu #controls {
-  opacity: var(--emu-subtle-opacity, 0.3); }
-  .-emu-layout.-emu-subtle-layout body.-emu #controls::before {
-    content: "";
-    bottom: calc(-1 * var(--emu-space-sm));
-    left: calc(-1 * var(--emu-space-sm));
-    right: -3.375rem;
-    top: calc(-1 * var(--emu-space-sm));
-    position: absolute; }
-  .-emu-layout.-emu-subtle-layout body.-emu #controls:hover, .-emu-layout.-emu-subtle-layout body.-emu #controls:active {
-    opacity: 1; }
-    .-emu-layout.-emu-subtle-layout body.-emu #controls:hover .scene-control.active .control-tools, .-emu-layout.-emu-subtle-layout body.-emu #controls:active .scene-control.active .control-tools {
-      opacity: 1; }
+  opacity: var(--emu-subtle-opacity, 0.3);
+}
+.-emu-layout.-emu-subtle-layout body.-emu #controls::before {
+  content: "";
+  bottom: calc(-1 * var(--emu-space-sm));
+  left: calc(-1 * var(--emu-space-sm));
+  right: -3.375rem;
+  top: calc(-1 * var(--emu-space-sm));
+  position: absolute;
+}
+.-emu-layout.-emu-subtle-layout body.-emu #controls:hover,
+.-emu-layout.-emu-subtle-layout body.-emu #controls:active {
+  opacity: 1;
+}
+.-emu-layout.-emu-subtle-layout
+  body.-emu
+  #controls:hover
+  .scene-control.active
+  .control-tools,
+.-emu-layout.-emu-subtle-layout
+  body.-emu
+  #controls:active
+  .scene-control.active
+  .control-tools {
+  opacity: 1;
+}
 
 body.-emu #controls .scene-control,
 body.-emu #controls .control-tool {
@@ -2870,769 +10014,1155 @@ body.-emu #controls .control-tool {
   box-shadow: none;
   color: rgba(var(--color-text-lightest), 1);
   font-size: var(--emu-font-size-lg);
-  transition: background 0.3s cubic-bezier(0.075, 0.82, 0.165, 1), box-shadow 0.3s cubic-bezier(0.075, 0.82, 0.165, 1), color 0.3s cubic-bezier(0.075, 0.82, 0.165, 1), opacity 0.3s cubic-bezier(0.075, 0.82, 0.165, 1); }
-  .-emu-layout body.-emu #controls .scene-control, .-emu-layout
-  body.-emu #controls .control-tool {
-    width: var(--emu-space-button-lg);
-    height: var(--emu-space-button-lg);
-    align-items: center;
-    cursor: pointer;
-    display: flex;
-    justify-content: center;
-    line-height: initial;
-    margin: 0;
-    -webkit-margin-after: var(--emu-space-base);
-            margin-block-end: var(--emu-space-base);
-    padding: 0;
-    pointer-events: all;
-    position: relative; }
-    .-emu-layout body.-emu #controls .scene-control:last-of-type, .-emu-layout
-    body.-emu #controls .control-tool:last-of-type {
-      -webkit-margin-after: 0;
-              margin-block-end: 0; }
-    .-emu-layout body.-emu #controls .scene-control > i, .-emu-layout
-    body.-emu #controls .control-tool > i {
-      margin: 0;
-      position: relative; }
-  body.-emu #controls .scene-control:hover,
-  body.-emu #controls .control-tool:hover {
-    background-image: none; }
-  body.-emu #controls .scene-control:focus,
-  body.-emu #controls .control-tool:focus {
-    background-image: none; }
-  body.-emu #controls .scene-control.active,
-  body.-emu #controls .control-tool.active {
-    background-image: none; }
+  transition: background 0.3s cubic-bezier(0.075, 0.82, 0.165, 1),
+    box-shadow 0.3s cubic-bezier(0.075, 0.82, 0.165, 1),
+    color 0.3s cubic-bezier(0.075, 0.82, 0.165, 1),
+    opacity 0.3s cubic-bezier(0.075, 0.82, 0.165, 1);
+}
+.-emu-layout body.-emu #controls .scene-control,
+.-emu-layout body.-emu #controls .control-tool {
+  width: var(--emu-space-button-lg);
+  height: var(--emu-space-button-lg);
+  align-items: center;
+  cursor: pointer;
+  display: flex;
+  justify-content: center;
+  line-height: initial;
+  margin: 0;
+  -webkit-margin-after: var(--emu-space-base);
+  margin-block-end: var(--emu-space-base);
+  padding: 0;
+  pointer-events: all;
+  position: relative;
+}
+.-emu-layout body.-emu #controls .scene-control:last-of-type,
+.-emu-layout body.-emu #controls .control-tool:last-of-type {
+  -webkit-margin-after: 0;
+  margin-block-end: 0;
+}
+.-emu-layout body.-emu #controls .scene-control > i,
+.-emu-layout body.-emu #controls .control-tool > i {
+  margin: 0;
+  position: relative;
+}
+body.-emu #controls .scene-control:hover,
+body.-emu #controls .control-tool:hover {
+  background-image: none;
+}
+body.-emu #controls .scene-control:focus,
+body.-emu #controls .control-tool:focus {
+  background-image: none;
+}
+body.-emu #controls .scene-control.active,
+body.-emu #controls .control-tool.active {
+  background-image: none;
+}
 
 body.-emu #controls .scene-control {
-  background-color: rgba(var(--color-background-darkest), var(--emu-background-opacity-scene-control, 0.8));
-  background-image: var(--emu-image-background-controls, none); }
-  body.-emu #controls .scene-control.active .control-tools {
-    opacity: 1; }
-    .-emu-layout body.-emu #controls .scene-control.active .control-tools {
-      display: inline-flex; }
-    .-emu-layout.-emu-subtle-layout body.-emu #controls .scene-control.active .control-tools {
-      opacity: 0; }
-  .-emu-layout.-emu-control-align-top body.-emu #controls .scene-control {
-    position: initial; }
+  background-color: rgba(
+    var(--color-background-darkest),
+    var(--emu-background-opacity-scene-control, 0.8)
+  );
+  background-image: var(--emu-image-background-controls, none);
+}
+body.-emu #controls .scene-control.active .control-tools {
+  opacity: 1;
+}
+.-emu-layout body.-emu #controls .scene-control.active .control-tools {
+  display: inline-flex;
+}
+.-emu-layout.-emu-subtle-layout
+  body.-emu
+  #controls
+  .scene-control.active
+  .control-tools {
+  opacity: 0;
+}
+.-emu-layout.-emu-control-align-top body.-emu #controls .scene-control {
+  position: initial;
+}
 
 body.-emu #controls .control-tool {
-  background-color: rgba(var(--color-background), var(--emu-background-opacity-scene-control, 0.8));
-  background-image: var(--emu-image-background-controls, none); }
-  .-emu-layout body.-emu #controls .control-tool {
-    -webkit-margin-end: var(--emu-space-base);
-            margin-inline-end: var(--emu-space-base); }
-  body.-emu #controls .control-tool.toggle {
-    background-color: rgba(var(--color-background-lightest), 1);
-    background-image: var(--emu-image-background-controls, none);
-    color: rgba(var(--color-text), 1); }
-    body.-emu #controls .control-tool.toggle:hover {
-      background-color: rgba(var(--color-primary), 1);
-      background-image: none;
-      color: rgba(var(--color-text-lightest), 1); }
-    body.-emu #controls .control-tool.toggle.active {
-      background-color: rgba(var(--color-primary), 1);
-      background-image: none; }
+  background-color: rgba(
+    var(--color-background),
+    var(--emu-background-opacity-scene-control, 0.8)
+  );
+  background-image: var(--emu-image-background-controls, none);
+}
+.-emu-layout body.-emu #controls .control-tool {
+  -webkit-margin-end: var(--emu-space-base);
+  margin-inline-end: var(--emu-space-base);
+}
+body.-emu #controls .control-tool.toggle {
+  background-color: rgba(var(--color-background-lightest), 1);
+  background-image: var(--emu-image-background-controls, none);
+  color: rgba(var(--color-text), 1);
+}
+body.-emu #controls .control-tool.toggle:hover {
+  background-color: rgba(var(--color-primary), 1);
+  background-image: none;
+  color: rgba(var(--color-text-lightest), 1);
+}
+body.-emu #controls .control-tool.toggle.active {
+  background-color: rgba(var(--color-primary), 1);
+  background-image: none;
+}
 
 .-emu-layout body.-emu #controls .control-tools {
-  top: 0;
-  left: 2.75rem;
+  top: 1em;
+  left: 0.75rem;
   position: absolute;
   flex-direction: column;
   flex-wrap: wrap;
   pointer-events: none;
   max-height: 60vh;
-  opacity: 0;
-  transition: opacity 0.3s cubic-bezier(0.075, 0.82, 0.165, 1), left 0.3s cubic-bezier(0.075, 0.82, 0.165, 1); }
+  opacity: 1;
+  transition: opacity 0.3s cubic-bezier(0.075, 0.82, 0.165, 1),
+    left 0.3s cubic-bezier(0.075, 0.82, 0.165, 1);
+}
+
+/* Fixes the menu overlaying on each other*/
+.-emu-layout body.-emu #controls ol.sub-controls.active {
+  left: 4.25em !important;
+}
 
 .-emu-layout.-emu-compact body.-emu #controls .control-tools {
-  left: 2.125rem; }
+  left: 0.125rem;
+}
+
+.-emu-layout.-emu-compact body.-emu #controls .control-tools.active {
+  left: 2.3rem !important;
+}
 
 .-emu-layout.-emu-subtle-layout body.-emu #controls .control-tools {
-  opacity: 0; }
+  opacity: 1;
+}
 
 body.-emu #navigation {
-  box-shadow: none; }
-  .-emu-layout body.-emu #navigation {
-    top: var(--emu-space-sm);
-    left: 9.25rem;
-    position: fixed;
-    transition: opacity 0.3s cubic-bezier(0.075, 0.82, 0.165, 1);
-    width: calc(100% - 9.25rem - var(--emu-space-sm) - var(--emu-space-sidebar));
-    z-index: 10; }
-  .-emu-layout.-emu-compact body.-emu #navigation {
-    left: 7rem;
-    width: calc(100% - 7rem - var(--emu-space-sm) - var(--emu-space-sidebar)); }
-  .-emu-layout.-emu-subtle-layout body.-emu #navigation {
-    left: 7rem;
-    opacity: var(--emu-subtle-opacity, 0.3);
-    width: calc(100% - 7rem - var(--emu-space-sm) - var(--emu-space-sidebar)); }
-    .-emu-layout.-emu-subtle-layout body.-emu #navigation:hover, .-emu-layout.-emu-subtle-layout body.-emu #navigation:active {
-      opacity: 1; }
-      .-emu-layout.-emu-subtle-layout body.-emu #navigation:hover #scene-list .scene, .-emu-layout.-emu-subtle-layout body.-emu #navigation:active #scene-list .scene {
-        display: inline-flex;
-        opacity: 1; }
-    .-emu-layout.-emu-subtle-layout body.-emu #navigation #scene-list::before {
-      content: "";
-      bottom: calc(-1 * var(--emu-space-sm));
-      left: calc(-1 * var(--emu-space-sm));
-      right: calc(-1 * var(--emu-space-sm));
-      top: calc(-1 * var(--emu-space-sm));
-      position: absolute; }
-  .-emu-layout.-emu-subtle-layout.-emu-compact body.-emu #navigation {
-    left: 4.625rem; }
-  body.-emu #navigation #nav-toggle {
-    background-color: rgba(var(--color-background), var(--emu-background-opacity-scene-navigation, 0.8));
-    background-image: var(--emu-image-background-controls, none); }
-    .-emu-layout body.-emu #navigation #nav-toggle {
-      top: 0;
-      left: -1.75rem;
-      position: absolute;
-      margin: 0;
-      z-index: 10; }
-    .-emu-layout.-emu-compact body.-emu #navigation #nav-toggle {
-      left: -1.5rem; }
-    .-emu-layout.-emu-subtle-layout body.-emu #navigation #nav-toggle {
-      display: none; }
-  .-emu-layout body.-emu #navigation #scene-list, .-emu-layout
-  body.-emu #navigation .scene-list {
-    display: flex;
-    flex-wrap: wrap;
-    position: relative;
-    pointer-events: all; }
-  body.-emu #navigation #scene-list .scene,
-  body.-emu #navigation .scene-list .scene {
-    background-color: rgba(var(--color-background-darkest), var(--emu-background-opacity-scene-navigation, 0.8));
-    background-image: var(--emu-image-background-controls, none);
-    border: none;
-    border-radius: var(--emu-border-radius-controls, 0);
-    box-shadow: none;
-    color: rgba(var(--color-text-lightest), 1);
-    outline: none;
-    text-shadow: none;
-    transition: box-shadow 0.3s cubic-bezier(0.075, 0.82, 0.165, 1), color 0.3s cubic-bezier(0.075, 0.82, 0.165, 1), opacity 0.3s cubic-bezier(0.075, 0.82, 0.165, 1); }
-    .-emu-layout body.-emu #navigation #scene-list .scene, .-emu-layout
-    body.-emu #navigation .scene-list .scene {
-      width: auto;
-      height: 2.25rem;
-      cursor: pointer;
-      display: block;
-      line-height: 2.25rem;
-      -webkit-margin-after: var(--emu-space-base);
-              margin-block-end: var(--emu-space-base);
-      -webkit-margin-end: var(--emu-space-base);
-              margin-inline-end: var(--emu-space-base);
-      max-width: 15rem;
-      min-width: 7rem;
-      padding: 0 var(--emu-space-md);
-      position: relative;
-      text-align: center; }
-      .-emu-layout body.-emu #navigation #scene-list .scene:last-of-type, .-emu-layout
-      body.-emu #navigation .scene-list .scene:last-of-type {
-        -webkit-margin-end: 0;
-                margin-inline-end: 0; }
-    .-emu-layout.-emu-compact body.-emu #navigation #scene-list .scene, .-emu-layout.-emu-compact
-    body.-emu #navigation .scene-list .scene {
-      height: 1.75rem;
-      line-height: 1.75rem;
-      min-width: 5.5rem; }
-    .-emu-layout.-emu-subtle-layout body.-emu #navigation #scene-list .scene, .-emu-layout.-emu-subtle-layout
-    body.-emu #navigation .scene-list .scene {
-      display: none;
-      opacity: 0; }
-      .-emu-layout.-emu-subtle-layout body.-emu #navigation #scene-list .scene.active, .-emu-layout.-emu-subtle-layout
-      body.-emu #navigation .scene-list .scene.active {
-        display: inline-flex;
-        opacity: 1; }
-    body.-emu #navigation #scene-list .scene:not(.gm),
-    body.-emu #navigation .scene-list .scene:not(.gm) {
-      background-color: rgba(var(--color-background), var(--emu-background-opacity-scene-navigation, 0.8));
-      background-image: var(--emu-image-background, none); }
-    body.-emu #navigation #scene-list .scene.active, body.-emu #navigation #scene-list .scene.view,
-    body.-emu #navigation .scene-list .scene.active,
-    body.-emu #navigation .scene-list .scene.view {
-      background-image: none; }
-      body.-emu #navigation #scene-list .scene.active:not(.gm), body.-emu #navigation #scene-list .scene.view:not(.gm),
-      body.-emu #navigation .scene-list .scene.active:not(.gm),
-      body.-emu #navigation .scene-list .scene.view:not(.gm) {
-        background-image: none; }
-    body.-emu #navigation #scene-list .scene:hover,
-    body.-emu #navigation .scene-list .scene:hover {
-      background-image: none; }
-    body.-emu #navigation #scene-list .scene:focus,
-    body.-emu #navigation .scene-list .scene:focus {
-      background-image: none; }
-    body.-emu #navigation #scene-list .scene a,
-    body.-emu #navigation .scene-list .scene a {
-      text-shadow: none; }
-      .-emu-layout body.-emu #navigation #scene-list .scene a, .-emu-layout
-      body.-emu #navigation .scene-list .scene a {
-        width: 100%;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
-        border: none;
-        display: block; }
-        .-emu-layout body.-emu #navigation #scene-list .scene a > i, .-emu-layout
-        body.-emu #navigation .scene-list .scene a > i {
-          -webkit-margin-end: var(--emu-space-base);
-                  margin-inline-end: var(--emu-space-base); }
-  .-emu-layout body.-emu #navigation #scene-list .scene-players, .-emu-layout
-  body.-emu #navigation .scene-list .scene-players {
-    top: 0;
-    left: 0;
-    position: absolute;
-    display: flex;
-    flex-wrap: wrap;
-    list-style: none;
-    margin: 0;
-    -webkit-margin-before: calc(-1 * var(--emu-space-base));
-            margin-block-start: calc(-1 * var(--emu-space-base));
-    padding: 0;
-    -webkit-padding-start: var(--emu-space-sm);
-            padding-inline-start: var(--emu-space-sm);
-    pointer-events: none; }
-  body.-emu #navigation #scene-list .scene-player,
-  body.-emu #navigation .scene-list .scene-player {
-    background-color: rgba(var(--color-white), 1);
-    border-radius: var(--emu-border-radius-controls, 0);
-    border: none;
-    box-shadow: inset 0 0 0 1px rgba(var(--color-primary), 1), inset 0 0 0 2px rgba(var(--color-white), 1), 0 1px 2px 0 rgba(var(--color-black), 0.3);
-    color: transparent;
-    font-size: var(--emu-font-size-xs); }
-    .-emu-layout body.-emu #navigation #scene-list .scene-player, .-emu-layout
-    body.-emu #navigation .scene-list .scene-player {
-      width: 0.75rem;
-      height: 0.75rem;
-      align-items: center;
-      display: flex;
-      justify-content: center;
-      -webkit-margin-after: var(--emu-space-xs);
-              margin-block-end: var(--emu-space-xs);
-      -webkit-margin-end: var(--emu-space-xs);
-              margin-inline-end: var(--emu-space-xs);
-      position: relative;
-      text-transform: uppercase; }
-    .-emu-layout.-emu-compact body.-emu #navigation #scene-list .scene-player, .-emu-layout.-emu-compact
-    body.-emu #navigation .scene-list .scene-player {
-      width: 0.5rem;
-      height: 0.5rem; }
+  box-shadow: none;
+}
+.-emu-layout body.-emu #navigation {
+  top: var(--emu-space-sm);
+  left: 9.25rem;
+  position: fixed;
+  transition: opacity 0.3s cubic-bezier(0.075, 0.82, 0.165, 1);
+  width: calc(100% - 9.25rem - var(--emu-space-sm) - var(--emu-space-sidebar));
+  z-index: 10;
+}
+.-emu-layout.-emu-compact body.-emu #navigation {
+  left: 7rem;
+  width: calc(100% - 7rem - var(--emu-space-sm) - var(--emu-space-sidebar));
+}
+.-emu-layout.-emu-subtle-layout body.-emu #navigation {
+  left: 7rem;
+  opacity: var(--emu-subtle-opacity, 0.3);
+  width: calc(100% - 7rem - var(--emu-space-sm) - var(--emu-space-sidebar));
+}
+.-emu-layout.-emu-subtle-layout body.-emu #navigation:hover,
+.-emu-layout.-emu-subtle-layout body.-emu #navigation:active {
+  opacity: 1;
+}
+.-emu-layout.-emu-subtle-layout body.-emu #navigation:hover #scene-list .scene,
+.-emu-layout.-emu-subtle-layout
+  body.-emu
+  #navigation:active
+  #scene-list
+  .scene {
+  display: inline-flex;
+  opacity: 1;
+}
+.-emu-layout.-emu-subtle-layout body.-emu #navigation #scene-list::before {
+  content: "";
+  bottom: calc(-1 * var(--emu-space-sm));
+  left: calc(-1 * var(--emu-space-sm));
+  right: calc(-1 * var(--emu-space-sm));
+  top: calc(-1 * var(--emu-space-sm));
+  position: absolute;
+}
+.-emu-layout.-emu-subtle-layout.-emu-compact body.-emu #navigation {
+  left: 4.625rem;
+}
+body.-emu #navigation #nav-toggle {
+  background-color: rgba(
+    var(--color-background),
+    var(--emu-background-opacity-scene-navigation, 0.8)
+  );
+  background-image: var(--emu-image-background-controls, none);
+}
+.-emu-layout body.-emu #navigation #nav-toggle {
+  top: 0;
+  left: -1.75rem;
+  position: absolute;
+  margin: 0;
+  z-index: 10;
+}
+.-emu-layout.-emu-compact body.-emu #navigation #nav-toggle {
+  left: -1.5rem;
+}
+.-emu-layout.-emu-subtle-layout body.-emu #navigation #nav-toggle {
+  display: none;
+}
+.-emu-layout body.-emu #navigation #scene-list,
+.-emu-layout body.-emu #navigation .scene-list {
+  display: flex;
+  flex-wrap: wrap;
+  position: relative;
+  pointer-events: all;
+}
+body.-emu #navigation #scene-list .scene,
+body.-emu #navigation .scene-list .scene {
+  background-color: rgba(
+    var(--color-background-darkest),
+    var(--emu-background-opacity-scene-navigation, 0.8)
+  );
+  background-image: var(--emu-image-background-controls, none);
+  border: none;
+  border-radius: var(--emu-border-radius-controls, 0);
+  box-shadow: none;
+  color: rgba(var(--color-text-lightest), 1);
+  outline: none;
+  text-shadow: none;
+  transition: box-shadow 0.3s cubic-bezier(0.075, 0.82, 0.165, 1),
+    color 0.3s cubic-bezier(0.075, 0.82, 0.165, 1),
+    opacity 0.3s cubic-bezier(0.075, 0.82, 0.165, 1);
+}
+.-emu-layout body.-emu #navigation #scene-list .scene,
+.-emu-layout body.-emu #navigation .scene-list .scene {
+  width: auto;
+  height: 2.25rem;
+  cursor: pointer;
+  display: block;
+  line-height: 2.25rem;
+  -webkit-margin-after: var(--emu-space-base);
+  margin-block-end: var(--emu-space-base);
+  -webkit-margin-end: var(--emu-space-base);
+  margin-inline-end: var(--emu-space-base);
+  max-width: 15rem;
+  min-width: 7rem;
+  padding: 0 var(--emu-space-md);
+  position: relative;
+  text-align: center;
+}
+.-emu-layout body.-emu #navigation #scene-list .scene:last-of-type,
+.-emu-layout body.-emu #navigation .scene-list .scene:last-of-type {
+  -webkit-margin-end: 0;
+  margin-inline-end: 0;
+}
+.-emu-layout.-emu-compact body.-emu #navigation #scene-list .scene,
+.-emu-layout.-emu-compact body.-emu #navigation .scene-list .scene {
+  height: 1.75rem;
+  line-height: 1.75rem;
+  min-width: 5.5rem;
+}
+.-emu-layout.-emu-subtle-layout body.-emu #navigation #scene-list .scene,
+.-emu-layout.-emu-subtle-layout body.-emu #navigation .scene-list .scene {
+  display: none;
+  opacity: 0;
+}
+.-emu-layout.-emu-subtle-layout body.-emu #navigation #scene-list .scene.active,
+.-emu-layout.-emu-subtle-layout
+  body.-emu
+  #navigation
+  .scene-list
+  .scene.active {
+  display: inline-flex;
+  opacity: 1;
+}
+body.-emu #navigation #scene-list .scene:not(.gm),
+body.-emu #navigation .scene-list .scene:not(.gm) {
+  background-color: rgba(
+    var(--color-background),
+    var(--emu-background-opacity-scene-navigation, 0.8)
+  );
+  background-image: var(--emu-image-background, none);
+}
+body.-emu #navigation #scene-list .scene.active,
+body.-emu #navigation #scene-list .scene.view,
+body.-emu #navigation .scene-list .scene.active,
+body.-emu #navigation .scene-list .scene.view {
+  background-image: none;
+}
+body.-emu #navigation #scene-list .scene.active:not(.gm),
+body.-emu #navigation #scene-list .scene.view:not(.gm),
+body.-emu #navigation .scene-list .scene.active:not(.gm),
+body.-emu #navigation .scene-list .scene.view:not(.gm) {
+  background-image: none;
+}
+body.-emu #navigation #scene-list .scene:hover,
+body.-emu #navigation .scene-list .scene:hover {
+  background-image: none;
+}
+body.-emu #navigation #scene-list .scene:focus,
+body.-emu #navigation .scene-list .scene:focus {
+  background-image: none;
+}
+body.-emu #navigation #scene-list .scene a,
+body.-emu #navigation .scene-list .scene a {
+  text-shadow: none;
+}
+.-emu-layout body.-emu #navigation #scene-list .scene a,
+.-emu-layout body.-emu #navigation .scene-list .scene a {
+  width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  border: none;
+  display: block;
+}
+.-emu-layout body.-emu #navigation #scene-list .scene a > i,
+.-emu-layout body.-emu #navigation .scene-list .scene a > i {
+  -webkit-margin-end: var(--emu-space-base);
+  margin-inline-end: var(--emu-space-base);
+}
+.-emu-layout body.-emu #navigation #scene-list .scene-players,
+.-emu-layout body.-emu #navigation .scene-list .scene-players {
+  top: 0;
+  left: 0;
+  position: absolute;
+  display: flex;
+  flex-wrap: wrap;
+  list-style: none;
+  margin: 0;
+  -webkit-margin-before: calc(-1 * var(--emu-space-base));
+  margin-block-start: calc(-1 * var(--emu-space-base));
+  padding: 0;
+  -webkit-padding-start: var(--emu-space-sm);
+  padding-inline-start: var(--emu-space-sm);
+  pointer-events: none;
+}
+body.-emu #navigation #scene-list .scene-player,
+body.-emu #navigation .scene-list .scene-player {
+  background-color: rgba(var(--color-white), 1);
+  border-radius: var(--emu-border-radius-controls, 0);
+  border: none;
+  box-shadow: inset 0 0 0 1px rgba(var(--color-primary), 1),
+    inset 0 0 0 2px rgba(var(--color-white), 1),
+    0 1px 2px 0 rgba(var(--color-black), 0.3);
+  color: transparent;
+  font-size: var(--emu-font-size-xs);
+}
+.-emu-layout body.-emu #navigation #scene-list .scene-player,
+.-emu-layout body.-emu #navigation .scene-list .scene-player {
+  width: 0.75rem;
+  height: 0.75rem;
+  align-items: center;
+  display: flex;
+  justify-content: center;
+  -webkit-margin-after: var(--emu-space-xs);
+  margin-block-end: var(--emu-space-xs);
+  -webkit-margin-end: var(--emu-space-xs);
+  margin-inline-end: var(--emu-space-xs);
+  position: relative;
+  text-transform: uppercase;
+}
+.-emu-layout.-emu-compact body.-emu #navigation #scene-list .scene-player,
+.-emu-layout.-emu-compact body.-emu #navigation .scene-list .scene-player {
+  width: 0.5rem;
+  height: 0.5rem;
+}
 
 body.-emu .app {
   background: none;
   border-radius: 0;
   box-shadow: none;
-  color: rgba(var(--color-text-lightest), 1); }
-  .-emu-layout body.-emu .app {
-    margin: 0;
-    max-height: 100%;
-    padding: 0;
-    z-index: 10; }
+  color: rgba(var(--color-text-lightest), 1);
+}
+.-emu-layout body.-emu .app {
+  margin: 0;
+  max-height: 100%;
+  padding: 0;
+  z-index: 10;
+}
 
 body.-emu .window-app {
-  background-color: rgba(var(--color-background), var(--emu-background-opacity-window, 1));
+  background-color: rgba(
+    var(--color-background),
+    var(--emu-background-opacity-window, 1)
+  );
   background-image: var(--emu-image-background, none);
   border: rgba(var(--color-border), 1) 1px solid;
   border-radius: var(--emu-border-radius-default, 0);
-  box-shadow: 0 2px 4px rgba(var(--color-black), 1); }
-  .-emu-layout body.-emu .window-app {
-    display: flex;
-    flex-direction: column;
-    flex-wrap: nowrap;
-    margin: 0; }
-    .-emu-layout body.-emu .window-app.minimized .window-resizable-handle {
-      display: none; }
-  body.-emu .window-app .window-header {
-    border: none;
-    -webkit-border-after: rgba(var(--color-border), 1) 1px solid;
-            border-block-end: rgba(var(--color-border), 1) 1px solid;
-    border-radius: calc(var(--emu-border-radius-default, 0) - 4px) calc(var(--emu-border-radius-default, 0) - 4px) 0 0;
-    color: rgba(var(--color-text-lightest), 1); }
-    .-emu-layout body.-emu .window-app .window-header {
-      align-items: center;
-      display: flex;
-      flex: 0 0 auto;
-      flex-wrap: nowrap;
-      line-height: initial;
-      margin: 0;
-      overflow: hidden;
-      padding: var(--emu-space-sm);
-      position: relative; }
-    body.-emu .window-app .window-header h4.window-title {
-      color: rgba(var(--color-text-lightest), 1); }
-      .-emu-layout body.-emu .window-app .window-header h4.window-title {
-        max-width: 100%;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
-        color: rgba(var(--color-text-lightest), 1);
-        flex: 1 1 auto;
-        font-weight: normal;
-        margin: 0;
-        position: relative; }
-    body.-emu .window-app .window-header > a,
-    body.-emu .window-app .window-header a.header-button {
-      background: transparent;
-      text-shadow: none; }
-      .-emu-layout body.-emu .window-app .window-header > a, .-emu-layout
-      body.-emu .window-app .window-header a.header-button {
-        padding: var(--emu-space-base);
-        position: relative;
-        width: auto; }
-        .-emu-layout body.-emu .window-app .window-header > a:hover, .-emu-layout
-        body.-emu .window-app .window-header a.header-button:hover {
-          color: rgba(var(--color-text-lightest), 1); }
-        .-emu-layout body.-emu .window-app .window-header > a:focus, .-emu-layout
-        body.-emu .window-app .window-header a.header-button:focus {
-          color: rgba(var(--color-text-lightest), 1);
-          text-decoration: none; }
-      body.-emu .window-app .window-header > a:hover,
-      body.-emu .window-app .window-header a.header-button:hover {
-        color: rgba(var(--color-primary), 1); }
-      body.-emu .window-app .window-header > a:focus,
-      body.-emu .window-app .window-header a.header-button:focus {
-        color: rgba(var(--color-primary), 1);
-        text-decoration: underline; }
-      .-emu-layout body.-emu .window-app .window-header > a.close, .-emu-layout
-      body.-emu .window-app .window-header a.header-button.close {
-        color: transparent;
-        overflow: hidden;
-        padding: 0;
-        width: var(--emu-space-button-sm); }
-        .-emu-layout body.-emu .window-app .window-header > a.close:hover, .-emu-layout body.-emu .window-app .window-header > a.close:focus, .-emu-layout
-        body.-emu .window-app .window-header a.header-button.close:hover, .-emu-layout
-        body.-emu .window-app .window-header a.header-button.close:focus {
-          color: transparent; }
-      .-emu-layout body.-emu .window-app .window-header > a.close > i, .-emu-layout
-      body.-emu .window-app .window-header a.header-button.close > i {
-        top: 0;
-        left: 0;
-        position: absolute;
-        width: 100%;
-        height: 100%;
-        align-items: center;
-        color: rgba(var(--color-text-lightest), 1);
-        display: flex;
-        font-size: var(--emu-font-size-lg);
-        justify-content: center;
-        margin: 0; }
-      .-emu-layout body.-emu .window-app .window-header > a > i, .-emu-layout
-      body.-emu .window-app .window-header > a > span.fas, .-emu-layout
-      body.-emu .window-app .window-header a.header-button > i, .-emu-layout
-      body.-emu .window-app .window-header a.header-button > span.fas {
-        -webkit-margin-end: var(--emu-space-base);
-                margin-inline-end: var(--emu-space-base); }
-  body.-emu .window-app .window-content {
-    background-color: rgba(var(--color-background-lightest), var(--emu-background-opacity-window-content, 1));
-    background-image: var(--emu-image-background-lightest, none);
-    color: rgba(var(--color-text), 1); }
-    .-emu-layout body.-emu .window-app .window-content {
-      flex: 1 1 auto;
-      font-size: var(--emu-font-size-md);
-      margin: 0;
-      overflow-x: hidden;
-      overflow-y: auto;
-      padding: var(--emu-space-sm);
-      position: relative; }
-    .-emu-layout body.-emu .window-app .window-content form {
-      height: 100%; }
-    body.-emu .window-app .window-content .chat-message {
-      border-radius: 0; }
-  body.-emu .window-app .window-resizable-handle {
-    background-color: rgba(var(--color-background-button), 1);
-    border: none;
-    -webkit-border-before: rgba(var(--color-background-lightest), 1) 2px solid;
-            border-block-start: rgba(var(--color-background-lightest), 1) 2px solid;
-    -webkit-border-start: rgba(var(--color-background-lightest), 1) 2px solid;
-            border-inline-start: rgba(var(--color-background-lightest), 1) 2px solid;
-    border-radius: var(--emu-border-radius-default, 0) 0 0 0;
-    color: rgba(var(--color-text-lightest), 1);
-    transition: background 0.3s cubic-bezier(0.075, 0.82, 0.165, 1), box-shadow 0.3s cubic-bezier(0.075, 0.82, 0.165, 1), color 0.3s cubic-bezier(0.075, 0.82, 0.165, 1); }
-    .-emu-layout body.-emu .window-app .window-resizable-handle {
-      right: 0;
-      bottom: 0;
-      position: absolute;
-      width: var(--emu-space-button-xs);
-      height: var(--emu-space-button-xs);
-      align-items: center;
-      cursor: pointer;
-      display: inline-flex;
-      font-size: var(--emu-font-size-md);
-      justify-content: center;
-      margin: 0;
-      padding: 0;
-      z-index: 10; }
-      .-emu-layout body.-emu .window-app .window-resizable-handle > i {
-        transform: rotate(45deg); }
+  box-shadow: 0 2px 4px rgba(var(--color-black), 1);
+}
+.-emu-layout body.-emu .window-app {
+  display: flex;
+  flex-direction: column;
+  flex-wrap: nowrap;
+  margin: 0;
+}
+.-emu-layout body.-emu .window-app.minimized .window-resizable-handle {
+  display: none;
+}
+body.-emu .window-app .window-header {
+  border: none;
+  -webkit-border-after: rgba(var(--color-border), 1) 1px solid;
+  border-block-end: rgba(var(--color-border), 1) 1px solid;
+  border-radius: calc(var(--emu-border-radius-default, 0) - 4px)
+    calc(var(--emu-border-radius-default, 0) - 4px) 0 0;
+  color: rgba(var(--color-text-lightest), 1);
+}
+.-emu-layout body.-emu .window-app .window-header {
+  align-items: center;
+  display: flex;
+  flex: 0 0 auto;
+  flex-wrap: nowrap;
+  line-height: initial;
+  margin: 0;
+  overflow: hidden;
+  padding: var(--emu-space-sm);
+  position: relative;
+}
+body.-emu .window-app .window-header h4.window-title {
+  color: rgba(var(--color-text-lightest), 1);
+}
+.-emu-layout body.-emu .window-app .window-header h4.window-title {
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: rgba(var(--color-text-lightest), 1);
+  flex: 1 1 auto;
+  font-weight: normal;
+  margin: 0;
+  position: relative;
+}
+body.-emu .window-app .window-header > a,
+body.-emu .window-app .window-header a.header-button {
+  background: transparent;
+  text-shadow: none;
+}
+.-emu-layout body.-emu .window-app .window-header > a,
+.-emu-layout body.-emu .window-app .window-header a.header-button {
+  padding: var(--emu-space-base);
+  position: relative;
+  width: auto;
+}
+.-emu-layout body.-emu .window-app .window-header > a:hover,
+.-emu-layout body.-emu .window-app .window-header a.header-button:hover {
+  color: rgba(var(--color-text-lightest), 1);
+}
+.-emu-layout body.-emu .window-app .window-header > a:focus,
+.-emu-layout body.-emu .window-app .window-header a.header-button:focus {
+  color: rgba(var(--color-text-lightest), 1);
+  text-decoration: none;
+}
+body.-emu .window-app .window-header > a:hover,
+body.-emu .window-app .window-header a.header-button:hover {
+  color: rgba(var(--color-primary), 1);
+}
+body.-emu .window-app .window-header > a:focus,
+body.-emu .window-app .window-header a.header-button:focus {
+  color: rgba(var(--color-primary), 1);
+  text-decoration: underline;
+}
+.-emu-layout body.-emu .window-app .window-header > a.close,
+.-emu-layout body.-emu .window-app .window-header a.header-button.close {
+  color: transparent;
+  overflow: hidden;
+  padding: 0;
+  width: var(--emu-space-button-sm);
+}
+.-emu-layout body.-emu .window-app .window-header > a.close:hover,
+.-emu-layout body.-emu .window-app .window-header > a.close:focus,
+.-emu-layout body.-emu .window-app .window-header a.header-button.close:hover,
+.-emu-layout body.-emu .window-app .window-header a.header-button.close:focus {
+  color: transparent;
+}
+.-emu-layout body.-emu .window-app .window-header > a.close > i,
+.-emu-layout body.-emu .window-app .window-header a.header-button.close > i {
+  top: 0;
+  left: 0;
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  align-items: center;
+  color: rgba(var(--color-text-lightest), 1);
+  display: flex;
+  font-size: var(--emu-font-size-lg);
+  justify-content: center;
+  margin: 0;
+}
+.-emu-layout body.-emu .window-app .window-header > a > i,
+.-emu-layout body.-emu .window-app .window-header > a > span.fas,
+.-emu-layout body.-emu .window-app .window-header a.header-button > i,
+.-emu-layout body.-emu .window-app .window-header a.header-button > span.fas {
+  -webkit-margin-end: var(--emu-space-base);
+  margin-inline-end: var(--emu-space-base);
+}
+body.-emu .window-app .window-content {
+  background-color: rgba(
+    var(--color-background-lightest),
+    var(--emu-background-opacity-window-content, 1)
+  );
+  background-image: var(--emu-image-background-lightest, none);
+  color: rgba(var(--color-text), 1);
+}
+.-emu-layout body.-emu .window-app .window-content {
+  flex: 1 1 auto;
+  font-size: var(--emu-font-size-md);
+  margin: 0;
+  overflow-x: hidden;
+  overflow-y: auto;
+  padding: var(--emu-space-sm);
+  position: relative;
+}
+.-emu-layout body.-emu .window-app .window-content form {
+  height: 100%;
+}
+body.-emu .window-app .window-content .chat-message {
+  border-radius: 0;
+}
+body.-emu .window-app .window-resizable-handle {
+  background-color: rgba(var(--color-background-button), 1);
+  border: none;
+  -webkit-border-before: rgba(var(--color-background-lightest), 1) 2px solid;
+  border-block-start: rgba(var(--color-background-lightest), 1) 2px solid;
+  -webkit-border-start: rgba(var(--color-background-lightest), 1) 2px solid;
+  border-inline-start: rgba(var(--color-background-lightest), 1) 2px solid;
+  border-radius: var(--emu-border-radius-default, 0) 0 0 0;
+  color: rgba(var(--color-text-lightest), 1);
+  transition: background 0.3s cubic-bezier(0.075, 0.82, 0.165, 1),
+    box-shadow 0.3s cubic-bezier(0.075, 0.82, 0.165, 1),
+    color 0.3s cubic-bezier(0.075, 0.82, 0.165, 1);
+}
+.-emu-layout body.-emu .window-app .window-resizable-handle {
+  right: 0;
+  bottom: 0;
+  position: absolute;
+  width: var(--emu-space-button-xs);
+  height: var(--emu-space-button-xs);
+  align-items: center;
+  cursor: pointer;
+  display: inline-flex;
+  font-size: var(--emu-font-size-md);
+  justify-content: center;
+  margin: 0;
+  padding: 0;
+  z-index: 10;
+}
+.-emu-layout body.-emu .window-app .window-resizable-handle > i {
+  transform: rotate(45deg);
+}
 
 .-emu-layout body.-emu .sheet .sheet-header {
   display: flex;
-  position: relative; }
+  position: relative;
+}
 
 body.-emu .sheet .sheet-header > img {
-  border: none; }
-  .-emu-layout body.-emu .sheet .sheet-header > img {
-    width: var(--emu-space-button-lg);
-    height: var(--emu-space-button-lg);
-    cursor: pointer;
-    flex: 0 0 auto;
-    -webkit-margin-end: var(--emu-space-sm);
-            margin-inline-end: var(--emu-space-sm);
-    -o-object-fit: cover;
-       object-fit: cover;
-    -o-object-position: 50% 50%;
-       object-position: 50% 50%;
-    position: relative; }
+  border: none;
+}
+.-emu-layout body.-emu .sheet .sheet-header > img {
+  width: var(--emu-space-button-lg);
+  height: var(--emu-space-button-lg);
+  cursor: pointer;
+  flex: 0 0 auto;
+  -webkit-margin-end: var(--emu-space-sm);
+  margin-inline-end: var(--emu-space-sm);
+  -o-object-fit: cover;
+  object-fit: cover;
+  -o-object-position: 50% 50%;
+  object-position: 50% 50%;
+  position: relative;
+}
 
 .-emu-layout body.-emu .sheet .sheet-header > h1 {
   flex: 1 1 auto;
-  margin: 0; }
+  margin: 0;
+}
 
 body.-emu .sheet .sheet-header > h1 input {
-  background-color: rgba(var(--color-background-light), 0.2); }
-  .-emu-layout body.-emu .sheet .sheet-header > h1 input {
-    width: 100%;
-    height: 2.5rem;
-    flex: 0 0 auto;
-    font-size: var(--emu-font-size-xxl);
-    line-height: 1;
-    margin: 0; }
+  background-color: rgba(var(--color-background-light), 0.2);
+}
+.-emu-layout body.-emu .sheet .sheet-header > h1 input {
+  width: 100%;
+  height: 2.5rem;
+  flex: 0 0 auto;
+  font-size: var(--emu-font-size-xxl);
+  line-height: 1;
+  margin: 0;
+}
 
 .-emu-layout body.-emu .sheet .sheet-footer {
   flex: 0 0 auto;
   line-height: initial;
   -webkit-margin-before: var(--emu-space-sm);
-          margin-block-start: var(--emu-space-sm);
-  z-index: 10; }
-  .-emu-layout body.-emu .sheet .sheet-footer + ::after {
-    display: none; }
+  margin-block-start: var(--emu-space-sm);
+  z-index: 10;
+}
+.-emu-layout body.-emu .sheet .sheet-footer + ::after {
+  display: none;
+}
 
 body.-emu #sidebar,
 body.-emu .sidebar-popout {
-  background-color: rgba(var(--color-background-darkest), var(--emu-background-opacity-sidebar, 0.8));
+  background-color: rgba(
+    var(--color-background-darkest),
+    var(--emu-background-opacity-sidebar, 0.8)
+  );
   background-image: var(--emu-image-background-darkest, none);
   border: rgba(var(--color-border), 1) 1px solid;
   box-shadow: none;
-  transition: opacity 0.3s cubic-bezier(0.075, 0.82, 0.165, 1); }
-  .-emu-layout body.-emu #sidebar, .-emu-layout
-  body.-emu .sidebar-popout {
-    top: calc(var(--emu-space-md) / 2);
-    right: 0;
-    bottom: auto;
-    position: fixed;
-    width: var(--emu-space-sidebar);
-    height: calc(100% - var(--emu-space-md));
-    display: flex;
-    flex-direction: column;
-    margin: 0;
-    overflow: hidden;
-    padding: 0;
-    z-index: 10; }
-    .-emu-layout body.-emu #sidebar ol,
-    .-emu-layout body.-emu #sidebar ul, .-emu-layout
-    body.-emu .sidebar-popout ol,
-    .-emu-layout
-    body.-emu .sidebar-popout ul {
-      margin: 0;
-      padding: 0; }
-  .-emu-layout body.-emu #sidebar.collapsed, .-emu-layout
-  body.-emu .sidebar-popout.collapsed {
-    height: auto !important;
-    width: 2rem !important; }
-  .-emu-layout.-emu-subtle-layout body.-emu #sidebar.collapsed, .-emu-layout.-emu-subtle-layout
-  body.-emu .sidebar-popout.collapsed {
-    opacity: var(--emu-subtle-opacity, 0.3); }
-    .-emu-layout.-emu-subtle-layout body.-emu #sidebar.collapsed:hover, .-emu-layout.-emu-subtle-layout
-    body.-emu .sidebar-popout.collapsed:hover {
-      opacity: 1; }
-  body.-emu #sidebar.collapsed #sidebar-tabs,
-  body.-emu .sidebar-popout.collapsed #sidebar-tabs {
-    -webkit-border-after: none;
-            border-block-end: none; }
-    .-emu-layout body.-emu #sidebar.collapsed #sidebar-tabs, .-emu-layout
-    body.-emu .sidebar-popout.collapsed #sidebar-tabs {
-      flex-wrap: wrap; }
-    body.-emu #sidebar.collapsed #sidebar-tabs > .collapse,
-    body.-emu .sidebar-popout.collapsed #sidebar-tabs > .collapse {
-      border-radius: 0 0 0 var(--emu-border-radius-default, 0); }
-  .-emu-layout body.-emu #sidebar.collapsed .sidebar-tab, .-emu-layout
-  body.-emu #sidebar.collapsed .sidebar-tab.active, .-emu-layout
-  body.-emu .sidebar-popout.collapsed .sidebar-tab, .-emu-layout
-  body.-emu .sidebar-popout.collapsed .sidebar-tab.active {
-    display: none; }
-  body.-emu #sidebar #sidebar-tabs,
-  body.-emu .sidebar-popout #sidebar-tabs {
-    -webkit-border-after: rgba(var(--color-border), 1) 1px solid;
-            border-block-end: rgba(var(--color-border), 1) 1px solid;
-    box-shadow: none;
-    transition: background 0.3s cubic-bezier(0.075, 0.82, 0.165, 1), box-shadow 0.3s cubic-bezier(0.075, 0.82, 0.165, 1), color 0.3s cubic-bezier(0.075, 0.82, 0.165, 1); }
-    .-emu-layout body.-emu #sidebar #sidebar-tabs, .-emu-layout
-    body.-emu .sidebar-popout #sidebar-tabs {
-      display: flex;
-      flex: 0 0 auto;
-      flex-wrap: nowrap;
-      font-size: var(--emu-font-size-sm);
-      margin: 0;
-      position: relative; }
-    body.-emu #sidebar #sidebar-tabs > .item,
-    body.-emu #sidebar #sidebar-tabs > .collapse,
-    body.-emu .sidebar-popout #sidebar-tabs > .item,
-    body.-emu .sidebar-popout #sidebar-tabs > .collapse {
-      border: none;
-      border-radius: 0;
-      box-shadow: none;
-      color: rgba(var(--color-text-lightest), 1);
-      transition: box-shadow 0.3s cubic-bezier(0.075, 0.82, 0.165, 1), color 0.3s cubic-bezier(0.075, 0.82, 0.165, 1); }
-      .-emu-layout body.-emu #sidebar #sidebar-tabs > .item, .-emu-layout
-      body.-emu #sidebar #sidebar-tabs > .collapse, .-emu-layout
-      body.-emu .sidebar-popout #sidebar-tabs > .item, .-emu-layout
-      body.-emu .sidebar-popout #sidebar-tabs > .collapse {
-        align-items: center;
-        cursor: pointer;
-        display: flex;
-        flex: 1 1 20%;
-        font-size: var(--emu-font-size-sm);
-        justify-content: center;
-        left: auto;
-        line-height: initial;
-        margin: 0;
-        padding: var(--emu-space-sm) var(--emu-space-base);
-        position: relative;
-        top: auto; }
-      body.-emu #sidebar #sidebar-tabs > .item.active,
-      body.-emu #sidebar #sidebar-tabs > .collapse.active,
-      body.-emu .sidebar-popout #sidebar-tabs > .item.active,
-      body.-emu .sidebar-popout #sidebar-tabs > .collapse.active {
-        border-radius: 0;
-        border: none; }
-        body.-emu #sidebar #sidebar-tabs > .item.active:first-child,
-        body.-emu #sidebar #sidebar-tabs > .collapse.active:first-child,
-        body.-emu .sidebar-popout #sidebar-tabs > .item.active:first-child,
-        body.-emu .sidebar-popout #sidebar-tabs > .collapse.active:first-child {
-          border-radius: var(--emu-border-radius-default, 0) 0 0 0; }
-      body.-emu #sidebar #sidebar-tabs > .item:first-child,
-      body.-emu #sidebar #sidebar-tabs > .collapse:first-child,
-      body.-emu .sidebar-popout #sidebar-tabs > .item:first-child,
-      body.-emu .sidebar-popout #sidebar-tabs > .collapse:first-child {
-        border-radius: var(--emu-border-radius-default, 0) 0 0 0; }
-      .-emu-layout body.-emu #sidebar #sidebar-tabs > .item > i, .-emu-layout
-      body.-emu #sidebar #sidebar-tabs > .collapse > i, .-emu-layout
-      body.-emu .sidebar-popout #sidebar-tabs > .item > i, .-emu-layout
-      body.-emu .sidebar-popout #sidebar-tabs > .collapse > i {
-        margin: 0;
-        position: relative;
-        z-index: 1; }
-      body.-emu #sidebar #sidebar-tabs > .item .notification-pip,
-      body.-emu #sidebar #sidebar-tabs > .collapse .notification-pip,
-      body.-emu .sidebar-popout #sidebar-tabs > .item .notification-pip,
-      body.-emu .sidebar-popout #sidebar-tabs > .collapse .notification-pip {
-        background-color: rgba(var(--color-primary), 1); }
-        .-emu-layout body.-emu #sidebar #sidebar-tabs > .item .notification-pip, .-emu-layout
-        body.-emu #sidebar #sidebar-tabs > .collapse .notification-pip, .-emu-layout
-        body.-emu .sidebar-popout #sidebar-tabs > .item .notification-pip, .-emu-layout
-        body.-emu .sidebar-popout #sidebar-tabs > .collapse .notification-pip {
-          top: 0;
-          right: 0;
-          bottom: 0;
-          left: 0;
-          position: absolute;
-          -webkit-animation-duration: 0.8s;
-                  animation-duration: 0.8s;
-          -webkit-animation-iteration-count: infinite;
-                  animation-iteration-count: infinite;
-          -webkit-animation-name: emu-notification-flash;
-                  animation-name: emu-notification-flash;
-          -webkit-animation-timing-function: cubic-bezier(0.77, 0, 0.175, 1);
-                  animation-timing-function: cubic-bezier(0.77, 0, 0.175, 1);
-          display: none;
-          opacity: 0;
-          pointer-events: none;
-          z-index: 0; }
-          .-emu-layout body.-emu #sidebar #sidebar-tabs > .item .notification-pip::before, .-emu-layout
-          body.-emu #sidebar #sidebar-tabs > .collapse .notification-pip::before, .-emu-layout
-          body.-emu .sidebar-popout #sidebar-tabs > .item .notification-pip::before, .-emu-layout
-          body.-emu .sidebar-popout #sidebar-tabs > .collapse .notification-pip::before {
-            display: none; }
-  .-emu-layout body.-emu #sidebar .window-content .sidebar-tab, .-emu-layout
-  body.-emu .sidebar-popout .window-content .sidebar-tab {
-    display: flex; }
-  .-emu-layout body.-emu #sidebar .sidebar-tab, .-emu-layout
-  body.-emu .sidebar-popout .sidebar-tab {
-    display: none;
-    flex: 1 1 auto;
-    flex-direction: column;
-    height: 100%;
-    justify-content: initial;
-    margin: 0;
-    min-height: 12.5rem;
-    position: relative; }
-    .-emu-layout body.-emu #sidebar .sidebar-tab.active, .-emu-layout
-    body.-emu .sidebar-popout .sidebar-tab.active {
-      display: flex; }
-  .-emu-layout.-emu-compact body.-emu #sidebar .sidebar-tab, .-emu-layout.-emu-compact
-  body.-emu .sidebar-popout .sidebar-tab {
-    min-height: 11rem; }
-  .-emu-layout body.-emu #sidebar .sidebar-tab .directory-header .header-actions button, .-emu-layout
-  body.-emu #sidebar .sidebar-tab .directory-footer button, .-emu-layout
-  body.-emu .sidebar-popout .sidebar-tab .directory-header .header-actions button, .-emu-layout
-  body.-emu .sidebar-popout .sidebar-tab .directory-footer button {
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    height: auto;
-    line-height: 1;
-    width: auto; }
-    .-emu-layout body.-emu #sidebar .sidebar-tab .directory-header .header-actions button > i, .-emu-layout
-    body.-emu #sidebar .sidebar-tab .directory-footer button > i, .-emu-layout
-    body.-emu .sidebar-popout .sidebar-tab .directory-header .header-actions button > i, .-emu-layout
-    body.-emu .sidebar-popout .sidebar-tab .directory-footer button > i {
-      font-size: var(--emu-font-size-md); }
-  body.-emu #sidebar .sidebar-tab .directory-header,
-  body.-emu .sidebar-popout .sidebar-tab .directory-header {
-    -webkit-border-after: rgba(var(--color-border), 1) 1px solid;
-            border-block-end: rgba(var(--color-border), 1) 1px solid; }
-    .-emu-layout body.-emu #sidebar .sidebar-tab .directory-header, .-emu-layout
-    body.-emu .sidebar-popout .sidebar-tab .directory-header {
-      flex-direction: column; }
-    .-emu-layout body.-emu #sidebar .sidebar-tab .directory-header .header-search, .-emu-layout
-    body.-emu .sidebar-popout .sidebar-tab .directory-header .header-search {
-      align-items: center;
-      display: flex;
-      flex: 1 1 auto;
-      flex-wrap: nowrap;
-      position: relative;
-      width: 100%; }
-      .-emu-layout body.-emu #sidebar .sidebar-tab .directory-header .header-search > i, .-emu-layout
-      body.-emu .sidebar-popout .sidebar-tab .directory-header .header-search > i {
-        flex: 0 0 auto; }
-    body.-emu #sidebar .sidebar-tab .directory-header .header-search input,
-    body.-emu .sidebar-popout .sidebar-tab .directory-header .header-search input {
-      background-color: rgba(var(--color-background-lightest), 1); }
-      .-emu-layout body.-emu #sidebar .sidebar-tab .directory-header .header-search input, .-emu-layout
-      body.-emu .sidebar-popout .sidebar-tab .directory-header .header-search input {
-        flex: 1 1 auto;
-        margin: 0; }
-    .-emu-layout body.-emu #sidebar .sidebar-tab .directory-header .header-search + .header-actions, .-emu-layout
-    body.-emu .sidebar-popout .sidebar-tab .directory-header .header-search + .header-actions {
-      -webkit-margin-before: var(--emu-space-sm);
-              margin-block-start: var(--emu-space-sm); }
-    .-emu-layout body.-emu #sidebar .sidebar-tab .directory-header .header-control, .-emu-layout
-    body.-emu .sidebar-popout .sidebar-tab .directory-header .header-control {
-      width: 2rem;
-      height: 2rem;
-      flex: 0 0 auto;
-      -webkit-margin-start: var(--emu-space-base);
-              margin-inline-start: var(--emu-space-base); }
-      .-emu-layout body.-emu #sidebar .sidebar-tab .directory-header .header-control > i, .-emu-layout
-      body.-emu .sidebar-popout .sidebar-tab .directory-header .header-control > i {
-        margin: 0; }
-    .-emu-layout body.-emu #sidebar .sidebar-tab .directory-header .header-actions, .-emu-layout
-    body.-emu .sidebar-popout .sidebar-tab .directory-header .header-actions {
-      align-items: center;
-      display: flex;
-      flex: 0 0 auto;
-      flex-wrap: wrap;
-      -webkit-margin-after: var(--emu-space-sm);
-              margin-block-end: var(--emu-space-sm);
-      position: relative;
-      width: 100%; }
-      .-emu-layout body.-emu #sidebar .sidebar-tab .directory-header .header-actions:only-child, .-emu-layout body.-emu #sidebar .sidebar-tab .directory-header .header-actions:last-child, .-emu-layout
-      body.-emu .sidebar-popout .sidebar-tab .directory-header .header-actions:only-child, .-emu-layout
-      body.-emu .sidebar-popout .sidebar-tab .directory-header .header-actions:last-child {
-        -webkit-margin-after: 0;
-                margin-block-end: 0; }
-    .-emu-layout body.-emu #sidebar .sidebar-tab .directory-header > .action-buttons, .-emu-layout
-    body.-emu .sidebar-popout .sidebar-tab .directory-header > .action-buttons {
-      align-items: center;
-      display: flex;
-      flex: 0 0 auto;
-      position: relative;
-      width: 100%; }
-    .-emu-layout body.-emu #sidebar .sidebar-tab .directory-header > .action-buttons + .action-buttons, .-emu-layout
-    body.-emu .sidebar-popout .sidebar-tab .directory-header > .action-buttons + .action-buttons {
-      -webkit-margin-before: var(--emu-space-base);
-              margin-block-start: var(--emu-space-base); }
-  body.-emu #sidebar .sidebar-tab .directory-footer,
-  body.-emu .sidebar-popout .sidebar-tab .directory-footer {
-    -webkit-border-before: rgba(var(--color-border), 1) 1px solid;
-            border-block-start: rgba(var(--color-border), 1) 1px solid; }
-    .-emu-layout body.-emu #sidebar .sidebar-tab .directory-footer, .-emu-layout
-    body.-emu .sidebar-popout .sidebar-tab .directory-footer {
-      flex-wrap: wrap; }
-  .-emu-layout body.-emu #sidebar > .directory-list, .-emu-layout
-  body.-emu .sidebar-popout > .directory-list {
-    display: flex;
-    flex-direction: column; }
+  transition: opacity 0.3s cubic-bezier(0.075, 0.82, 0.165, 1);
+}
+.-emu-layout body.-emu #sidebar,
+.-emu-layout body.-emu .sidebar-popout {
+  top: calc(var(--emu-space-md) / 2);
+  right: 0;
+  bottom: auto;
+  position: fixed;
+  width: var(--emu-space-sidebar);
+  height: calc(100% - var(--emu-space-md));
+  display: flex;
+  flex-direction: column;
+  margin: 0;
+  overflow: hidden;
+  padding: 0;
+  z-index: 10;
+}
+.-emu-layout body.-emu #sidebar ol,
+.-emu-layout body.-emu #sidebar ul,
+.-emu-layout body.-emu .sidebar-popout ol,
+.-emu-layout body.-emu .sidebar-popout ul {
+  margin: 0;
+  padding: 0;
+}
+.-emu-layout body.-emu #sidebar.collapsed,
+.-emu-layout body.-emu .sidebar-popout.collapsed {
+  height: auto !important;
+  width: 2rem !important;
+}
+.-emu-layout.-emu-subtle-layout body.-emu #sidebar.collapsed,
+.-emu-layout.-emu-subtle-layout body.-emu .sidebar-popout.collapsed {
+  opacity: var(--emu-subtle-opacity, 0.3);
+}
+.-emu-layout.-emu-subtle-layout body.-emu #sidebar.collapsed:hover,
+.-emu-layout.-emu-subtle-layout body.-emu .sidebar-popout.collapsed:hover {
+  opacity: 1;
+}
+body.-emu #sidebar.collapsed #sidebar-tabs,
+body.-emu .sidebar-popout.collapsed #sidebar-tabs {
+  -webkit-border-after: none;
+  border-block-end: none;
+}
+.-emu-layout body.-emu #sidebar.collapsed #sidebar-tabs,
+.-emu-layout body.-emu .sidebar-popout.collapsed #sidebar-tabs {
+  flex-wrap: wrap;
+}
+body.-emu #sidebar.collapsed #sidebar-tabs > .collapse,
+body.-emu .sidebar-popout.collapsed #sidebar-tabs > .collapse {
+  border-radius: 0 0 0 var(--emu-border-radius-default, 0);
+}
+.-emu-layout body.-emu #sidebar.collapsed .sidebar-tab,
+.-emu-layout body.-emu #sidebar.collapsed .sidebar-tab.active,
+.-emu-layout body.-emu .sidebar-popout.collapsed .sidebar-tab,
+.-emu-layout body.-emu .sidebar-popout.collapsed .sidebar-tab.active {
+  display: none;
+}
+body.-emu #sidebar #sidebar-tabs,
+body.-emu .sidebar-popout #sidebar-tabs {
+  -webkit-border-after: rgba(var(--color-border), 1) 1px solid;
+  border-block-end: rgba(var(--color-border), 1) 1px solid;
+  box-shadow: none;
+  transition: background 0.3s cubic-bezier(0.075, 0.82, 0.165, 1),
+    box-shadow 0.3s cubic-bezier(0.075, 0.82, 0.165, 1),
+    color 0.3s cubic-bezier(0.075, 0.82, 0.165, 1);
+}
+.-emu-layout body.-emu #sidebar #sidebar-tabs,
+.-emu-layout body.-emu .sidebar-popout #sidebar-tabs {
+  display: flex;
+  flex: 0 0 auto;
+  flex-wrap: nowrap;
+  font-size: var(--emu-font-size-sm);
+  margin: 0;
+  position: relative;
+}
+body.-emu #sidebar #sidebar-tabs > .item,
+body.-emu #sidebar #sidebar-tabs > .collapse,
+body.-emu .sidebar-popout #sidebar-tabs > .item,
+body.-emu .sidebar-popout #sidebar-tabs > .collapse {
+  border: none;
+  border-radius: 0;
+  box-shadow: none;
+  color: rgba(var(--color-text-lightest), 1);
+  transition: box-shadow 0.3s cubic-bezier(0.075, 0.82, 0.165, 1),
+    color 0.3s cubic-bezier(0.075, 0.82, 0.165, 1);
+}
+.-emu-layout body.-emu #sidebar #sidebar-tabs > .item,
+.-emu-layout body.-emu #sidebar #sidebar-tabs > .collapse,
+.-emu-layout body.-emu .sidebar-popout #sidebar-tabs > .item,
+.-emu-layout body.-emu .sidebar-popout #sidebar-tabs > .collapse {
+  align-items: center;
+  cursor: pointer;
+  display: flex;
+  flex: 1 1 20%;
+  font-size: var(--emu-font-size-sm);
+  justify-content: center;
+  left: auto;
+  line-height: initial;
+  margin: 0;
+  padding: var(--emu-space-sm) var(--emu-space-base);
+  position: relative;
+  top: auto;
+}
+body.-emu #sidebar #sidebar-tabs > .item.active,
+body.-emu #sidebar #sidebar-tabs > .collapse.active,
+body.-emu .sidebar-popout #sidebar-tabs > .item.active,
+body.-emu .sidebar-popout #sidebar-tabs > .collapse.active {
+  border-radius: 0;
+  border: none;
+}
+body.-emu #sidebar #sidebar-tabs > .item.active:first-child,
+body.-emu #sidebar #sidebar-tabs > .collapse.active:first-child,
+body.-emu .sidebar-popout #sidebar-tabs > .item.active:first-child,
+body.-emu .sidebar-popout #sidebar-tabs > .collapse.active:first-child {
+  border-radius: var(--emu-border-radius-default, 0) 0 0 0;
+}
+body.-emu #sidebar #sidebar-tabs > .item:first-child,
+body.-emu #sidebar #sidebar-tabs > .collapse:first-child,
+body.-emu .sidebar-popout #sidebar-tabs > .item:first-child,
+body.-emu .sidebar-popout #sidebar-tabs > .collapse:first-child {
+  border-radius: var(--emu-border-radius-default, 0) 0 0 0;
+}
+.-emu-layout body.-emu #sidebar #sidebar-tabs > .item > i,
+.-emu-layout body.-emu #sidebar #sidebar-tabs > .collapse > i,
+.-emu-layout body.-emu .sidebar-popout #sidebar-tabs > .item > i,
+.-emu-layout body.-emu .sidebar-popout #sidebar-tabs > .collapse > i {
+  margin: 0;
+  position: relative;
+  z-index: 1;
+}
+body.-emu #sidebar #sidebar-tabs > .item .notification-pip,
+body.-emu #sidebar #sidebar-tabs > .collapse .notification-pip,
+body.-emu .sidebar-popout #sidebar-tabs > .item .notification-pip,
+body.-emu .sidebar-popout #sidebar-tabs > .collapse .notification-pip {
+  background-color: rgba(var(--color-primary), 1);
+}
+.-emu-layout body.-emu #sidebar #sidebar-tabs > .item .notification-pip,
+.-emu-layout body.-emu #sidebar #sidebar-tabs > .collapse .notification-pip,
+.-emu-layout body.-emu .sidebar-popout #sidebar-tabs > .item .notification-pip,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #sidebar-tabs
+  > .collapse
+  .notification-pip {
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  position: absolute;
+  -webkit-animation-duration: 0.8s;
+  animation-duration: 0.8s;
+  -webkit-animation-iteration-count: infinite;
+  animation-iteration-count: infinite;
+  -webkit-animation-name: emu-notification-flash;
+  animation-name: emu-notification-flash;
+  -webkit-animation-timing-function: cubic-bezier(0.77, 0, 0.175, 1);
+  animation-timing-function: cubic-bezier(0.77, 0, 0.175, 1);
+  display: none;
+  opacity: 0;
+  pointer-events: none;
+  z-index: 0;
+}
+.-emu-layout body.-emu #sidebar #sidebar-tabs > .item .notification-pip::before,
+.-emu-layout
+  body.-emu
+  #sidebar
+  #sidebar-tabs
+  > .collapse
+  .notification-pip::before,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #sidebar-tabs
+  > .item
+  .notification-pip::before,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #sidebar-tabs
+  > .collapse
+  .notification-pip::before {
+  display: none;
+}
+.-emu-layout body.-emu #sidebar .window-content .sidebar-tab,
+.-emu-layout body.-emu .sidebar-popout .window-content .sidebar-tab {
+  display: flex;
+}
+.-emu-layout body.-emu #sidebar .sidebar-tab,
+.-emu-layout body.-emu .sidebar-popout .sidebar-tab {
+  display: none;
+  flex: 1 1 auto;
+  flex-direction: column;
+  height: 100%;
+  justify-content: initial;
+  margin: 0;
+  min-height: 12.5rem;
+  position: relative;
+}
+.-emu-layout body.-emu #sidebar .sidebar-tab.active,
+.-emu-layout body.-emu .sidebar-popout .sidebar-tab.active {
+  display: flex;
+}
+.-emu-layout.-emu-compact body.-emu #sidebar .sidebar-tab,
+.-emu-layout.-emu-compact body.-emu .sidebar-popout .sidebar-tab {
+  min-height: 11rem;
+}
+.-emu-layout
+  body.-emu
+  #sidebar
+  .sidebar-tab
+  .directory-header
+  .header-actions
+  button,
+.-emu-layout body.-emu #sidebar .sidebar-tab .directory-footer button,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  .sidebar-tab
+  .directory-header
+  .header-actions
+  button,
+.-emu-layout body.-emu .sidebar-popout .sidebar-tab .directory-footer button {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  height: auto;
+  line-height: 1;
+  width: auto;
+}
+.-emu-layout
+  body.-emu
+  #sidebar
+  .sidebar-tab
+  .directory-header
+  .header-actions
+  button
+  > i,
+.-emu-layout body.-emu #sidebar .sidebar-tab .directory-footer button > i,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  .sidebar-tab
+  .directory-header
+  .header-actions
+  button
+  > i,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  .sidebar-tab
+  .directory-footer
+  button
+  > i {
+  font-size: var(--emu-font-size-md);
+}
+body.-emu #sidebar .sidebar-tab .directory-header,
+body.-emu .sidebar-popout .sidebar-tab .directory-header {
+  -webkit-border-after: rgba(var(--color-border), 1) 1px solid;
+  border-block-end: rgba(var(--color-border), 1) 1px solid;
+}
+.-emu-layout body.-emu #sidebar .sidebar-tab .directory-header,
+.-emu-layout body.-emu .sidebar-popout .sidebar-tab .directory-header {
+  flex-direction: column;
+}
+.-emu-layout body.-emu #sidebar .sidebar-tab .directory-header .header-search,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  .sidebar-tab
+  .directory-header
+  .header-search {
+  align-items: center;
+  display: flex;
+  flex: 1 1 auto;
+  flex-wrap: nowrap;
+  position: relative;
+  width: 100%;
+}
+.-emu-layout
+  body.-emu
+  #sidebar
+  .sidebar-tab
+  .directory-header
+  .header-search
+  > i,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  .sidebar-tab
+  .directory-header
+  .header-search
+  > i {
+  flex: 0 0 auto;
+}
+body.-emu #sidebar .sidebar-tab .directory-header .header-search input,
+body.-emu .sidebar-popout .sidebar-tab .directory-header .header-search input {
+  background-color: rgba(var(--color-background-lightest), 1);
+}
+.-emu-layout
+  body.-emu
+  #sidebar
+  .sidebar-tab
+  .directory-header
+  .header-search
+  input,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  .sidebar-tab
+  .directory-header
+  .header-search
+  input {
+  flex: 1 1 auto;
+  margin: 0;
+}
+.-emu-layout
+  body.-emu
+  #sidebar
+  .sidebar-tab
+  .directory-header
+  .header-search
+  + .header-actions,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  .sidebar-tab
+  .directory-header
+  .header-search
+  + .header-actions {
+  -webkit-margin-before: var(--emu-space-sm);
+  margin-block-start: var(--emu-space-sm);
+}
+.-emu-layout body.-emu #sidebar .sidebar-tab .directory-header .header-control,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  .sidebar-tab
+  .directory-header
+  .header-control {
+  width: 2rem;
+  height: 2rem;
+  flex: 0 0 auto;
+  -webkit-margin-start: var(--emu-space-base);
+  margin-inline-start: var(--emu-space-base);
+}
+.-emu-layout
+  body.-emu
+  #sidebar
+  .sidebar-tab
+  .directory-header
+  .header-control
+  > i,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  .sidebar-tab
+  .directory-header
+  .header-control
+  > i {
+  margin: 0;
+}
+.-emu-layout body.-emu #sidebar .sidebar-tab .directory-header .header-actions,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  .sidebar-tab
+  .directory-header
+  .header-actions {
+  align-items: center;
+  display: flex;
+  flex: 0 0 auto;
+  flex-wrap: wrap;
+  -webkit-margin-after: var(--emu-space-sm);
+  margin-block-end: var(--emu-space-sm);
+  position: relative;
+  width: 100%;
+}
+.-emu-layout
+  body.-emu
+  #sidebar
+  .sidebar-tab
+  .directory-header
+  .header-actions:only-child,
+.-emu-layout
+  body.-emu
+  #sidebar
+  .sidebar-tab
+  .directory-header
+  .header-actions:last-child,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  .sidebar-tab
+  .directory-header
+  .header-actions:only-child,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  .sidebar-tab
+  .directory-header
+  .header-actions:last-child {
+  -webkit-margin-after: 0;
+  margin-block-end: 0;
+}
+.-emu-layout
+  body.-emu
+  #sidebar
+  .sidebar-tab
+  .directory-header
+  > .action-buttons,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  .sidebar-tab
+  .directory-header
+  > .action-buttons {
+  align-items: center;
+  display: flex;
+  flex: 0 0 auto;
+  position: relative;
+  width: 100%;
+}
+.-emu-layout
+  body.-emu
+  #sidebar
+  .sidebar-tab
+  .directory-header
+  > .action-buttons
+  + .action-buttons,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  .sidebar-tab
+  .directory-header
+  > .action-buttons
+  + .action-buttons {
+  -webkit-margin-before: var(--emu-space-base);
+  margin-block-start: var(--emu-space-base);
+}
+body.-emu #sidebar .sidebar-tab .directory-footer,
+body.-emu .sidebar-popout .sidebar-tab .directory-footer {
+  -webkit-border-before: rgba(var(--color-border), 1) 1px solid;
+  border-block-start: rgba(var(--color-border), 1) 1px solid;
+}
+.-emu-layout body.-emu #sidebar .sidebar-tab .directory-footer,
+.-emu-layout body.-emu .sidebar-popout .sidebar-tab .directory-footer {
+  flex-wrap: wrap;
+}
+.-emu-layout body.-emu #sidebar > .directory-list,
+.-emu-layout body.-emu .sidebar-popout > .directory-list {
+  display: flex;
+  flex-direction: column;
+}
 
 body.-emu #sidebar {
   -webkit-border-end: none;
-          border-inline-end: none;
-  border-radius: var(--emu-border-radius-default, 0) 0 0 var(--emu-border-radius-default, 0); }
-  .-emu-layout.-emu-subtle-layout body.-emu #sidebar {
-    opacity: var(--emu-subtle-opacity, 0.3);
-    overflow: visible;
-    right: calc(-1 * var(--emu-space-sidebar));
-    transition: opacity 0.3s cubic-bezier(0.77, 0, 0.175, 1), right 0.3s cubic-bezier(0.77, 0, 0.175, 1); }
-    .-emu-layout.-emu-subtle-layout body.-emu #sidebar.collapsed {
-      right: 0; }
-      .-emu-layout.-emu-subtle-layout body.-emu #sidebar.collapsed::before,
-      .-emu-layout.-emu-subtle-layout body.-emu #sidebar.collapsed #emu-sidebar-lock {
-        display: none; }
-    .-emu-layout.-emu-subtle-layout body.-emu #sidebar:hover, .-emu-layout.-emu-subtle-layout body.-emu #sidebar.is-locked {
-      opacity: 1;
-      right: 0; }
-      .-emu-layout.-emu-subtle-layout body.-emu #sidebar:hover #emu-sidebar-lock::before, .-emu-layout.-emu-subtle-layout body.-emu #sidebar.is-locked #emu-sidebar-lock::before {
-        content: "\f0da"; }
-    .-emu-layout.-emu-subtle-layout body.-emu #sidebar.is-locked #emu-sidebar-lock::before {
-      content: "\f023"; }
-    .-emu-layout.-emu-subtle-layout body.-emu #sidebar::before {
-      top: calc(-1 * var(--emu-space-md) / 2);
-      right: 0;
-      position: absolute;
-      background-color: transparent;
-      content: "";
-      height: calc(100% + var(--emu-space-md));
-      width: calc(100% + var(--emu-space-button));
-      z-index: -1; }
-    .-emu-layout.-emu-subtle-layout body.-emu #sidebar #emu-sidebar-lock {
-      top: 50%;
-      right: 100%;
-      position: absolute;
-      align-items: center;
-      background-color: rgba(var(--color-background), 1);
-      border: rgba(var(--color-border), 1) 1px solid;
-      -webkit-border-end: 0;
-              border-inline-end: 0;
-      color: rgba(var(--color-text-lightest), 1);
-      cursor: pointer;
-      display: flex;
-      height: 4rem;
-      justify-content: center;
-      -webkit-margin-before: -2rem;
-              margin-block-start: -2rem;
-      width: var(--emu-space-button); }
-      .-emu-layout.-emu-subtle-layout body.-emu #sidebar #emu-sidebar-lock::before {
-        content: "\f0d9"; }
-      .-emu-layout.-emu-subtle-layout body.-emu #sidebar #emu-sidebar-lock:hover::before {
-        content: "\f023"; }
-  .-emu-layout.-emu-subtle-layout-sidebar-locked body.-emu #sidebar {
-    opacity: 1;
-    right: 0; }
-    .-emu-layout.-emu-subtle-layout-sidebar-locked body.-emu #sidebar #emu-sidebar-lock {
-      display: none; }
-  body.-emu #sidebar #emu-sidebar-lock {
-    display: none; }
+  border-inline-end: none;
+  border-radius: var(--emu-border-radius-default, 0) 0 0
+    var(--emu-border-radius-default, 0);
+}
+.-emu-layout.-emu-subtle-layout body.-emu #sidebar {
+  opacity: var(--emu-subtle-opacity, 0.3);
+  overflow: visible;
+  right: calc(-1 * var(--emu-space-sidebar));
+  transition: opacity 0.3s cubic-bezier(0.77, 0, 0.175, 1),
+    right 0.3s cubic-bezier(0.77, 0, 0.175, 1);
+}
+.-emu-layout.-emu-subtle-layout body.-emu #sidebar.collapsed {
+  right: 0;
+}
+.-emu-layout.-emu-subtle-layout body.-emu #sidebar.collapsed::before,
+.-emu-layout.-emu-subtle-layout body.-emu #sidebar.collapsed #emu-sidebar-lock {
+  display: none;
+}
+.-emu-layout.-emu-subtle-layout body.-emu #sidebar:hover,
+.-emu-layout.-emu-subtle-layout body.-emu #sidebar.is-locked {
+  opacity: 1;
+  right: 0;
+}
+.-emu-layout.-emu-subtle-layout
+  body.-emu
+  #sidebar:hover
+  #emu-sidebar-lock::before,
+.-emu-layout.-emu-subtle-layout
+  body.-emu
+  #sidebar.is-locked
+  #emu-sidebar-lock::before {
+  content: "\f0da";
+}
+.-emu-layout.-emu-subtle-layout
+  body.-emu
+  #sidebar.is-locked
+  #emu-sidebar-lock::before {
+  content: "\f023";
+}
+.-emu-layout.-emu-subtle-layout body.-emu #sidebar::before {
+  top: calc(-1 * var(--emu-space-md) / 2);
+  right: 0;
+  position: absolute;
+  background-color: transparent;
+  content: "";
+  height: calc(100% + var(--emu-space-md));
+  width: calc(100% + var(--emu-space-button));
+  z-index: -1;
+}
+.-emu-layout.-emu-subtle-layout body.-emu #sidebar #emu-sidebar-lock {
+  top: 50%;
+  right: 100%;
+  position: absolute;
+  align-items: center;
+  background-color: rgba(var(--color-background), 1);
+  border: rgba(var(--color-border), 1) 1px solid;
+  -webkit-border-end: 0;
+  border-inline-end: 0;
+  color: rgba(var(--color-text-lightest), 1);
+  cursor: pointer;
+  display: flex;
+  height: 4rem;
+  justify-content: center;
+  -webkit-margin-before: -2rem;
+  margin-block-start: -2rem;
+  width: var(--emu-space-button);
+}
+.-emu-layout.-emu-subtle-layout body.-emu #sidebar #emu-sidebar-lock::before {
+  content: "\f0d9";
+}
+.-emu-layout.-emu-subtle-layout
+  body.-emu
+  #sidebar
+  #emu-sidebar-lock:hover::before {
+  content: "\f023";
+}
+.-emu-layout.-emu-subtle-layout-sidebar-locked body.-emu #sidebar {
+  opacity: 1;
+  right: 0;
+}
+.-emu-layout.-emu-subtle-layout-sidebar-locked
+  body.-emu
+  #sidebar
+  #emu-sidebar-lock {
+  display: none;
+}
+body.-emu #sidebar #emu-sidebar-lock {
+  display: none;
+}
 
 body.-emu .sidebar-popout {
-  border-radius: var(--emu-border-radius-default, 0); }
-  .-emu-layout body.-emu .sidebar-popout {
-    height: auto;
-    min-height: 50vh;
-    min-width: var(--emu-space-sidebar); }
-  body.-emu .sidebar-popout .window-content {
-    background-color: transparent; }
-    .-emu-layout body.-emu .sidebar-popout .window-content {
-      padding: 0; }
+  border-radius: var(--emu-border-radius-default, 0);
+}
+.-emu-layout body.-emu .sidebar-popout {
+  height: auto;
+  min-height: 50vh;
+  min-width: var(--emu-space-sidebar);
+}
+body.-emu .sidebar-popout .window-content {
+  background-color: transparent;
+}
+.-emu-layout body.-emu .sidebar-popout .window-content {
+  padding: 0;
+}
 
 body.-emu #sidebar #chat #chat-log .message,
 body.-emu .sidebar-popout #chat #chat-log .message {
@@ -3640,864 +11170,1962 @@ body.-emu .sidebar-popout #chat #chat-log .message {
   background-image: var(--emu-image-background-light, none);
   border: rgba(var(--color-border), 1) 1px solid;
   border-radius: var(--emu-border-radius-default, 0);
-  color: rgba(var(--color-text), 1); }
-  .-emu-layout body.-emu #sidebar #chat #chat-log .message, .-emu-layout
-  body.-emu .sidebar-popout #chat #chat-log .message {
-    font-family: inherit;
-    font-size: var(--emu-font-size-md);
-    padding: var(--emu-space-base);
-    margin: var(--emu-space-base); }
-    .-emu-layout body.-emu #sidebar #chat #chat-log .message:hover .message-metadata, .-emu-layout body.-emu #sidebar #chat #chat-log .message:focus .message-metadata, .-emu-layout
-    body.-emu .sidebar-popout #chat #chat-log .message:hover .message-metadata, .-emu-layout
-    body.-emu .sidebar-popout #chat #chat-log .message:focus .message-metadata {
-      opacity: 1; }
-  body.-emu #sidebar #chat #chat-log .message.whisper,
-  body.-emu .sidebar-popout #chat #chat-log .message.whisper {
-    background-color: rgba(var(--color-background-chat-message-whisper), 1); }
-  body.-emu #sidebar #chat #chat-log .message.blind,
-  body.-emu .sidebar-popout #chat #chat-log .message.blind {
-    background-color: rgba(var(--color-background-chat-message-blind), 1); }
-  body.-emu #sidebar #chat #chat-log .message .message-header,
-  body.-emu .sidebar-popout #chat #chat-log .message .message-header {
-    background-color: transparent;
-    color: inherit; }
-    .-emu-layout body.-emu #sidebar #chat #chat-log .message .message-header, .-emu-layout
-    body.-emu .sidebar-popout #chat #chat-log .message .message-header {
-      align-items: center;
-      line-height: 1.2;
-      -webkit-margin-after: var(--emu-space-base);
-              margin-block-end: var(--emu-space-base); }
-  body.-emu #sidebar #chat #chat-log .message .message-metadata,
-  body.-emu #sidebar #chat #chat-log .message .message-sender,
-  body.-emu .sidebar-popout #chat #chat-log .message .message-metadata,
-  body.-emu .sidebar-popout #chat #chat-log .message .message-sender {
-    color: inherit; }
-    .-emu-layout body.-emu #sidebar #chat #chat-log .message .message-metadata, .-emu-layout
-    body.-emu #sidebar #chat #chat-log .message .message-sender, .-emu-layout
-    body.-emu .sidebar-popout #chat #chat-log .message .message-metadata, .-emu-layout
-    body.-emu .sidebar-popout #chat #chat-log .message .message-sender {
-      align-items: center;
-      display: inline-flex;
-      font-size: var(--emu-font-size-sm); }
-  .-emu-layout body.-emu #sidebar #chat #chat-log .message .message-sender, .-emu-layout
-  body.-emu .sidebar-popout #chat #chat-log .message .message-sender {
-    margin: var(--emu-space-base) 0;
-    overflow: hidden;
-    white-space: initial; }
-  .-emu-layout body.-emu #sidebar #chat #chat-log .message .message-sender, .-emu-layout
-  body.-emu .sidebar-popout #chat #chat-log .message .message-sender {
-    margin: var(--emu-space-xs) 0; }
-  body.-emu #sidebar #chat #chat-log .message .message-metadata,
-  body.-emu .sidebar-popout #chat #chat-log .message .message-metadata {
-    transition: opacity 0.3s cubic-bezier(0.075, 0.82, 0.165, 1); }
-    .-emu-layout body.-emu #sidebar #chat #chat-log .message .message-metadata, .-emu-layout
-    body.-emu .sidebar-popout #chat #chat-log .message .message-metadata {
-      opacity: 0;
-      justify-content: flex-end; }
-  body.-emu #sidebar #chat #chat-log .message .flavor-text,
-  body.-emu #sidebar #chat #chat-log .message .whisper-to,
-  body.-emu .sidebar-popout #chat #chat-log .message .flavor-text,
-  body.-emu .sidebar-popout #chat #chat-log .message .whisper-to {
-    color: inherit; }
-    .-emu-layout body.-emu #sidebar #chat #chat-log .message .flavor-text, .-emu-layout
-    body.-emu #sidebar #chat #chat-log .message .whisper-to, .-emu-layout
-    body.-emu .sidebar-popout #chat #chat-log .message .flavor-text, .-emu-layout
-    body.-emu .sidebar-popout #chat #chat-log .message .whisper-to {
-      font-size: var(--emu-font-size-sm); }
-  body.-emu #sidebar #chat #chat-log .message .dice-roll .dice-formula,
-  body.-emu #sidebar #chat #chat-log .message .dice-roll .dice-total,
-  body.-emu .sidebar-popout #chat #chat-log .message .dice-roll .dice-formula,
-  body.-emu .sidebar-popout #chat #chat-log .message .dice-roll .dice-total {
-    background-color: rgba(var(--color-background), 0.1);
-    box-shadow: none;
-    border: rgba(var(--color-border), 1) 1px solid;
-    border-radius: var(--emu-border-radius-default, 0);
-    color: inherit; }
-    .-emu-layout body.-emu #sidebar #chat #chat-log .message .dice-roll .dice-formula, .-emu-layout
-    body.-emu #sidebar #chat #chat-log .message .dice-roll .dice-total, .-emu-layout
-    body.-emu .sidebar-popout #chat #chat-log .message .dice-roll .dice-formula, .-emu-layout
-    body.-emu .sidebar-popout #chat #chat-log .message .dice-roll .dice-total {
-      line-height: initial;
-      font-size: inherit;
-      font-weight: normal;
-      margin: 0;
-      -webkit-margin-before: var(--emu-space-base);
-              margin-block-start: var(--emu-space-base); }
-      .-emu-layout body.-emu #sidebar #chat #chat-log .message .dice-roll .dice-formula:first-child, .-emu-layout body.-emu #sidebar #chat #chat-log .message .dice-roll .dice-formula:only-child, .-emu-layout
-      body.-emu #sidebar #chat #chat-log .message .dice-roll .dice-total:first-child, .-emu-layout
-      body.-emu #sidebar #chat #chat-log .message .dice-roll .dice-total:only-child, .-emu-layout
-      body.-emu .sidebar-popout #chat #chat-log .message .dice-roll .dice-formula:first-child, .-emu-layout
-      body.-emu .sidebar-popout #chat #chat-log .message .dice-roll .dice-formula:only-child, .-emu-layout
-      body.-emu .sidebar-popout #chat #chat-log .message .dice-roll .dice-total:first-child, .-emu-layout
-      body.-emu .sidebar-popout #chat #chat-log .message .dice-roll .dice-total:only-child {
-        -webkit-margin-before: 0;
-                margin-block-start: 0; }
-  .-emu-layout body.-emu #sidebar #chat #chat-log .message .dice-roll .dice-formula, .-emu-layout
-  body.-emu .sidebar-popout #chat #chat-log .message .dice-roll .dice-formula {
-    font-size: var(--emu-font-size-md);
-    padding: var(--emu-space-xs) 0; }
-  .-emu-layout body.-emu #sidebar #chat #chat-log .message .dice-roll .dice-total, .-emu-layout
-  body.-emu .sidebar-popout #chat #chat-log .message .dice-roll .dice-total {
-    font-size: var(--emu-font-size-chat-roll);
-    padding: var(--emu-space-xs) 0; }
-  .-emu-layout body.-emu #sidebar #chat #chat-log .message .dice-roll + .dice-roll, .-emu-layout
-  body.-emu #sidebar #chat #chat-log .message .dice-roll .dice-total + .dice-roll .dice-total, .-emu-layout
-  body.-emu .sidebar-popout #chat #chat-log .message .dice-roll + .dice-roll, .-emu-layout
-  body.-emu .sidebar-popout #chat #chat-log .message .dice-roll .dice-total + .dice-roll .dice-total {
-    -webkit-margin-before: var(--emu-space-base);
-            margin-block-start: var(--emu-space-base); }
-  body.-emu #sidebar #chat #chat-log .message .dice-roll .dice-total.critical, body.-emu #sidebar #chat #chat-log .message .dice-roll .dice-total.success,
-  body.-emu .sidebar-popout #chat #chat-log .message .dice-roll .dice-total.critical,
-  body.-emu .sidebar-popout #chat #chat-log .message .dice-roll .dice-total.success {
-    background-color: rgba(var(--color-positive), 1);
-    border-color: rgba(var(--color-green-800), 1);
-    color: rgba(var(--color-white), 1); }
-  body.-emu #sidebar #chat #chat-log .message .dice-roll .dice-total.fumble, body.-emu #sidebar #chat #chat-log .message .dice-roll .dice-total.failure,
-  body.-emu .sidebar-popout #chat #chat-log .message .dice-roll .dice-total.fumble,
-  body.-emu .sidebar-popout #chat #chat-log .message .dice-roll .dice-total.failure {
-    background-color: rgba(var(--color-negative), 1);
-    border-color: rgba(var(--color-red-800), 1);
-    color: rgba(var(--color-white), 1); }
-  .-emu-layout body.-emu #sidebar #chat #chat-log .message .dice-tooltip, .-emu-layout
-  body.-emu .sidebar-popout #chat #chat-log .message .dice-tooltip {
-    -webkit-margin-before: var(--emu-space-base);
-            margin-block-start: var(--emu-space-base); }
-    .-emu-layout body.-emu #sidebar #chat #chat-log .message .dice-tooltip:first-child, .-emu-layout body.-emu #sidebar #chat #chat-log .message .dice-tooltip:only-child, .-emu-layout
-    body.-emu .sidebar-popout #chat #chat-log .message .dice-tooltip:first-child, .-emu-layout
-    body.-emu .sidebar-popout #chat #chat-log .message .dice-tooltip:only-child {
-      -webkit-margin-before: 0;
-              margin-block-start: 0; }
-  .-emu-layout body.-emu #sidebar #chat #chat-log .message .dice-rolls, .-emu-layout
-  body.-emu .sidebar-popout #chat #chat-log .message .dice-rolls {
-    margin: var(--emu-space-base); }
-  body.-emu #sidebar #chat #chat-log .message .button.message-delete,
-  body.-emu .sidebar-popout #chat #chat-log .message .button.message-delete {
-    color: rgba(var(--color-text), 1); }
-    .-emu-layout body.-emu #sidebar #chat #chat-log .message .button.message-delete, .-emu-layout
-    body.-emu .sidebar-popout #chat #chat-log .message .button.message-delete {
-      color: rgba(var(--color-text), 1); }
+  color: rgba(var(--color-text), 1);
+}
+.-emu-layout body.-emu #sidebar #chat #chat-log .message,
+.-emu-layout body.-emu .sidebar-popout #chat #chat-log .message {
+  font-family: inherit;
+  font-size: var(--emu-font-size-md);
+  padding: var(--emu-space-base);
+  margin: var(--emu-space-base);
+}
+.-emu-layout
+  body.-emu
+  #sidebar
+  #chat
+  #chat-log
+  .message:hover
+  .message-metadata,
+.-emu-layout
+  body.-emu
+  #sidebar
+  #chat
+  #chat-log
+  .message:focus
+  .message-metadata,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #chat
+  #chat-log
+  .message:hover
+  .message-metadata,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #chat
+  #chat-log
+  .message:focus
+  .message-metadata {
+  opacity: 1;
+}
+body.-emu #sidebar #chat #chat-log .message.whisper,
+body.-emu .sidebar-popout #chat #chat-log .message.whisper {
+  background-color: rgba(var(--color-background-chat-message-whisper), 1);
+}
+body.-emu #sidebar #chat #chat-log .message.blind,
+body.-emu .sidebar-popout #chat #chat-log .message.blind {
+  background-color: rgba(var(--color-background-chat-message-blind), 1);
+}
+body.-emu #sidebar #chat #chat-log .message .message-header,
+body.-emu .sidebar-popout #chat #chat-log .message .message-header {
+  background-color: transparent;
+  color: inherit;
+}
+.-emu-layout body.-emu #sidebar #chat #chat-log .message .message-header,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #chat
+  #chat-log
+  .message
+  .message-header {
+  align-items: center;
+  line-height: 1.2;
+  -webkit-margin-after: var(--emu-space-base);
+  margin-block-end: var(--emu-space-base);
+}
+body.-emu #sidebar #chat #chat-log .message .message-metadata,
+body.-emu #sidebar #chat #chat-log .message .message-sender,
+body.-emu .sidebar-popout #chat #chat-log .message .message-metadata,
+body.-emu .sidebar-popout #chat #chat-log .message .message-sender {
+  color: inherit;
+}
+.-emu-layout body.-emu #sidebar #chat #chat-log .message .message-metadata,
+.-emu-layout body.-emu #sidebar #chat #chat-log .message .message-sender,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #chat
+  #chat-log
+  .message
+  .message-metadata,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #chat
+  #chat-log
+  .message
+  .message-sender {
+  align-items: center;
+  display: inline-flex;
+  font-size: var(--emu-font-size-sm);
+}
+.-emu-layout body.-emu #sidebar #chat #chat-log .message .message-sender,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #chat
+  #chat-log
+  .message
+  .message-sender {
+  margin: var(--emu-space-base) 0;
+  overflow: hidden;
+  white-space: initial;
+}
+.-emu-layout body.-emu #sidebar #chat #chat-log .message .message-sender,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #chat
+  #chat-log
+  .message
+  .message-sender {
+  margin: var(--emu-space-xs) 0;
+}
+body.-emu #sidebar #chat #chat-log .message .message-metadata,
+body.-emu .sidebar-popout #chat #chat-log .message .message-metadata {
+  transition: opacity 0.3s cubic-bezier(0.075, 0.82, 0.165, 1);
+}
+.-emu-layout body.-emu #sidebar #chat #chat-log .message .message-metadata,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #chat
+  #chat-log
+  .message
+  .message-metadata {
+  opacity: 0;
+  justify-content: flex-end;
+}
+body.-emu #sidebar #chat #chat-log .message .flavor-text,
+body.-emu #sidebar #chat #chat-log .message .whisper-to,
+body.-emu .sidebar-popout #chat #chat-log .message .flavor-text,
+body.-emu .sidebar-popout #chat #chat-log .message .whisper-to {
+  color: inherit;
+}
+.-emu-layout body.-emu #sidebar #chat #chat-log .message .flavor-text,
+.-emu-layout body.-emu #sidebar #chat #chat-log .message .whisper-to,
+.-emu-layout body.-emu .sidebar-popout #chat #chat-log .message .flavor-text,
+.-emu-layout body.-emu .sidebar-popout #chat #chat-log .message .whisper-to {
+  font-size: var(--emu-font-size-sm);
+}
+body.-emu #sidebar #chat #chat-log .message .dice-roll .dice-formula,
+body.-emu #sidebar #chat #chat-log .message .dice-roll .dice-total,
+body.-emu .sidebar-popout #chat #chat-log .message .dice-roll .dice-formula,
+body.-emu .sidebar-popout #chat #chat-log .message .dice-roll .dice-total {
+  background-color: rgba(var(--color-background), 0.1);
+  box-shadow: none;
+  border: rgba(var(--color-border), 1) 1px solid;
+  border-radius: var(--emu-border-radius-default, 0);
+  color: inherit;
+}
+.-emu-layout
+  body.-emu
+  #sidebar
+  #chat
+  #chat-log
+  .message
+  .dice-roll
+  .dice-formula,
+.-emu-layout body.-emu #sidebar #chat #chat-log .message .dice-roll .dice-total,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #chat
+  #chat-log
+  .message
+  .dice-roll
+  .dice-formula,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #chat
+  #chat-log
+  .message
+  .dice-roll
+  .dice-total {
+  line-height: initial;
+  font-size: inherit;
+  font-weight: normal;
+  margin: 0;
+  -webkit-margin-before: var(--emu-space-base);
+  margin-block-start: var(--emu-space-base);
+}
+.-emu-layout
+  body.-emu
+  #sidebar
+  #chat
+  #chat-log
+  .message
+  .dice-roll
+  .dice-formula:first-child,
+.-emu-layout
+  body.-emu
+  #sidebar
+  #chat
+  #chat-log
+  .message
+  .dice-roll
+  .dice-formula:only-child,
+.-emu-layout
+  body.-emu
+  #sidebar
+  #chat
+  #chat-log
+  .message
+  .dice-roll
+  .dice-total:first-child,
+.-emu-layout
+  body.-emu
+  #sidebar
+  #chat
+  #chat-log
+  .message
+  .dice-roll
+  .dice-total:only-child,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #chat
+  #chat-log
+  .message
+  .dice-roll
+  .dice-formula:first-child,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #chat
+  #chat-log
+  .message
+  .dice-roll
+  .dice-formula:only-child,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #chat
+  #chat-log
+  .message
+  .dice-roll
+  .dice-total:first-child,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #chat
+  #chat-log
+  .message
+  .dice-roll
+  .dice-total:only-child {
+  -webkit-margin-before: 0;
+  margin-block-start: 0;
+}
+.-emu-layout
+  body.-emu
+  #sidebar
+  #chat
+  #chat-log
+  .message
+  .dice-roll
+  .dice-formula,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #chat
+  #chat-log
+  .message
+  .dice-roll
+  .dice-formula {
+  font-size: var(--emu-font-size-md);
+  padding: var(--emu-space-xs) 0;
+}
+.-emu-layout body.-emu #sidebar #chat #chat-log .message .dice-roll .dice-total,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #chat
+  #chat-log
+  .message
+  .dice-roll
+  .dice-total {
+  font-size: var(--emu-font-size-chat-roll);
+  padding: var(--emu-space-xs) 0;
+}
+.-emu-layout
+  body.-emu
+  #sidebar
+  #chat
+  #chat-log
+  .message
+  .dice-roll
+  + .dice-roll,
+.-emu-layout
+  body.-emu
+  #sidebar
+  #chat
+  #chat-log
+  .message
+  .dice-roll
+  .dice-total
+  + .dice-roll
+  .dice-total,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #chat
+  #chat-log
+  .message
+  .dice-roll
+  + .dice-roll,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #chat
+  #chat-log
+  .message
+  .dice-roll
+  .dice-total
+  + .dice-roll
+  .dice-total {
+  -webkit-margin-before: var(--emu-space-base);
+  margin-block-start: var(--emu-space-base);
+}
+body.-emu #sidebar #chat #chat-log .message .dice-roll .dice-total.critical,
+body.-emu #sidebar #chat #chat-log .message .dice-roll .dice-total.success,
+body.-emu
+  .sidebar-popout
+  #chat
+  #chat-log
+  .message
+  .dice-roll
+  .dice-total.critical,
+body.-emu
+  .sidebar-popout
+  #chat
+  #chat-log
+  .message
+  .dice-roll
+  .dice-total.success {
+  background-color: rgba(var(--color-positive), 1);
+  border-color: rgba(var(--color-green-800), 1);
+  color: rgba(var(--color-white), 1);
+}
+body.-emu #sidebar #chat #chat-log .message .dice-roll .dice-total.fumble,
+body.-emu #sidebar #chat #chat-log .message .dice-roll .dice-total.failure,
+body.-emu
+  .sidebar-popout
+  #chat
+  #chat-log
+  .message
+  .dice-roll
+  .dice-total.fumble,
+body.-emu
+  .sidebar-popout
+  #chat
+  #chat-log
+  .message
+  .dice-roll
+  .dice-total.failure {
+  background-color: rgba(var(--color-negative), 1);
+  border-color: rgba(var(--color-red-800), 1);
+  color: rgba(var(--color-white), 1);
+}
+.-emu-layout body.-emu #sidebar #chat #chat-log .message .dice-tooltip,
+.-emu-layout body.-emu .sidebar-popout #chat #chat-log .message .dice-tooltip {
+  -webkit-margin-before: var(--emu-space-base);
+  margin-block-start: var(--emu-space-base);
+}
+.-emu-layout
+  body.-emu
+  #sidebar
+  #chat
+  #chat-log
+  .message
+  .dice-tooltip:first-child,
+.-emu-layout
+  body.-emu
+  #sidebar
+  #chat
+  #chat-log
+  .message
+  .dice-tooltip:only-child,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #chat
+  #chat-log
+  .message
+  .dice-tooltip:first-child,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #chat
+  #chat-log
+  .message
+  .dice-tooltip:only-child {
+  -webkit-margin-before: 0;
+  margin-block-start: 0;
+}
+.-emu-layout body.-emu #sidebar #chat #chat-log .message .dice-rolls,
+.-emu-layout body.-emu .sidebar-popout #chat #chat-log .message .dice-rolls {
+  margin: var(--emu-space-base);
+}
+body.-emu #sidebar #chat #chat-log .message .button.message-delete,
+body.-emu .sidebar-popout #chat #chat-log .message .button.message-delete {
+  color: rgba(var(--color-text), 1);
+}
+.-emu-layout body.-emu #sidebar #chat #chat-log .message .button.message-delete,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #chat
+  #chat-log
+  .message
+  .button.message-delete {
+  color: rgba(var(--color-text), 1);
+}
 
 body.-emu #sidebar #chat #chat-controls,
 body.-emu .sidebar-popout #chat #chat-controls {
   background-color: rgba(var(--color-background), 0.5);
   background-image: var(--emu-image-background, none);
   -webkit-border-before: rgba(var(--color-border), 1) 1px solid;
-          border-block-start: rgba(var(--color-border), 1) 1px solid;
-  color: rgba(var(--color-text-lightest), 1); }
-  .-emu-layout body.-emu #sidebar #chat #chat-controls, .-emu-layout
-  body.-emu .sidebar-popout #chat #chat-controls {
-    align-items: center;
-    display: flex;
-    flex: 0 0 auto;
-    margin: 0;
-    padding: var(--emu-space-sm);
-    position: relative; }
-  .-emu-layout body.-emu #sidebar #chat #chat-controls .chat-control-icon, .-emu-layout
-  body.-emu .sidebar-popout #chat #chat-controls .chat-control-icon {
-    -webkit-margin-end: var(--emu-space-xs);
-            margin-inline-end: var(--emu-space-xs); }
-  .-emu-layout body.-emu #sidebar #chat #chat-controls .chat-control-icon .fa-dice-d20, .-emu-layout
-  body.-emu .sidebar-popout #chat #chat-controls .chat-control-icon .fa-dice-d20 {
-    font-size: var(--emu-font-size-md);
-    margin: 0; }
-  body.-emu #sidebar #chat #chat-controls .roll-type-select,
-  body.-emu .sidebar-popout #chat #chat-controls .roll-type-select {
-    background-color: rgba(var(--color-background), 0.5);
-    color: rgba(var(--color-text-lightest), 1); }
-    .-emu-layout body.-emu #sidebar #chat #chat-controls .roll-type-select, .-emu-layout
-    body.-emu .sidebar-popout #chat #chat-controls .roll-type-select {
-      height: 2rem;
-      margin: 0;
-      width: auto; }
-  .-emu-layout body.-emu #sidebar #chat #chat-controls .control-buttons, .-emu-layout
-  body.-emu .sidebar-popout #chat #chat-controls .control-buttons {
-    align-items: center;
-    display: flex;
-    flex: 0 0 auto; }
-  .-emu-layout body.-emu #sidebar #chat #chat-controls .control-buttons .button > i, .-emu-layout
-  body.-emu .sidebar-popout #chat #chat-controls .control-buttons .button > i {
-    font-size: inherit;
-    line-height: initial; }
+  border-block-start: rgba(var(--color-border), 1) 1px solid;
+  color: rgba(var(--color-text-lightest), 1);
+}
+.-emu-layout body.-emu #sidebar #chat #chat-controls,
+.-emu-layout body.-emu .sidebar-popout #chat #chat-controls {
+  align-items: center;
+  display: flex;
+  flex: 0 0 auto;
+  margin: 0;
+  padding: var(--emu-space-sm);
+  position: relative;
+}
+.-emu-layout body.-emu #sidebar #chat #chat-controls .chat-control-icon,
+.-emu-layout body.-emu .sidebar-popout #chat #chat-controls .chat-control-icon {
+  -webkit-margin-end: var(--emu-space-xs);
+  margin-inline-end: var(--emu-space-xs);
+}
+.-emu-layout
+  body.-emu
+  #sidebar
+  #chat
+  #chat-controls
+  .chat-control-icon
+  .fa-dice-d20,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #chat
+  #chat-controls
+  .chat-control-icon
+  .fa-dice-d20 {
+  font-size: var(--emu-font-size-md);
+  margin: 0;
+}
+body.-emu #sidebar #chat #chat-controls .roll-type-select,
+body.-emu .sidebar-popout #chat #chat-controls .roll-type-select {
+  background-color: rgba(var(--color-background), 0.5);
+  color: rgba(var(--color-text-lightest), 1);
+}
+.-emu-layout body.-emu #sidebar #chat #chat-controls .roll-type-select,
+.-emu-layout body.-emu .sidebar-popout #chat #chat-controls .roll-type-select {
+  height: 2rem;
+  margin: 0;
+  width: auto;
+}
+.-emu-layout body.-emu #sidebar #chat #chat-controls .control-buttons,
+.-emu-layout body.-emu .sidebar-popout #chat #chat-controls .control-buttons {
+  align-items: center;
+  display: flex;
+  flex: 0 0 auto;
+}
+.-emu-layout
+  body.-emu
+  #sidebar
+  #chat
+  #chat-controls
+  .control-buttons
+  .button
+  > i,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #chat
+  #chat-controls
+  .control-buttons
+  .button
+  > i {
+  font-size: inherit;
+  line-height: initial;
+}
 
 body.-emu #sidebar #chat #chat-form,
 body.-emu .sidebar-popout #chat #chat-form {
   background-color: rgba(var(--color-background), 0.5);
   background-image: var(--emu-image-background, none);
   -webkit-border-before: rgba(var(--color-border), 1) 1px solid;
-          border-block-start: rgba(var(--color-border), 1) 1px solid;
-  color: rgba(var(--color-text-lightest), 1); }
-  .-emu-layout body.-emu #sidebar #chat #chat-form, .-emu-layout
-  body.-emu .sidebar-popout #chat #chat-form {
-    align-items: center;
-    display: flex;
-    flex: 0 0 auto;
-    height: 7rem;
-    margin: 0;
-    padding: var(--emu-space-sm);
-    position: relative; }
-  body.-emu #sidebar #chat #chat-form textarea,
-  body.-emu .sidebar-popout #chat #chat-form textarea {
-    background-color: rgba(var(--color-background-lightest), 0.9);
-    background-image: var(--emu-image-background-light, none); }
-    .-emu-layout body.-emu #sidebar #chat #chat-form textarea, .-emu-layout
-    body.-emu .sidebar-popout #chat #chat-form textarea {
-      width: 100%;
-      height: 100%;
-      padding: var(--emu-space-sm); }
+  border-block-start: rgba(var(--color-border), 1) 1px solid;
+  color: rgba(var(--color-text-lightest), 1);
+}
+.-emu-layout body.-emu #sidebar #chat #chat-form,
+.-emu-layout body.-emu .sidebar-popout #chat #chat-form {
+  align-items: center;
+  display: flex;
+  flex: 0 0 auto;
+  height: 7rem;
+  margin: 0;
+  padding: var(--emu-space-sm);
+  position: relative;
+}
+body.-emu #sidebar #chat #chat-form textarea,
+body.-emu .sidebar-popout #chat #chat-form textarea {
+  background-color: rgba(var(--color-background-lightest), 0.9);
+  background-image: var(--emu-image-background-light, none);
+}
+.-emu-layout body.-emu #sidebar #chat #chat-form textarea,
+.-emu-layout body.-emu .sidebar-popout #chat #chat-form textarea {
+  width: 100%;
+  height: 100%;
+  padding: var(--emu-space-sm);
+}
 
-.-emu-layout body.-emu #sidebar #combat #combat-round, .-emu-layout
-body.-emu .sidebar-popout #combat #combat-round {
-  flex-direction: column; }
+.-emu-layout body.-emu #sidebar #combat #combat-round,
+.-emu-layout body.-emu .sidebar-popout #combat #combat-round {
+  flex-direction: column;
+}
 
-.-emu-layout body.-emu #sidebar #combat #combat-round .encounters, .-emu-layout
-body.-emu .sidebar-popout #combat #combat-round .encounters {
+.-emu-layout body.-emu #sidebar #combat #combat-round .encounters,
+.-emu-layout body.-emu .sidebar-popout #combat #combat-round .encounters {
   align-items: center;
   display: flex;
   flex-wrap: nowrap;
-  width: 100%; }
-  .-emu-layout body.-emu #sidebar #combat #combat-round .encounters + .encounters, .-emu-layout
-  body.-emu .sidebar-popout #combat #combat-round .encounters + .encounters {
-    -webkit-margin-before: var(--emu-space-base);
-            margin-block-start: var(--emu-space-base); }
+  width: 100%;
+}
+.-emu-layout body.-emu #sidebar #combat #combat-round .encounters + .encounters,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #combat
+  #combat-round
+  .encounters
+  + .encounters {
+  -webkit-margin-before: var(--emu-space-base);
+  margin-block-start: var(--emu-space-base);
+}
 
 body.-emu #sidebar #combat #combat-round .encounters h3,
 body.-emu #sidebar #combat #combat-round .encounters h4,
 body.-emu .sidebar-popout #combat #combat-round .encounters h3,
 body.-emu .sidebar-popout #combat #combat-round .encounters h4 {
   -webkit-border-after: none;
-          border-block-end: none;
-  color: rgba(var(--color-text-lightest), 1); }
-  .-emu-layout body.-emu #sidebar #combat #combat-round .encounters h3, .-emu-layout
-  body.-emu #sidebar #combat #combat-round .encounters h4, .-emu-layout
-  body.-emu .sidebar-popout #combat #combat-round .encounters h3, .-emu-layout
-  body.-emu .sidebar-popout #combat #combat-round .encounters h4 {
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    display: block;
-    flex: 1 1 auto;
-    font-size: var(--emu-font-size-md);
-    -webkit-margin-start: var(--emu-space-base);
-            margin-inline-start: var(--emu-space-base);
-    text-align: center; }
+  border-block-end: none;
+  color: rgba(var(--color-text-lightest), 1);
+}
+.-emu-layout body.-emu #sidebar #combat #combat-round .encounters h3,
+.-emu-layout body.-emu #sidebar #combat #combat-round .encounters h4,
+.-emu-layout body.-emu .sidebar-popout #combat #combat-round .encounters h3,
+.-emu-layout body.-emu .sidebar-popout #combat #combat-round .encounters h4 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  display: block;
+  flex: 1 1 auto;
+  font-size: var(--emu-font-size-md);
+  -webkit-margin-start: var(--emu-space-base);
+  margin-inline-start: var(--emu-space-base);
+  text-align: center;
+}
 
 body.-emu #sidebar #combat #combat-round .encounters h3,
 body.-emu .sidebar-popout #combat #combat-round .encounters h3 {
-  color: rgba(var(--color-text-lightest), 1); }
-  .-emu-layout body.-emu #sidebar #combat #combat-round .encounters h3, .-emu-layout
-  body.-emu .sidebar-popout #combat #combat-round .encounters h3 {
-    font-size: var(--emu-font-size-xl); }
+  color: rgba(var(--color-text-lightest), 1);
+}
+.-emu-layout body.-emu #sidebar #combat #combat-round .encounters h3,
+.-emu-layout body.-emu .sidebar-popout #combat #combat-round .encounters h3 {
+  font-size: var(--emu-font-size-xl);
+}
 
-.-emu-layout body.-emu #sidebar #combat #combat-round .encounters a[disabled], .-emu-layout
-body.-emu .sidebar-popout #combat #combat-round .encounters a[disabled] {
+.-emu-layout body.-emu #sidebar #combat #combat-round .encounters a[disabled],
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #combat
+  #combat-round
+  .encounters
+  a[disabled] {
   pointer-events: none;
-  visibility: hidden; }
+  visibility: hidden;
+}
 
-.-emu-layout body.-emu #sidebar #combat #combat-round .encounters a:first-child, .-emu-layout
-body.-emu .sidebar-popout #combat #combat-round .encounters a:first-child {
+.-emu-layout body.-emu #sidebar #combat #combat-round .encounters a:first-child,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #combat
+  #combat-round
+  .encounters
+  a:first-child {
   -webkit-margin-start: 0;
-          margin-inline-start: 0; }
+  margin-inline-start: 0;
+}
 
-.-emu-layout body.-emu #sidebar #combat #combat-tracker, .-emu-layout
-body.-emu .sidebar-popout #combat #combat-tracker {
+.-emu-layout body.-emu #sidebar #combat #combat-tracker,
+.-emu-layout body.-emu .sidebar-popout #combat #combat-tracker {
   -webkit-padding-before: var(--emu-space-base);
-          padding-block-start: var(--emu-space-base); }
+  padding-block-start: var(--emu-space-base);
+}
 
 body.-emu #sidebar #combat #combat-tracker .combatant,
 body.-emu .sidebar-popout #combat #combat-tracker .combatant {
   background-color: rgba(var(--color-background), 1);
   border: none;
   border-radius: var(--emu-border-radius-default, 0);
-  transition: background 0.3s cubic-bezier(0.075, 0.82, 0.165, 1), box-shadow 0.3s cubic-bezier(0.075, 0.82, 0.165, 1), opacity 0.3s cubic-bezier(0.075, 0.82, 0.165, 1); }
-  .-emu-layout body.-emu #sidebar #combat #combat-tracker .combatant, .-emu-layout
-  body.-emu .sidebar-popout #combat #combat-tracker .combatant {
-    align-items: center;
-    display: flex;
-    flex-wrap: nowrap;
-    height: auto;
-    line-height: initial;
-    margin: var(--emu-space-base) var(--emu-space-sm);
-    padding: var(--emu-space-base) var(--emu-space-sm);
-    position: relative;
-    width: auto; }
-  .-emu-layout body.-emu #sidebar #combat #combat-tracker .combatant.hidden .token-name h4, .-emu-layout
-  body.-emu #sidebar #combat #combat-tracker .combatant.hidden .token-image, .-emu-layout
-  body.-emu .sidebar-popout #combat #combat-tracker .combatant.hidden .token-name h4, .-emu-layout
-  body.-emu .sidebar-popout #combat #combat-tracker .combatant.hidden .token-image {
-    opacity: 0.5; }
-  body.-emu #sidebar #combat #combat-tracker .combatant.active .token-name h4,
-  body.-emu .sidebar-popout #combat #combat-tracker .combatant.active .token-name h4 {
-    border-color: rgba(var(--color-text-lightest), 1); }
-  body.-emu #sidebar #combat #combat-tracker .combatant.active .combatant-control.active,
-  body.-emu .sidebar-popout #combat #combat-tracker .combatant.active .combatant-control.active {
-    background-color: rgba(var(--color-white), 1);
-    color: rgba(var(--color-primary), 1); }
-  body.-emu #sidebar #combat #combat-tracker .combatant.defeated,
-  body.-emu .sidebar-popout #combat #combat-tracker .combatant.defeated {
-    background-color: rgba(var(--color-red-600), 0.5); }
-    body.-emu #sidebar #combat #combat-tracker .combatant.defeated.active .combatant-control.active,
-    body.-emu .sidebar-popout #combat #combat-tracker .combatant.defeated.active .combatant-control.active {
-      background-color: rgba(var(--color-primary), 1);
-      color: rgba(var(--color-text-lightest), 1); }
-  .-emu-layout body.-emu #sidebar #combat #combat-tracker .combatant .token-image, .-emu-layout
-  body.-emu .sidebar-popout #combat #combat-tracker .combatant .token-image {
-    width: var(--emu-space-button);
-    height: var(--emu-space-button);
-    cursor: default;
-    flex: 0 0 auto;
-    -webkit-margin-end: var(--emu-space-sm);
-            margin-inline-end: var(--emu-space-sm);
-    position: relative; }
-  body.-emu #sidebar #combat #combat-tracker .combatant .token-name,
-  body.-emu .sidebar-popout #combat #combat-tracker .combatant .token-name {
-    text-shadow: none; }
-    .-emu-layout body.-emu #sidebar #combat #combat-tracker .combatant .token-name, .-emu-layout
-    body.-emu .sidebar-popout #combat #combat-tracker .combatant .token-name {
-      display: flex;
-      flex: 1 1 auto;
-      flex-direction: column;
-      margin: 0;
-      overflow: hidden;
-      position: relative; }
-    body.-emu #sidebar #combat #combat-tracker .combatant .token-name h4,
-    body.-emu .sidebar-popout #combat #combat-tracker .combatant .token-name h4 {
-      color: rgba(var(--color-text-lightest), 1);
-      -webkit-border-after: 1px solid rgba(var(--color-border-lighter), 0.1);
-              border-block-end: 1px solid rgba(var(--color-border-lighter), 0.1); }
-      .-emu-layout body.-emu #sidebar #combat #combat-tracker .combatant .token-name h4, .-emu-layout
-      body.-emu .sidebar-popout #combat #combat-tracker .combatant .token-name h4 {
-        max-width: 100%;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
-        flex: initial;
-        font-size: var(--emu-font-size-lg);
-        line-height: initial;
-        -webkit-margin-after: var(--emu-space-base);
-                margin-block-end: var(--emu-space-base); }
-  body.-emu #sidebar #combat #combat-tracker .combatant .token-resource,
-  body.-emu #sidebar #combat #combat-tracker .combatant .token-initiative,
-  body.-emu .sidebar-popout #combat #combat-tracker .combatant .token-resource,
-  body.-emu .sidebar-popout #combat #combat-tracker .combatant .token-initiative {
-    color: rgba(var(--color-text-lightest), 1); }
-    .-emu-layout body.-emu #sidebar #combat #combat-tracker .combatant .token-resource, .-emu-layout
-    body.-emu #sidebar #combat #combat-tracker .combatant .token-initiative, .-emu-layout
-    body.-emu .sidebar-popout #combat #combat-tracker .combatant .token-resource, .-emu-layout
-    body.-emu .sidebar-popout #combat #combat-tracker .combatant .token-initiative {
-      align-items: center;
-      display: flex;
-      flex: 0 0 auto;
-      position: relative; }
-  body.-emu #sidebar #combat #combat-tracker .combatant .token-resource,
-  body.-emu .sidebar-popout #combat #combat-tracker .combatant .token-resource {
-    -webkit-border-end: rgba(var(--color-border-lighter), 1) 1px solid;
-            border-inline-end: rgba(var(--color-border-lighter), 1) 1px solid; }
-    .-emu-layout body.-emu #sidebar #combat #combat-tracker .combatant .token-resource, .-emu-layout
-    body.-emu .sidebar-popout #combat #combat-tracker .combatant .token-resource {
-      font-size: var(--emu-font-size-md);
-      line-height: 1;
-      -webkit-margin-start: var(--emu-space-sm);
-              margin-inline-start: var(--emu-space-sm);
-      -webkit-padding-end: var(--emu-space-sm);
-              padding-inline-end: var(--emu-space-sm); }
-  .-emu-layout body.-emu #sidebar #combat #combat-tracker .combatant .token-initiative, .-emu-layout
-  body.-emu .sidebar-popout #combat #combat-tracker .combatant .token-initiative {
-    padding: 0;
-    -webkit-padding-start: var(--emu-space-sm);
-            padding-inline-start: var(--emu-space-sm); }
-  body.-emu #sidebar #combat #combat-tracker .combatant .token-initiative .initiative,
-  body.-emu .sidebar-popout #combat #combat-tracker .combatant .token-initiative .initiative {
-    color: inherit;
-    text-shadow: none; }
-    .-emu-layout body.-emu #sidebar #combat #combat-tracker .combatant .token-initiative .initiative, .-emu-layout
-    body.-emu .sidebar-popout #combat #combat-tracker .combatant .token-initiative .initiative {
-      font-size: var(--emu-font-size-lg);
-      font-weight: normal; }
-  .-emu-layout body.-emu #sidebar #combat #combat-tracker .combatant .combatant-controls, .-emu-layout
-  body.-emu .sidebar-popout #combat #combat-tracker .combatant .combatant-controls {
-    align-items: center;
-    display: flex; }
-  .-emu-layout body.-emu #sidebar #combat #combat-tracker .combatant .combatant-control, .-emu-layout
-  body.-emu .sidebar-popout #combat #combat-tracker .combatant .combatant-control {
-    -webkit-margin-start: 0;
-            margin-inline-start: 0;
-    -webkit-margin-end: var(--emu-space-base);
-            margin-inline-end: var(--emu-space-base); }
-  body.-emu #sidebar #combat #combat-tracker .combatant .combatant-control.roll,
-  body.-emu .sidebar-popout #combat #combat-tracker .combatant .combatant-control.roll {
-    background: transparent; }
-    .-emu-layout body.-emu #sidebar #combat #combat-tracker .combatant .combatant-control.roll, .-emu-layout
-    body.-emu .sidebar-popout #combat #combat-tracker .combatant .combatant-control.roll {
-      width: var(--emu-space-button);
-      height: var(--emu-space-button);
-      background: transparent;
-      font-size: var(--emu-font-size-xl);
-      margin: 0; }
-      .-emu-layout body.-emu #sidebar #combat #combat-tracker .combatant .combatant-control.roll::before, .-emu-layout
-      body.-emu .sidebar-popout #combat #combat-tracker .combatant .combatant-control.roll::before {
-        content: "\f6cf"; }
-  .-emu-layout body.-emu #sidebar #combat #combat-tracker .combatant .token-effects, .-emu-layout
-  body.-emu .sidebar-popout #combat #combat-tracker .combatant .token-effects {
-    display: flex;
-    flex: 1 1 auto;
-    flex-wrap: wrap;
-    height: auto; }
-    .-emu-layout body.-emu #sidebar #combat #combat-tracker .combatant .token-effects img, .-emu-layout
-    body.-emu .sidebar-popout #combat #combat-tracker .combatant .token-effects img {
-      cursor: default;
-      margin: var(--emu-space-xs);
-      max-height: 0.875rem;
-      max-width: 0.875rem;
-      opacity: 1;
-      transform: none; }
+  transition: background 0.3s cubic-bezier(0.075, 0.82, 0.165, 1),
+    box-shadow 0.3s cubic-bezier(0.075, 0.82, 0.165, 1),
+    opacity 0.3s cubic-bezier(0.075, 0.82, 0.165, 1);
+}
+.-emu-layout body.-emu #sidebar #combat #combat-tracker .combatant,
+.-emu-layout body.-emu .sidebar-popout #combat #combat-tracker .combatant {
+  align-items: center;
+  display: flex;
+  flex-wrap: nowrap;
+  height: auto;
+  line-height: initial;
+  margin: var(--emu-space-base) var(--emu-space-sm);
+  padding: var(--emu-space-base) var(--emu-space-sm);
+  position: relative;
+  width: auto;
+}
+.-emu-layout
+  body.-emu
+  #sidebar
+  #combat
+  #combat-tracker
+  .combatant.hidden
+  .token-name
+  h4,
+.-emu-layout
+  body.-emu
+  #sidebar
+  #combat
+  #combat-tracker
+  .combatant.hidden
+  .token-image,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #combat
+  #combat-tracker
+  .combatant.hidden
+  .token-name
+  h4,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #combat
+  #combat-tracker
+  .combatant.hidden
+  .token-image {
+  opacity: 0.5;
+}
+body.-emu #sidebar #combat #combat-tracker .combatant.active .token-name h4,
+body.-emu
+  .sidebar-popout
+  #combat
+  #combat-tracker
+  .combatant.active
+  .token-name
+  h4 {
+  border-color: rgba(var(--color-text-lightest), 1);
+}
+body.-emu
+  #sidebar
+  #combat
+  #combat-tracker
+  .combatant.active
+  .combatant-control.active,
+body.-emu
+  .sidebar-popout
+  #combat
+  #combat-tracker
+  .combatant.active
+  .combatant-control.active {
+  background-color: rgba(var(--color-white), 1);
+  color: rgba(var(--color-primary), 1);
+}
+body.-emu #sidebar #combat #combat-tracker .combatant.defeated,
+body.-emu .sidebar-popout #combat #combat-tracker .combatant.defeated {
+  background-color: rgba(var(--color-red-600), 0.5);
+}
+body.-emu
+  #sidebar
+  #combat
+  #combat-tracker
+  .combatant.defeated.active
+  .combatant-control.active,
+body.-emu
+  .sidebar-popout
+  #combat
+  #combat-tracker
+  .combatant.defeated.active
+  .combatant-control.active {
+  background-color: rgba(var(--color-primary), 1);
+  color: rgba(var(--color-text-lightest), 1);
+}
+.-emu-layout body.-emu #sidebar #combat #combat-tracker .combatant .token-image,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #combat
+  #combat-tracker
+  .combatant
+  .token-image {
+  width: var(--emu-space-button);
+  height: var(--emu-space-button);
+  cursor: default;
+  flex: 0 0 auto;
+  -webkit-margin-end: var(--emu-space-sm);
+  margin-inline-end: var(--emu-space-sm);
+  position: relative;
+}
+body.-emu #sidebar #combat #combat-tracker .combatant .token-name,
+body.-emu .sidebar-popout #combat #combat-tracker .combatant .token-name {
+  text-shadow: none;
+}
+.-emu-layout body.-emu #sidebar #combat #combat-tracker .combatant .token-name,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #combat
+  #combat-tracker
+  .combatant
+  .token-name {
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+  margin: 0;
+  overflow: hidden;
+  position: relative;
+}
+body.-emu #sidebar #combat #combat-tracker .combatant .token-name h4,
+body.-emu .sidebar-popout #combat #combat-tracker .combatant .token-name h4 {
+  color: rgba(var(--color-text-lightest), 1);
+  -webkit-border-after: 1px solid rgba(var(--color-border-lighter), 0.1);
+  border-block-end: 1px solid rgba(var(--color-border-lighter), 0.1);
+}
+.-emu-layout
+  body.-emu
+  #sidebar
+  #combat
+  #combat-tracker
+  .combatant
+  .token-name
+  h4,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #combat
+  #combat-tracker
+  .combatant
+  .token-name
+  h4 {
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: initial;
+  font-size: var(--emu-font-size-lg);
+  line-height: initial;
+  -webkit-margin-after: var(--emu-space-base);
+  margin-block-end: var(--emu-space-base);
+}
+body.-emu #sidebar #combat #combat-tracker .combatant .token-resource,
+body.-emu #sidebar #combat #combat-tracker .combatant .token-initiative,
+body.-emu .sidebar-popout #combat #combat-tracker .combatant .token-resource,
+body.-emu .sidebar-popout #combat #combat-tracker .combatant .token-initiative {
+  color: rgba(var(--color-text-lightest), 1);
+}
+.-emu-layout
+  body.-emu
+  #sidebar
+  #combat
+  #combat-tracker
+  .combatant
+  .token-resource,
+.-emu-layout
+  body.-emu
+  #sidebar
+  #combat
+  #combat-tracker
+  .combatant
+  .token-initiative,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #combat
+  #combat-tracker
+  .combatant
+  .token-resource,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #combat
+  #combat-tracker
+  .combatant
+  .token-initiative {
+  align-items: center;
+  display: flex;
+  flex: 0 0 auto;
+  position: relative;
+}
+body.-emu #sidebar #combat #combat-tracker .combatant .token-resource,
+body.-emu .sidebar-popout #combat #combat-tracker .combatant .token-resource {
+  -webkit-border-end: rgba(var(--color-border-lighter), 1) 1px solid;
+  border-inline-end: rgba(var(--color-border-lighter), 1) 1px solid;
+}
+.-emu-layout
+  body.-emu
+  #sidebar
+  #combat
+  #combat-tracker
+  .combatant
+  .token-resource,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #combat
+  #combat-tracker
+  .combatant
+  .token-resource {
+  font-size: var(--emu-font-size-md);
+  line-height: 1;
+  -webkit-margin-start: var(--emu-space-sm);
+  margin-inline-start: var(--emu-space-sm);
+  -webkit-padding-end: var(--emu-space-sm);
+  padding-inline-end: var(--emu-space-sm);
+}
+.-emu-layout
+  body.-emu
+  #sidebar
+  #combat
+  #combat-tracker
+  .combatant
+  .token-initiative,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #combat
+  #combat-tracker
+  .combatant
+  .token-initiative {
+  padding: 0;
+  -webkit-padding-start: var(--emu-space-sm);
+  padding-inline-start: var(--emu-space-sm);
+}
+body.-emu
+  #sidebar
+  #combat
+  #combat-tracker
+  .combatant
+  .token-initiative
+  .initiative,
+body.-emu
+  .sidebar-popout
+  #combat
+  #combat-tracker
+  .combatant
+  .token-initiative
+  .initiative {
+  color: inherit;
+  text-shadow: none;
+}
+.-emu-layout
+  body.-emu
+  #sidebar
+  #combat
+  #combat-tracker
+  .combatant
+  .token-initiative
+  .initiative,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #combat
+  #combat-tracker
+  .combatant
+  .token-initiative
+  .initiative {
+  font-size: var(--emu-font-size-lg);
+  font-weight: normal;
+}
+.-emu-layout
+  body.-emu
+  #sidebar
+  #combat
+  #combat-tracker
+  .combatant
+  .combatant-controls,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #combat
+  #combat-tracker
+  .combatant
+  .combatant-controls {
+  align-items: center;
+  display: flex;
+}
+.-emu-layout
+  body.-emu
+  #sidebar
+  #combat
+  #combat-tracker
+  .combatant
+  .combatant-control,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #combat
+  #combat-tracker
+  .combatant
+  .combatant-control {
+  -webkit-margin-start: 0;
+  margin-inline-start: 0;
+  -webkit-margin-end: var(--emu-space-base);
+  margin-inline-end: var(--emu-space-base);
+}
+body.-emu #sidebar #combat #combat-tracker .combatant .combatant-control.roll,
+body.-emu
+  .sidebar-popout
+  #combat
+  #combat-tracker
+  .combatant
+  .combatant-control.roll {
+  background: transparent;
+}
+.-emu-layout
+  body.-emu
+  #sidebar
+  #combat
+  #combat-tracker
+  .combatant
+  .combatant-control.roll,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #combat
+  #combat-tracker
+  .combatant
+  .combatant-control.roll {
+  width: var(--emu-space-button);
+  height: var(--emu-space-button);
+  background: transparent;
+  font-size: var(--emu-font-size-xl);
+  margin: 0;
+}
+.-emu-layout
+  body.-emu
+  #sidebar
+  #combat
+  #combat-tracker
+  .combatant
+  .combatant-control.roll::before,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #combat
+  #combat-tracker
+  .combatant
+  .combatant-control.roll::before {
+  content: "\f6cf";
+}
+.-emu-layout
+  body.-emu
+  #sidebar
+  #combat
+  #combat-tracker
+  .combatant
+  .token-effects,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #combat
+  #combat-tracker
+  .combatant
+  .token-effects {
+  display: flex;
+  flex: 1 1 auto;
+  flex-wrap: wrap;
+  height: auto;
+}
+.-emu-layout
+  body.-emu
+  #sidebar
+  #combat
+  #combat-tracker
+  .combatant
+  .token-effects
+  img,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #combat
+  #combat-tracker
+  .combatant
+  .token-effects
+  img {
+  cursor: default;
+  margin: var(--emu-space-xs);
+  max-height: 0.875rem;
+  max-width: 0.875rem;
+  opacity: 1;
+  transform: none;
+}
 
 body.-emu #sidebar #combat #combat-controls,
 body.-emu .sidebar-popout #combat #combat-controls {
   -webkit-border-before: rgba(var(--color-border), 1) 1px solid;
-          border-block-start: rgba(var(--color-border), 1) 1px solid; }
-  .-emu-layout body.-emu #sidebar #combat #combat-controls, .-emu-layout
-  body.-emu .sidebar-popout #combat #combat-controls {
-    flex-wrap: nowrap;
-    -webkit-padding-before: var(--emu-space-sm);
-            padding-block-start: var(--emu-space-sm); }
-    .-emu-layout body.-emu #sidebar #combat #combat-controls:empty, .-emu-layout
-    body.-emu .sidebar-popout #combat #combat-controls:empty {
-      display: none; }
-  .-emu-layout body.-emu #sidebar #combat #combat-controls .combat-control.center, .-emu-layout
-  body.-emu .sidebar-popout #combat #combat-controls .combat-control.center {
-    flex: 1 1 auto;
-    white-space: nowrap; }
-  .-emu-layout body.-emu #sidebar #combat #combat-controls .combat-control + .combat-control, .-emu-layout
-  body.-emu .sidebar-popout #combat #combat-controls .combat-control + .combat-control {
-    -webkit-margin-start: var(--emu-space-base);
-            margin-inline-start: var(--emu-space-base); }
-  .-emu-layout body.-emu #sidebar #combat #combat-controls .combat-control > i, .-emu-layout
-  body.-emu .sidebar-popout #combat #combat-controls .combat-control > i {
-    margin: 0; }
+  border-block-start: rgba(var(--color-border), 1) 1px solid;
+}
+.-emu-layout body.-emu #sidebar #combat #combat-controls,
+.-emu-layout body.-emu .sidebar-popout #combat #combat-controls {
+  flex-wrap: nowrap;
+  -webkit-padding-before: var(--emu-space-sm);
+  padding-block-start: var(--emu-space-sm);
+}
+.-emu-layout body.-emu #sidebar #combat #combat-controls:empty,
+.-emu-layout body.-emu .sidebar-popout #combat #combat-controls:empty {
+  display: none;
+}
+.-emu-layout body.-emu #sidebar #combat #combat-controls .combat-control.center,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #combat
+  #combat-controls
+  .combat-control.center {
+  flex: 1 1 auto;
+  white-space: nowrap;
+}
+.-emu-layout
+  body.-emu
+  #sidebar
+  #combat
+  #combat-controls
+  .combat-control
+  + .combat-control,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #combat
+  #combat-controls
+  .combat-control
+  + .combat-control {
+  -webkit-margin-start: var(--emu-space-base);
+  margin-inline-start: var(--emu-space-base);
+}
+.-emu-layout body.-emu #sidebar #combat #combat-controls .combat-control > i,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #combat
+  #combat-controls
+  .combat-control
+  > i {
+  margin: 0;
+}
 
-.-emu-layout body.-emu #sidebar #scenes .directory-list, .-emu-layout
-body.-emu .sidebar-popout #scenes .directory-list {
+.-emu-layout body.-emu #sidebar #scenes .directory-list,
+.-emu-layout body.-emu .sidebar-popout #scenes .directory-list {
   -webkit-padding-before: var(--emu-space-base);
-          padding-block-start: var(--emu-space-base); }
+  padding-block-start: var(--emu-space-base);
+}
 
 body.-emu #sidebar #scenes .directory-list .subdirectory,
 body.-emu .sidebar-popout #scenes .directory-list .subdirectory {
   -webkit-border-start: rgba(var(--color-primary), 1) 4px solid;
-          border-inline-start: rgba(var(--color-primary), 1) 4px solid; }
-  body.-emu #sidebar #scenes .directory-list .subdirectory .subdirectory,
-  body.-emu .sidebar-popout #scenes .directory-list .subdirectory .subdirectory {
-    -webkit-border-start: rgba(var(--color-orange-700), 1) 4px solid;
-            border-inline-start: rgba(var(--color-orange-700), 1) 4px solid; }
-    body.-emu #sidebar #scenes .directory-list .subdirectory .subdirectory .subdirectory,
-    body.-emu .sidebar-popout #scenes .directory-list .subdirectory .subdirectory .subdirectory {
-      -webkit-border-start: rgba(var(--color-orange-900), 1) 4px solid;
-              border-inline-start: rgba(var(--color-orange-900), 1) 4px solid; }
+  border-inline-start: rgba(var(--color-primary), 1) 4px solid;
+}
+body.-emu #sidebar #scenes .directory-list .subdirectory .subdirectory,
+body.-emu .sidebar-popout #scenes .directory-list .subdirectory .subdirectory {
+  -webkit-border-start: rgba(var(--color-orange-700), 1) 4px solid;
+  border-inline-start: rgba(var(--color-orange-700), 1) 4px solid;
+}
+body.-emu
+  #sidebar
+  #scenes
+  .directory-list
+  .subdirectory
+  .subdirectory
+  .subdirectory,
+body.-emu
+  .sidebar-popout
+  #scenes
+  .directory-list
+  .subdirectory
+  .subdirectory
+  .subdirectory {
+  -webkit-border-start: rgba(var(--color-orange-900), 1) 4px solid;
+  border-inline-start: rgba(var(--color-orange-900), 1) 4px solid;
+}
 
 body.-emu #sidebar #scenes .scene,
 body.-emu .sidebar-popout #scenes .scene {
   background-position: 50%;
   background-size: cover;
   border: none;
-  box-shadow: none; }
-  .-emu-layout body.-emu #sidebar #scenes .scene, .-emu-layout
-  body.-emu .sidebar-popout #scenes .scene {
-    height: auto;
-    line-height: 1; }
-  .-emu-layout.-emu-scene-thumbs body.-emu #sidebar #scenes .scene, .-emu-layout.-emu-scene-thumbs
-  body.-emu .sidebar-popout #scenes .scene {
-    background-image: none !important; }
-  body.-emu #sidebar #scenes .scene:hover,
-  body.-emu .sidebar-popout #scenes .scene:hover {
-    background-position: 50%;
-    background-size: cover; }
-  .-emu-layout body.-emu #sidebar #scenes .scene.context, .-emu-layout
-  body.-emu .sidebar-popout #scenes .scene.context {
-    -webkit-margin-before: var(--emu-space-base);
-            margin-block-start: var(--emu-space-base); }
-  body.-emu #sidebar #scenes .scene h3,
-  body.-emu .sidebar-popout #scenes .scene h3 {
-    text-shadow: none; }
-    .-emu-layout body.-emu #sidebar #scenes .scene h3, .-emu-layout
-    body.-emu .sidebar-popout #scenes .scene h3 {
-      font-size: var(--emu-font-size-lg);
-      line-height: 1;
-      text-align: start; }
-    body.-emu #sidebar #scenes .scene h3 > a,
-    body.-emu .sidebar-popout #scenes .scene h3 > a {
-      text-shadow: 1px 1px 2px rgba(var(--color-black), 1), -1px -1px 2px rgba(var(--color-black), 1); }
-      .-emu-layout body.-emu #sidebar #scenes .scene h3 > a, .-emu-layout
-      body.-emu .sidebar-popout #scenes .scene h3 > a {
-        padding: var(--emu-space-sm) 0; }
-      .-emu-layout.-emu-scene-thumbs body.-emu #sidebar #scenes .scene h3 > a, .-emu-layout.-emu-scene-thumbs
-      body.-emu .sidebar-popout #scenes .scene h3 > a {
-        padding: 0;
-        text-shadow: none; }
+  box-shadow: none;
+}
+.-emu-layout body.-emu #sidebar #scenes .scene,
+.-emu-layout body.-emu .sidebar-popout #scenes .scene {
+  height: auto;
+  line-height: 1;
+}
+.-emu-layout.-emu-scene-thumbs body.-emu #sidebar #scenes .scene,
+.-emu-layout.-emu-scene-thumbs body.-emu .sidebar-popout #scenes .scene {
+  background-image: none !important;
+}
+body.-emu #sidebar #scenes .scene:hover,
+body.-emu .sidebar-popout #scenes .scene:hover {
+  background-position: 50%;
+  background-size: cover;
+}
+.-emu-layout body.-emu #sidebar #scenes .scene.context,
+.-emu-layout body.-emu .sidebar-popout #scenes .scene.context {
+  -webkit-margin-before: var(--emu-space-base);
+  margin-block-start: var(--emu-space-base);
+}
+body.-emu #sidebar #scenes .scene h3,
+body.-emu .sidebar-popout #scenes .scene h3 {
+  text-shadow: none;
+}
+.-emu-layout body.-emu #sidebar #scenes .scene h3,
+.-emu-layout body.-emu .sidebar-popout #scenes .scene h3 {
+  font-size: var(--emu-font-size-lg);
+  line-height: 1;
+  text-align: start;
+}
+body.-emu #sidebar #scenes .scene h3 > a,
+body.-emu .sidebar-popout #scenes .scene h3 > a {
+  text-shadow: 1px 1px 2px rgba(var(--color-black), 1),
+    -1px -1px 2px rgba(var(--color-black), 1);
+}
+.-emu-layout body.-emu #sidebar #scenes .scene h3 > a,
+.-emu-layout body.-emu .sidebar-popout #scenes .scene h3 > a {
+  padding: var(--emu-space-sm) 0;
+}
+.-emu-layout.-emu-scene-thumbs body.-emu #sidebar #scenes .scene h3 > a,
+.-emu-layout.-emu-scene-thumbs body.-emu .sidebar-popout #scenes .scene h3 > a {
+  padding: 0;
+  text-shadow: none;
+}
 
-.-emu-layout body.-emu #sidebar #actors .directory-list, .-emu-layout
-body.-emu .sidebar-popout #actors .directory-list {
+.-emu-layout body.-emu #sidebar #actors .directory-list,
+.-emu-layout body.-emu .sidebar-popout #actors .directory-list {
   -webkit-padding-before: var(--emu-space-base);
-          padding-block-start: var(--emu-space-base); }
+  padding-block-start: var(--emu-space-base);
+}
 
-.-emu-layout body.-emu #sidebar #actors .directory-item .actor-profile, .-emu-layout
-body.-emu .sidebar-popout #actors .directory-item .actor-profile {
+.-emu-layout body.-emu #sidebar #actors .directory-item .actor-profile,
+.-emu-layout body.-emu .sidebar-popout #actors .directory-item .actor-profile {
   -o-object-position: 50% 0;
-     object-position: 50% 0; }
+  object-position: 50% 0;
+}
 
-.-emu-layout body.-emu #sidebar #items .directory-list, .-emu-layout
-body.-emu .sidebar-popout #items .directory-list {
+.-emu-layout body.-emu #sidebar #items .directory-list,
+.-emu-layout body.-emu .sidebar-popout #items .directory-list {
   -webkit-padding-before: var(--emu-space-base);
-          padding-block-start: var(--emu-space-base); }
+  padding-block-start: var(--emu-space-base);
+}
 
-.-emu-layout body.-emu #sidebar #journal .directory-list, .-emu-layout
-body.-emu .sidebar-popout #journal .directory-list {
+.-emu-layout body.-emu #sidebar #journal .directory-list,
+.-emu-layout body.-emu .sidebar-popout #journal .directory-list {
   -webkit-padding-before: var(--emu-space-base);
-          padding-block-start: var(--emu-space-base); }
+  padding-block-start: var(--emu-space-base);
+}
 
-.-emu-layout body.-emu #sidebar #tables .directory-list, .-emu-layout
-body.-emu .sidebar-popout #tables .directory-list {
+.-emu-layout body.-emu #sidebar #tables .directory-list,
+.-emu-layout body.-emu .sidebar-popout #tables .directory-list {
   -webkit-padding-before: var(--emu-space-base);
-          padding-block-start: var(--emu-space-base); }
+  padding-block-start: var(--emu-space-base);
+}
 
 body.-emu #sidebar #playlists,
 body.-emu .sidebar-popout #playlists {
-  color: rgba(var(--color-text-lightest), 1); }
-  body.-emu #sidebar #playlists .global-control,
-  body.-emu .sidebar-popout #playlists .global-control {
-    background-color: rgba(var(--color-background), 0.5);
-    -webkit-border-after: rgba(var(--color-border), 1) 1px solid;
-            border-block-end: rgba(var(--color-border), 1) 1px solid;
-    color: rgba(var(--color-text-lightest), 1); }
-    .-emu-layout body.-emu #sidebar #playlists .global-control, .-emu-layout
-    body.-emu .sidebar-popout #playlists .global-control {
-      display: flex;
-      flex: 0 0 auto;
-      flex-wrap: wrap;
-      line-height: 1;
-      margin: 0;
-      padding: var(--emu-space-sm);
-      position: relative; }
-    .-emu-layout body.-emu #sidebar #playlists .global-control.collapsed .playlist-sounds, .-emu-layout
-    body.-emu .sidebar-popout #playlists .global-control.collapsed .playlist-sounds {
-      height: auto !important;
-      max-height: 0 !important;
-      padding: 0 !important; }
-    body.-emu #sidebar #playlists .global-control .playlist-header,
-    body.-emu .sidebar-popout #playlists .global-control .playlist-header {
-      background: transparent;
-      border: none;
-      color: rgba(var(--color-text-lightest), 1); }
-      .-emu-layout body.-emu #sidebar #playlists .global-control .playlist-header, .-emu-layout
-      body.-emu .sidebar-popout #playlists .global-control .playlist-header {
-        flex: 0 0 auto;
-        font-size: var(--emu-font-size-md);
-        padding: var(--emu-space-xs) 0;
-        width: 100%; }
-      body.-emu #sidebar #playlists .global-control .playlist-header h4,
-      body.-emu .sidebar-popout #playlists .global-control .playlist-header h4 {
-        text-decoration: none; }
-        .-emu-layout body.-emu #sidebar #playlists .global-control .playlist-header h4, .-emu-layout
-        body.-emu .sidebar-popout #playlists .global-control .playlist-header h4 {
-          height: auto;
-          margin: 0;
-          -webkit-padding-start: 0;
-                  padding-inline-start: 0; }
-        body.-emu #sidebar #playlists .global-control .playlist-header h4 i.fa,
-        body.-emu .sidebar-popout #playlists .global-control .playlist-header h4 i.fa {
-          color: inherit; }
-          .-emu-layout body.-emu #sidebar #playlists .global-control .playlist-header h4 i.fa, .-emu-layout
-          body.-emu .sidebar-popout #playlists .global-control .playlist-header h4 i.fa {
-            -webkit-margin-start: var(--emu-space-xs);
-                    margin-inline-start: var(--emu-space-xs); }
-    body.-emu #sidebar #playlists .global-control .playlist-sounds,
-    body.-emu .sidebar-popout #playlists .global-control .playlist-sounds {
-      background: transparent;
-      -webkit-border-start: none;
-              border-inline-start: none; }
-      .-emu-layout body.-emu #sidebar #playlists .global-control .playlist-sounds, .-emu-layout
-      body.-emu .sidebar-popout #playlists .global-control .playlist-sounds {
-        flex: 0 0 auto;
-        height: auto !important;
-        padding: 0 !important;
-        width: 100%; }
-      body.-emu #sidebar #playlists .global-control .playlist-sounds h4,
-      body.-emu .sidebar-popout #playlists .global-control .playlist-sounds h4 {
-        -webkit-border-after: 0;
-                border-block-end: 0;
-        color: rgba(var(--color-text-lightest), 1); }
-        .-emu-layout body.-emu #sidebar #playlists .global-control .playlist-sounds h4, .-emu-layout
-        body.-emu .sidebar-popout #playlists .global-control .playlist-sounds h4 {
-          font-size: var(--emu-font-size-lg);
-          margin: 0; }
-          .-emu-layout body.-emu #sidebar #playlists .global-control .playlist-sounds h4 + input[type="range"], .-emu-layout
-          body.-emu .sidebar-popout #playlists .global-control .playlist-sounds h4 + input[type="range"] {
-            -webkit-margin-start: var(--emu-space-base);
-                    margin-inline-start: var(--emu-space-base); }
-      body.-emu #sidebar #playlists .global-control .playlist-sounds .sound,
-      body.-emu .sidebar-popout #playlists .global-control .playlist-sounds .sound {
-        -webkit-border-after: 0;
-                border-block-end: 0; }
-        .-emu-layout body.-emu #sidebar #playlists .global-control .playlist-sounds .sound, .-emu-layout
-        body.-emu .sidebar-popout #playlists .global-control .playlist-sounds .sound {
-          flex-wrap: nowrap;
-          -webkit-padding-start: 0;
-                  padding-inline-start: 0;
-          -webkit-padding-end: 0;
-                  padding-inline-end: 0; }
-          .-emu-layout body.-emu #sidebar #playlists .global-control .playlist-sounds .sound:last-of-type, .-emu-layout
-          body.-emu .sidebar-popout #playlists .global-control .playlist-sounds .sound:last-of-type {
-            -webkit-padding-after: 0;
-                    padding-block-end: 0; }
-          .-emu-layout body.-emu #sidebar #playlists .global-control .playlist-sounds .sound .global-volume, .-emu-layout
-          body.-emu .sidebar-popout #playlists .global-control .playlist-sounds .sound .global-volume {
-            flex: 0 0 50%; }
-  .-emu-layout body.-emu #sidebar #playlists .directory-list, .-emu-layout
-  body.-emu .sidebar-popout #playlists .directory-list {
-    -webkit-padding-before: var(--emu-space-base);
-            padding-block-start: var(--emu-space-base); }
-  .-emu-layout body.-emu #sidebar #playlists .directory-list .directory-item.playlist, .-emu-layout
-  body.-emu .sidebar-popout #playlists .directory-list .directory-item.playlist {
-    flex-direction: column;
-    line-height: 1;
-    padding: 0 var(--emu-space-sm); }
-  body.-emu #sidebar #playlists .directory-list .directory-item.playlist:not(.collapsed):hover, body.-emu #sidebar #playlists .directory-list .directory-item.playlist:not(.collapsed):focus,
-  body.-emu .sidebar-popout #playlists .directory-list .directory-item.playlist:not(.collapsed):hover,
-  body.-emu .sidebar-popout #playlists .directory-list .directory-item.playlist:not(.collapsed):focus {
-    background-color: rgba(var(--color-folder-directory), 1); }
-  body.-emu #sidebar #playlists .directory-list .directory-item.playlist:not(.collapsed) .playlist-sounds .sound:first-child,
-  body.-emu .sidebar-popout #playlists .directory-list .directory-item.playlist:not(.collapsed) .playlist-sounds .sound:first-child {
-    -webkit-border-before: rgba(var(--color-border), 1) 1px solid;
-            border-block-start: rgba(var(--color-border), 1) 1px solid; }
-  .-emu-layout body.-emu #sidebar #playlists .directory-list .playlist-sounds, .-emu-layout
-  body.-emu .sidebar-popout #playlists .directory-list .playlist-sounds {
-    height: auto !important;
-    width: 100%; }
-  body.-emu #sidebar #playlists .directory-list .playlist-sounds .sound:first-child,
-  body.-emu .sidebar-popout #playlists .directory-list .playlist-sounds .sound:first-child {
-    -webkit-border-before: transparent 1px solid;
-            border-block-start: transparent 1px solid; }
-  .-emu-layout body.-emu #sidebar #playlists .directory-list .playlist-header, .-emu-layout
-  body.-emu #sidebar #playlists .directory-list .sound, .-emu-layout
-  body.-emu .sidebar-popout #playlists .directory-list .playlist-header, .-emu-layout
-  body.-emu .sidebar-popout #playlists .directory-list .sound {
-    display: flex;
-    flex: 1 1 100%;
-    flex-wrap: nowrap;
-    margin: 0;
-    text-decoration: none;
-    width: 100%; }
-  .-emu-layout body.-emu #sidebar #playlists .directory-list .playlist-header .playlist-name, .-emu-layout
-  body.-emu #sidebar #playlists .directory-list .sound .playlist-name, .-emu-layout
-  body.-emu .sidebar-popout #playlists .directory-list .playlist-header .playlist-name, .-emu-layout
-  body.-emu .sidebar-popout #playlists .directory-list .sound .playlist-name {
-    align-items: center;
-    display: inline-flex;
-    flex: 1 1 100%;
-    overflow: visible;
-    padding: var(--emu-space-base) 0;
-    word-break: normal;
-    white-space: initial;
-    width: 100%; }
-    .-emu-layout body.-emu #sidebar #playlists .directory-list .playlist-header .playlist-name > i, .-emu-layout
-    body.-emu #sidebar #playlists .directory-list .sound .playlist-name > i, .-emu-layout
-    body.-emu .sidebar-popout #playlists .directory-list .playlist-header .playlist-name > i, .-emu-layout
-    body.-emu .sidebar-popout #playlists .directory-list .sound .playlist-name > i {
-      display: none; }
-  .-emu-layout body.-emu #sidebar #playlists .directory-list .playlist-header .sound-controls, .-emu-layout
-  body.-emu #sidebar #playlists .directory-list .sound .sound-controls, .-emu-layout
-  body.-emu .sidebar-popout #playlists .directory-list .playlist-header .sound-controls, .-emu-layout
-  body.-emu .sidebar-popout #playlists .directory-list .sound .sound-controls {
-    flex: 0 0 auto;
-    flex-wrap: nowrap;
-    -webkit-margin-start: var(--emu-space-base);
-            margin-inline-start: var(--emu-space-base);
-    padding: var(--emu-space-base) 0;
-    width: auto; }
-  body.-emu #sidebar #playlists .directory-list .playlist-header .sound-controls .sound-control.inactive,
-  body.-emu #sidebar #playlists .directory-list .sound .sound-controls .sound-control.inactive,
-  body.-emu .sidebar-popout #playlists .directory-list .playlist-header .sound-controls .sound-control.inactive,
-  body.-emu .sidebar-popout #playlists .directory-list .sound .sound-controls .sound-control.inactive {
-    opacity: 0.5; }
-  .-emu-layout body.-emu #sidebar #playlists .directory-list .playlist-header, .-emu-layout
-  body.-emu .sidebar-popout #playlists .directory-list .playlist-header {
-    flex: 0 0 auto; }
-  body.-emu #sidebar #playlists .directory-list .sound:nth-child(even),
-  body.-emu .sidebar-popout #playlists .directory-list .sound:nth-child(even) {
-    background-color: rgba(var(--color-background-darkest), 0.2); }
-  body.-emu #sidebar #playlists h4,
-  body.-emu #sidebar #playlists i,
-  body.-emu #sidebar #playlists input[type=range],
-  body.-emu .sidebar-popout #playlists h4,
-  body.-emu .sidebar-popout #playlists i,
-  body.-emu .sidebar-popout #playlists input[type=range] {
-    color: inherit; }
-    .-emu-layout body.-emu #sidebar #playlists h4, .-emu-layout
-    body.-emu #sidebar #playlists i, .-emu-layout
-    body.-emu #sidebar #playlists input[type=range], .-emu-layout
-    body.-emu .sidebar-popout #playlists h4, .-emu-layout
-    body.-emu .sidebar-popout #playlists i, .-emu-layout
-    body.-emu .sidebar-popout #playlists input[type=range] {
-      height: auto;
-      line-height: 1.2;
-      word-break: normal; }
-  .-emu-layout body.-emu #sidebar #playlists h4 + input[type="range"], .-emu-layout
-  body.-emu #sidebar #playlists i + input[type="range"], .-emu-layout
-  body.-emu .sidebar-popout #playlists h4 + input[type="range"], .-emu-layout
-  body.-emu .sidebar-popout #playlists i + input[type="range"] {
-    -webkit-margin-start: var(--emu-space-base);
-            margin-inline-start: var(--emu-space-base); }
-  .-emu-layout body.-emu #sidebar #playlists h4, .-emu-layout
-  body.-emu .sidebar-popout #playlists h4 {
-    padding: var(--emu-space-base); }
-  .-emu-layout body.-emu #sidebar #playlists input[type="range"], .-emu-layout
-  body.-emu .sidebar-popout #playlists input[type="range"] {
-    margin: 0; }
-  .-emu-layout body.-emu #sidebar #playlists #currently-playing, .-emu-layout
-  body.-emu .sidebar-popout #playlists #currently-playing {
-    flex-direction: row;
-    max-height: 30%;
-    overflow-x: hidden;
-    overflow-y: auto; }
-  .-emu-layout body.-emu #sidebar #playlists #currently-playing .sound, .-emu-layout
-  body.-emu .sidebar-popout #playlists #currently-playing .sound {
-    display: grid;
-    flex: 1 1 100%;
-    grid-template-areas: "name controls" "playback playback";
-    grid-template-columns: 1fr -webkit-min-content;
-    grid-template-columns: 1fr min-content;
-    grid-template-rows: -webkit-min-content -webkit-min-content;
-    grid-template-rows: min-content min-content;
-    margin: 0;
-    text-decoration: none;
-    width: 100%; }
-  body.-emu #sidebar #playlists #currently-playing .sound + .sound,
-  body.-emu .sidebar-popout #playlists #currently-playing .sound + .sound {
-    -webkit-border-before: rgba(var(--color-border), 1) 1px solid;
-            border-block-start: rgba(var(--color-border), 1) 1px solid; }
-    .-emu-layout body.-emu #sidebar #playlists #currently-playing .sound + .sound, .-emu-layout
-    body.-emu .sidebar-popout #playlists #currently-playing .sound + .sound {
-      -webkit-padding-before: var(--emu-space-sm);
-              padding-block-start: var(--emu-space-sm); }
-  .-emu-layout body.-emu #sidebar #playlists #currently-playing .sound .sound-name, .-emu-layout
-  body.-emu .sidebar-popout #playlists #currently-playing .sound .sound-name {
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    align-items: center;
-    display: inline-flex;
-    grid-area: name;
-    margin: 0;
-    padding: var(--emu-space-base) 0; }
-  .-emu-layout body.-emu #sidebar #playlists #currently-playing .sound .sound-controls, .-emu-layout
-  body.-emu .sidebar-popout #playlists #currently-playing .sound .sound-controls {
-    flex-wrap: nowrap;
-    grid-area: controls;
-    margin: 0;
-    -webkit-margin-start: var(--emu-space-base);
-            margin-inline-start: var(--emu-space-base);
-    padding: var(--emu-space-base) 0;
-    width: auto; }
-  body.-emu #sidebar #playlists #currently-playing .sound .sound-control.inactive,
-  body.-emu .sidebar-popout #playlists #currently-playing .sound .sound-control.inactive {
-    opacity: 0.5; }
-  .-emu-layout body.-emu #sidebar #playlists #currently-playing .sound .sound-playback, .-emu-layout
-  body.-emu .sidebar-popout #playlists #currently-playing .sound .sound-playback {
-    align-items: center;
-    display: flex;
-    grid-area: playback;
-    padding: 0; }
-  body.-emu #sidebar #playlists #currently-playing .sound .sound-playback .sound-timer,
-  body.-emu .sidebar-popout #playlists #currently-playing .sound .sound-playback .sound-timer {
-    color: rgba(var(--color-text-lightest), 1); }
-    .-emu-layout body.-emu #sidebar #playlists #currently-playing .sound .sound-playback .sound-timer, .-emu-layout
-    body.-emu .sidebar-popout #playlists #currently-playing .sound .sound-playback .sound-timer {
-      font-size: var(--emu-font-size-sm);
-      -webkit-margin-end: var(--emu-space-sm);
-              margin-inline-end: var(--emu-space-sm); }
-  .-emu-layout body.-emu #sidebar #playlists #currently-playing .sound .sound-playback .volume-icon, .-emu-layout
-  body.-emu .sidebar-popout #playlists #currently-playing .sound .sound-playback .volume-icon {
-    -webkit-margin-end: var(--emu-space-base);
-            margin-inline-end: var(--emu-space-base); }
+  color: rgba(var(--color-text-lightest), 1);
+}
+body.-emu #sidebar #playlists .global-control,
+body.-emu .sidebar-popout #playlists .global-control {
+  background-color: rgba(var(--color-background), 0.5);
+  -webkit-border-after: rgba(var(--color-border), 1) 1px solid;
+  border-block-end: rgba(var(--color-border), 1) 1px solid;
+  color: rgba(var(--color-text-lightest), 1);
+}
+.-emu-layout body.-emu #sidebar #playlists .global-control,
+.-emu-layout body.-emu .sidebar-popout #playlists .global-control {
+  display: flex;
+  flex: 0 0 auto;
+  flex-wrap: wrap;
+  line-height: 1;
+  margin: 0;
+  padding: var(--emu-space-sm);
+  position: relative;
+}
+.-emu-layout
+  body.-emu
+  #sidebar
+  #playlists
+  .global-control.collapsed
+  .playlist-sounds,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #playlists
+  .global-control.collapsed
+  .playlist-sounds {
+  height: auto !important;
+  max-height: 0 !important;
+  padding: 0 !important;
+}
+body.-emu #sidebar #playlists .global-control .playlist-header,
+body.-emu .sidebar-popout #playlists .global-control .playlist-header {
+  background: transparent;
+  border: none;
+  color: rgba(var(--color-text-lightest), 1);
+}
+.-emu-layout body.-emu #sidebar #playlists .global-control .playlist-header,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #playlists
+  .global-control
+  .playlist-header {
+  flex: 0 0 auto;
+  font-size: var(--emu-font-size-md);
+  padding: var(--emu-space-xs) 0;
+  width: 100%;
+}
+body.-emu #sidebar #playlists .global-control .playlist-header h4,
+body.-emu .sidebar-popout #playlists .global-control .playlist-header h4 {
+  text-decoration: none;
+}
+.-emu-layout body.-emu #sidebar #playlists .global-control .playlist-header h4,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #playlists
+  .global-control
+  .playlist-header
+  h4 {
+  height: auto;
+  margin: 0;
+  -webkit-padding-start: 0;
+  padding-inline-start: 0;
+}
+body.-emu #sidebar #playlists .global-control .playlist-header h4 i.fa,
+body.-emu .sidebar-popout #playlists .global-control .playlist-header h4 i.fa {
+  color: inherit;
+}
+.-emu-layout
+  body.-emu
+  #sidebar
+  #playlists
+  .global-control
+  .playlist-header
+  h4
+  i.fa,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #playlists
+  .global-control
+  .playlist-header
+  h4
+  i.fa {
+  -webkit-margin-start: var(--emu-space-xs);
+  margin-inline-start: var(--emu-space-xs);
+}
+body.-emu #sidebar #playlists .global-control .playlist-sounds,
+body.-emu .sidebar-popout #playlists .global-control .playlist-sounds {
+  background: transparent;
+  -webkit-border-start: none;
+  border-inline-start: none;
+}
+.-emu-layout body.-emu #sidebar #playlists .global-control .playlist-sounds,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #playlists
+  .global-control
+  .playlist-sounds {
+  flex: 0 0 auto;
+  height: auto !important;
+  padding: 0 !important;
+  width: 100%;
+}
+body.-emu #sidebar #playlists .global-control .playlist-sounds h4,
+body.-emu .sidebar-popout #playlists .global-control .playlist-sounds h4 {
+  -webkit-border-after: 0;
+  border-block-end: 0;
+  color: rgba(var(--color-text-lightest), 1);
+}
+.-emu-layout body.-emu #sidebar #playlists .global-control .playlist-sounds h4,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #playlists
+  .global-control
+  .playlist-sounds
+  h4 {
+  font-size: var(--emu-font-size-lg);
+  margin: 0;
+}
+.-emu-layout
+  body.-emu
+  #sidebar
+  #playlists
+  .global-control
+  .playlist-sounds
+  h4
+  + input[type="range"],
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #playlists
+  .global-control
+  .playlist-sounds
+  h4
+  + input[type="range"] {
+  -webkit-margin-start: var(--emu-space-base);
+  margin-inline-start: var(--emu-space-base);
+}
+body.-emu #sidebar #playlists .global-control .playlist-sounds .sound,
+body.-emu .sidebar-popout #playlists .global-control .playlist-sounds .sound {
+  -webkit-border-after: 0;
+  border-block-end: 0;
+}
+.-emu-layout
+  body.-emu
+  #sidebar
+  #playlists
+  .global-control
+  .playlist-sounds
+  .sound,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #playlists
+  .global-control
+  .playlist-sounds
+  .sound {
+  flex-wrap: nowrap;
+  -webkit-padding-start: 0;
+  padding-inline-start: 0;
+  -webkit-padding-end: 0;
+  padding-inline-end: 0;
+}
+.-emu-layout
+  body.-emu
+  #sidebar
+  #playlists
+  .global-control
+  .playlist-sounds
+  .sound:last-of-type,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #playlists
+  .global-control
+  .playlist-sounds
+  .sound:last-of-type {
+  -webkit-padding-after: 0;
+  padding-block-end: 0;
+}
+.-emu-layout
+  body.-emu
+  #sidebar
+  #playlists
+  .global-control
+  .playlist-sounds
+  .sound
+  .global-volume,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #playlists
+  .global-control
+  .playlist-sounds
+  .sound
+  .global-volume {
+  flex: 0 0 50%;
+}
+.-emu-layout body.-emu #sidebar #playlists .directory-list,
+.-emu-layout body.-emu .sidebar-popout #playlists .directory-list {
+  -webkit-padding-before: var(--emu-space-base);
+  padding-block-start: var(--emu-space-base);
+}
+.-emu-layout
+  body.-emu
+  #sidebar
+  #playlists
+  .directory-list
+  .directory-item.playlist,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #playlists
+  .directory-list
+  .directory-item.playlist {
+  flex-direction: column;
+  line-height: 1;
+  padding: 0 var(--emu-space-sm);
+}
+body.-emu
+  #sidebar
+  #playlists
+  .directory-list
+  .directory-item.playlist:not(.collapsed):hover,
+body.-emu
+  #sidebar
+  #playlists
+  .directory-list
+  .directory-item.playlist:not(.collapsed):focus,
+body.-emu
+  .sidebar-popout
+  #playlists
+  .directory-list
+  .directory-item.playlist:not(.collapsed):hover,
+body.-emu
+  .sidebar-popout
+  #playlists
+  .directory-list
+  .directory-item.playlist:not(.collapsed):focus {
+  background-color: rgba(var(--color-folder-directory), 1);
+}
+body.-emu
+  #sidebar
+  #playlists
+  .directory-list
+  .directory-item.playlist:not(.collapsed)
+  .playlist-sounds
+  .sound:first-child,
+body.-emu
+  .sidebar-popout
+  #playlists
+  .directory-list
+  .directory-item.playlist:not(.collapsed)
+  .playlist-sounds
+  .sound:first-child {
+  -webkit-border-before: rgba(var(--color-border), 1) 1px solid;
+  border-block-start: rgba(var(--color-border), 1) 1px solid;
+}
+.-emu-layout body.-emu #sidebar #playlists .directory-list .playlist-sounds,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #playlists
+  .directory-list
+  .playlist-sounds {
+  height: auto !important;
+  width: 100%;
+}
+body.-emu
+  #sidebar
+  #playlists
+  .directory-list
+  .playlist-sounds
+  .sound:first-child,
+body.-emu
+  .sidebar-popout
+  #playlists
+  .directory-list
+  .playlist-sounds
+  .sound:first-child {
+  -webkit-border-before: transparent 1px solid;
+  border-block-start: transparent 1px solid;
+}
+.-emu-layout body.-emu #sidebar #playlists .directory-list .playlist-header,
+.-emu-layout body.-emu #sidebar #playlists .directory-list .sound,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #playlists
+  .directory-list
+  .playlist-header,
+.-emu-layout body.-emu .sidebar-popout #playlists .directory-list .sound {
+  display: flex;
+  flex: 1 1 100%;
+  flex-wrap: nowrap;
+  margin: 0;
+  text-decoration: none;
+  width: 100%;
+}
+.-emu-layout
+  body.-emu
+  #sidebar
+  #playlists
+  .directory-list
+  .playlist-header
+  .playlist-name,
+.-emu-layout
+  body.-emu
+  #sidebar
+  #playlists
+  .directory-list
+  .sound
+  .playlist-name,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #playlists
+  .directory-list
+  .playlist-header
+  .playlist-name,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #playlists
+  .directory-list
+  .sound
+  .playlist-name {
+  align-items: center;
+  display: inline-flex;
+  flex: 1 1 100%;
+  overflow: visible;
+  padding: var(--emu-space-base) 0;
+  word-break: normal;
+  white-space: initial;
+  width: 100%;
+}
+.-emu-layout
+  body.-emu
+  #sidebar
+  #playlists
+  .directory-list
+  .playlist-header
+  .playlist-name
+  > i,
+.-emu-layout
+  body.-emu
+  #sidebar
+  #playlists
+  .directory-list
+  .sound
+  .playlist-name
+  > i,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #playlists
+  .directory-list
+  .playlist-header
+  .playlist-name
+  > i,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #playlists
+  .directory-list
+  .sound
+  .playlist-name
+  > i {
+  display: none;
+}
+.-emu-layout
+  body.-emu
+  #sidebar
+  #playlists
+  .directory-list
+  .playlist-header
+  .sound-controls,
+.-emu-layout
+  body.-emu
+  #sidebar
+  #playlists
+  .directory-list
+  .sound
+  .sound-controls,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #playlists
+  .directory-list
+  .playlist-header
+  .sound-controls,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #playlists
+  .directory-list
+  .sound
+  .sound-controls {
+  flex: 0 0 auto;
+  flex-wrap: nowrap;
+  -webkit-margin-start: var(--emu-space-base);
+  margin-inline-start: var(--emu-space-base);
+  padding: var(--emu-space-base) 0;
+  width: auto;
+}
+body.-emu
+  #sidebar
+  #playlists
+  .directory-list
+  .playlist-header
+  .sound-controls
+  .sound-control.inactive,
+body.-emu
+  #sidebar
+  #playlists
+  .directory-list
+  .sound
+  .sound-controls
+  .sound-control.inactive,
+body.-emu
+  .sidebar-popout
+  #playlists
+  .directory-list
+  .playlist-header
+  .sound-controls
+  .sound-control.inactive,
+body.-emu
+  .sidebar-popout
+  #playlists
+  .directory-list
+  .sound
+  .sound-controls
+  .sound-control.inactive {
+  opacity: 0.5;
+}
+.-emu-layout body.-emu #sidebar #playlists .directory-list .playlist-header,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #playlists
+  .directory-list
+  .playlist-header {
+  flex: 0 0 auto;
+}
+body.-emu #sidebar #playlists .directory-list .sound:nth-child(even),
+body.-emu .sidebar-popout #playlists .directory-list .sound:nth-child(even) {
+  background-color: rgba(var(--color-background-darkest), 0.2);
+}
+body.-emu #sidebar #playlists h4,
+body.-emu #sidebar #playlists i,
+body.-emu #sidebar #playlists input[type="range"],
+body.-emu .sidebar-popout #playlists h4,
+body.-emu .sidebar-popout #playlists i,
+body.-emu .sidebar-popout #playlists input[type="range"] {
+  color: inherit;
+}
+.-emu-layout body.-emu #sidebar #playlists h4,
+.-emu-layout body.-emu #sidebar #playlists i,
+.-emu-layout body.-emu #sidebar #playlists input[type="range"],
+.-emu-layout body.-emu .sidebar-popout #playlists h4,
+.-emu-layout body.-emu .sidebar-popout #playlists i,
+.-emu-layout body.-emu .sidebar-popout #playlists input[type="range"] {
+  height: auto;
+  line-height: 1.2;
+  word-break: normal;
+}
+.-emu-layout body.-emu #sidebar #playlists h4 + input[type="range"],
+.-emu-layout body.-emu #sidebar #playlists i + input[type="range"],
+.-emu-layout body.-emu .sidebar-popout #playlists h4 + input[type="range"],
+.-emu-layout body.-emu .sidebar-popout #playlists i + input[type="range"] {
+  -webkit-margin-start: var(--emu-space-base);
+  margin-inline-start: var(--emu-space-base);
+}
+.-emu-layout body.-emu #sidebar #playlists h4,
+.-emu-layout body.-emu .sidebar-popout #playlists h4 {
+  padding: var(--emu-space-base);
+}
+.-emu-layout body.-emu #sidebar #playlists input[type="range"],
+.-emu-layout body.-emu .sidebar-popout #playlists input[type="range"] {
+  margin: 0;
+}
+.-emu-layout body.-emu #sidebar #playlists #currently-playing,
+.-emu-layout body.-emu .sidebar-popout #playlists #currently-playing {
+  flex-direction: row;
+  max-height: 30%;
+  overflow-x: hidden;
+  overflow-y: auto;
+}
+.-emu-layout body.-emu #sidebar #playlists #currently-playing .sound,
+.-emu-layout body.-emu .sidebar-popout #playlists #currently-playing .sound {
+  display: grid;
+  flex: 1 1 100%;
+  grid-template-areas:
+    "name controls"
+    "playback playback";
+  grid-template-columns: 1fr -webkit-min-content;
+  grid-template-columns: 1fr min-content;
+  grid-template-rows: -webkit-min-content -webkit-min-content;
+  grid-template-rows: min-content min-content;
+  margin: 0;
+  text-decoration: none;
+  width: 100%;
+}
+body.-emu #sidebar #playlists #currently-playing .sound + .sound,
+body.-emu .sidebar-popout #playlists #currently-playing .sound + .sound {
+  -webkit-border-before: rgba(var(--color-border), 1) 1px solid;
+  border-block-start: rgba(var(--color-border), 1) 1px solid;
+}
+.-emu-layout body.-emu #sidebar #playlists #currently-playing .sound + .sound,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #playlists
+  #currently-playing
+  .sound
+  + .sound {
+  -webkit-padding-before: var(--emu-space-sm);
+  padding-block-start: var(--emu-space-sm);
+}
+.-emu-layout
+  body.-emu
+  #sidebar
+  #playlists
+  #currently-playing
+  .sound
+  .sound-name,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #playlists
+  #currently-playing
+  .sound
+  .sound-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  align-items: center;
+  display: inline-flex;
+  grid-area: name;
+  margin: 0;
+  padding: var(--emu-space-base) 0;
+}
+.-emu-layout
+  body.-emu
+  #sidebar
+  #playlists
+  #currently-playing
+  .sound
+  .sound-controls,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #playlists
+  #currently-playing
+  .sound
+  .sound-controls {
+  flex-wrap: nowrap;
+  grid-area: controls;
+  margin: 0;
+  -webkit-margin-start: var(--emu-space-base);
+  margin-inline-start: var(--emu-space-base);
+  padding: var(--emu-space-base) 0;
+  width: auto;
+}
+body.-emu #sidebar #playlists #currently-playing .sound .sound-control.inactive,
+body.-emu
+  .sidebar-popout
+  #playlists
+  #currently-playing
+  .sound
+  .sound-control.inactive {
+  opacity: 0.5;
+}
+.-emu-layout
+  body.-emu
+  #sidebar
+  #playlists
+  #currently-playing
+  .sound
+  .sound-playback,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #playlists
+  #currently-playing
+  .sound
+  .sound-playback {
+  align-items: center;
+  display: flex;
+  grid-area: playback;
+  padding: 0;
+}
+body.-emu
+  #sidebar
+  #playlists
+  #currently-playing
+  .sound
+  .sound-playback
+  .sound-timer,
+body.-emu
+  .sidebar-popout
+  #playlists
+  #currently-playing
+  .sound
+  .sound-playback
+  .sound-timer {
+  color: rgba(var(--color-text-lightest), 1);
+}
+.-emu-layout
+  body.-emu
+  #sidebar
+  #playlists
+  #currently-playing
+  .sound
+  .sound-playback
+  .sound-timer,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #playlists
+  #currently-playing
+  .sound
+  .sound-playback
+  .sound-timer {
+  font-size: var(--emu-font-size-sm);
+  -webkit-margin-end: var(--emu-space-sm);
+  margin-inline-end: var(--emu-space-sm);
+}
+.-emu-layout
+  body.-emu
+  #sidebar
+  #playlists
+  #currently-playing
+  .sound
+  .sound-playback
+  .volume-icon,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #playlists
+  #currently-playing
+  .sound
+  .sound-playback
+  .volume-icon {
+  -webkit-margin-end: var(--emu-space-base);
+  margin-inline-end: var(--emu-space-base);
+}
 
-.-emu-layout body.-emu #sidebar #compendium > .directory-list, .-emu-layout
-body.-emu .sidebar-popout #compendium > .directory-list {
-  padding: var(--emu-space-sm); }
+.-emu-layout body.-emu #sidebar #compendium > .directory-list,
+.-emu-layout body.-emu .sidebar-popout #compendium > .directory-list {
+  padding: var(--emu-space-sm);
+}
 
-.-emu-layout body.-emu #sidebar #compendium .directory-item, .-emu-layout
-body.-emu .sidebar-popout #compendium .directory-item {
+.-emu-layout body.-emu #sidebar #compendium .directory-item,
+.-emu-layout body.-emu .sidebar-popout #compendium .directory-item {
   flex-wrap: wrap;
   line-height: 1;
   margin: var(--emu-space-base);
-  padding: 0 var(--emu-space-sm); }
+  padding: 0 var(--emu-space-sm);
+}
 
-.-emu-layout body.-emu #sidebar #compendium .directory-item h4, .-emu-layout
-body.-emu .sidebar-popout #compendium .directory-item h4 {
+.-emu-layout body.-emu #sidebar #compendium .directory-item h4,
+.-emu-layout body.-emu .sidebar-popout #compendium .directory-item h4 {
   align-items: center;
   display: flex;
-  width: 100%; }
+  width: 100%;
+}
 
 body.-emu #sidebar #compendium .directory-item h4 .status-icons,
 body.-emu .sidebar-popout #compendium .directory-item h4 .status-icons {
-  color: rgba(var(--color-text-lightest), 1); }
-  .-emu-layout body.-emu #sidebar #compendium .directory-item h4 .status-icons, .-emu-layout
-  body.-emu .sidebar-popout #compendium .directory-item h4 .status-icons {
-    position: relative; }
-    .-emu-layout body.-emu #sidebar #compendium .directory-item h4 .status-icons i, .-emu-layout
-    body.-emu .sidebar-popout #compendium .directory-item h4 .status-icons i {
-      margin: 0;
-      -webkit-margin-start: var(--emu-space-base);
-              margin-inline-start: var(--emu-space-base); }
+  color: rgba(var(--color-text-lightest), 1);
+}
+.-emu-layout body.-emu #sidebar #compendium .directory-item h4 .status-icons,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #compendium
+  .directory-item
+  h4
+  .status-icons {
+  position: relative;
+}
+.-emu-layout body.-emu #sidebar #compendium .directory-item h4 .status-icons i,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #compendium
+  .directory-item
+  h4
+  .status-icons
+  i {
+  margin: 0;
+  -webkit-margin-start: var(--emu-space-base);
+  margin-inline-start: var(--emu-space-base);
+}
 
 body.-emu #sidebar #compendium .directory-item .compendium-footer,
 body.-emu .sidebar-popout #compendium .directory-item .compendium-footer {
-  color: rgba(var(--color-text-lightest), 1); }
-  .-emu-layout body.-emu #sidebar #compendium .directory-item .compendium-footer, .-emu-layout
-  body.-emu .sidebar-popout #compendium .directory-item .compendium-footer {
-    flex: 0 0 auto;
-    font-size: var(--emu-font-size-md);
-    -webkit-padding-after: var(--emu-space-sm);
-            padding-block-end: var(--emu-space-sm);
-    width: 100%; }
+  color: rgba(var(--color-text-lightest), 1);
+}
+.-emu-layout body.-emu #sidebar #compendium .directory-item .compendium-footer,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #compendium
+  .directory-item
+  .compendium-footer {
+  flex: 0 0 auto;
+  font-size: var(--emu-font-size-md);
+  -webkit-padding-after: var(--emu-space-sm);
+  padding-block-end: var(--emu-space-sm);
+  width: 100%;
+}
 
 body.-emu #sidebar #compendium .compendium-type,
 body.-emu .sidebar-popout #compendium .compendium-type {
   background-color: rgba(var(--color-folder-subdirectory), 1);
   background-image: none;
-  border-radius: var(--emu-border-radius-default, 0) var(--emu-border-radius-default, 0) 0 0; }
-  .-emu-layout body.-emu #sidebar #compendium .compendium-type, .-emu-layout
-  body.-emu .sidebar-popout #compendium .compendium-type {
-    display: flex;
-    flex-direction: column;
-    -webkit-margin-after: var(--emu-space-base);
-            margin-block-end: var(--emu-space-base); }
-  body.-emu #sidebar #compendium .compendium-type h3,
-  body.-emu .sidebar-popout #compendium .compendium-type h3 {
-    background-color: rgba(var(--color-folder-header), 1);
-    background-image: none;
-    border-radius: var(--emu-border-radius-default, 0) var(--emu-border-radius-default, 0) 0 0;
-    color: rgba(var(--color-text), 1);
-    transition: background 0.3s cubic-bezier(0.075, 0.82, 0.165, 1), box-shadow 0.3s cubic-bezier(0.075, 0.82, 0.165, 1), color 0.3s cubic-bezier(0.075, 0.82, 0.165, 1); }
-    .-emu-layout body.-emu #sidebar #compendium .compendium-type h3, .-emu-layout
-    body.-emu .sidebar-popout #compendium .compendium-type h3 {
-      align-items: center;
-      border: 0;
-      cursor: default;
-      display: flex;
-      flex-wrap: nowrap;
-      font-size: var(--emu-font-size-lg);
-      line-height: 1;
-      margin: 0;
-      min-height: var(--emu-space-button);
-      padding: var(--emu-space-base) var(--emu-space-sm);
-      position: relative;
-      width: 100%; }
+  border-radius: var(--emu-border-radius-default, 0)
+    var(--emu-border-radius-default, 0) 0 0;
+}
+.-emu-layout body.-emu #sidebar #compendium .compendium-type,
+.-emu-layout body.-emu .sidebar-popout #compendium .compendium-type {
+  display: flex;
+  flex-direction: column;
+  -webkit-margin-after: var(--emu-space-base);
+  margin-block-end: var(--emu-space-base);
+}
+body.-emu #sidebar #compendium .compendium-type h3,
+body.-emu .sidebar-popout #compendium .compendium-type h3 {
+  background-color: rgba(var(--color-folder-header), 1);
+  background-image: none;
+  border-radius: var(--emu-border-radius-default, 0)
+    var(--emu-border-radius-default, 0) 0 0;
+  color: rgba(var(--color-text), 1);
+  transition: background 0.3s cubic-bezier(0.075, 0.82, 0.165, 1),
+    box-shadow 0.3s cubic-bezier(0.075, 0.82, 0.165, 1),
+    color 0.3s cubic-bezier(0.075, 0.82, 0.165, 1);
+}
+.-emu-layout body.-emu #sidebar #compendium .compendium-type h3,
+.-emu-layout body.-emu .sidebar-popout #compendium .compendium-type h3 {
+  align-items: center;
+  border: 0;
+  cursor: default;
+  display: flex;
+  flex-wrap: nowrap;
+  font-size: var(--emu-font-size-lg);
+  line-height: 1;
+  margin: 0;
+  min-height: var(--emu-space-button);
+  padding: var(--emu-space-base) var(--emu-space-sm);
+  position: relative;
+  width: 100%;
+}
 
-.-emu-layout body.-emu #sidebar #settings, .-emu-layout
-body.-emu .sidebar-popout #settings {
-  padding: var(--emu-space-sm); }
+.-emu-layout body.-emu #sidebar #settings,
+.-emu-layout body.-emu .sidebar-popout #settings {
+  padding: var(--emu-space-sm);
+}
 
-.-emu-layout body.-emu #sidebar #settings div, .-emu-layout
-body.-emu .sidebar-popout #settings div {
-  margin: 0; }
+.-emu-layout body.-emu #sidebar #settings div,
+.-emu-layout body.-emu .sidebar-popout #settings div {
+  margin: 0;
+}
 
 body.-emu #sidebar #settings h2,
 body.-emu #sidebar #settings h4,
@@ -4505,226 +13133,356 @@ body.-emu .sidebar-popout #settings h2,
 body.-emu .sidebar-popout #settings h4 {
   background: transparent;
   border: none;
-  color: rgba(var(--color-text-lightest), 1); }
-  .-emu-layout body.-emu #sidebar #settings h2, .-emu-layout
-  body.-emu #sidebar #settings h4, .-emu-layout
-  body.-emu .sidebar-popout #settings h2, .-emu-layout
-  body.-emu .sidebar-popout #settings h4 {
-    padding: 0;
-    -webkit-margin-after: var(--emu-space-sm);
-            margin-block-end: var(--emu-space-sm); }
+  color: rgba(var(--color-text-lightest), 1);
+}
+.-emu-layout body.-emu #sidebar #settings h2,
+.-emu-layout body.-emu #sidebar #settings h4,
+.-emu-layout body.-emu .sidebar-popout #settings h2,
+.-emu-layout body.-emu .sidebar-popout #settings h4 {
+  padding: 0;
+  -webkit-margin-after: var(--emu-space-sm);
+  margin-block-end: var(--emu-space-sm);
+}
 
 body.-emu #sidebar #settings h2,
 body.-emu .sidebar-popout #settings h2 {
   -webkit-border-after: rgba(var(--color-border-lighter), 1) 1px solid;
-          border-block-end: rgba(var(--color-border-lighter), 1) 1px solid; }
-  .-emu-layout body.-emu #sidebar #settings h2, .-emu-layout
-  body.-emu .sidebar-popout #settings h2 {
-    font-size: var(--emu-font-size-xl);
-    -webkit-margin-before: var(--emu-space-sm);
-            margin-block-start: var(--emu-space-sm); }
+  border-block-end: rgba(var(--color-border-lighter), 1) 1px solid;
+}
+.-emu-layout body.-emu #sidebar #settings h2,
+.-emu-layout body.-emu .sidebar-popout #settings h2 {
+  font-size: var(--emu-font-size-xl);
+  -webkit-margin-before: var(--emu-space-sm);
+  margin-block-start: var(--emu-space-sm);
+}
 
 body.-emu #sidebar #settings h4,
 body.-emu .sidebar-popout #settings h4 {
-  color: rgba(var(--color-primary), 1); }
-  .-emu-layout body.-emu #sidebar #settings h4, .-emu-layout
-  body.-emu .sidebar-popout #settings h4 {
-    font-size: var(--emu-font-size-lg); }
+  color: rgba(var(--color-primary), 1);
+}
+.-emu-layout body.-emu #sidebar #settings h4,
+.-emu-layout body.-emu .sidebar-popout #settings h4 {
+  font-size: var(--emu-font-size-lg);
+}
 
-.-emu-layout body.-emu #sidebar #settings button, .-emu-layout
-body.-emu .sidebar-popout #settings button {
+.-emu-layout body.-emu #sidebar #settings button,
+.-emu-layout body.-emu .sidebar-popout #settings button {
   margin: 0;
   -webkit-margin-after: var(--emu-space-base);
-          margin-block-end: var(--emu-space-base); }
+  margin-block-end: var(--emu-space-base);
+}
 
 body.-emu #sidebar #settings #game-details,
 body.-emu .sidebar-popout #settings #game-details {
-  color: rgba(var(--color-text-lightest), 1); }
-  .-emu-layout body.-emu #sidebar #settings #game-details, .-emu-layout
-  body.-emu .sidebar-popout #settings #game-details {
-    margin: 0;
-    padding: 0; }
+  color: rgba(var(--color-text-lightest), 1);
+}
+.-emu-layout body.-emu #sidebar #settings #game-details,
+.-emu-layout body.-emu .sidebar-popout #settings #game-details {
+  margin: 0;
+  padding: 0;
+}
 
 .-emu-layout body.-emu .sheet.active-effect-sheet .sheet-header {
   -webkit-margin-after: var(--emu-space-base);
-          margin-block-end: var(--emu-space-base); }
+  margin-block-end: var(--emu-space-base);
+}
 
 body.-emu .sheet.active-effect-sheet .sheet-header h1 {
-  border: none; }
-  .-emu-layout body.-emu .sheet.active-effect-sheet .sheet-header h1 {
-    margin: 0; }
+  border: none;
+}
+.-emu-layout body.-emu .sheet.active-effect-sheet .sheet-header h1 {
+  margin: 0;
+}
 
-.-emu-layout body.-emu .sheet.active-effect-sheet .changes-list li:nth-of-type(even) {
-  background-color: rgba(var(--color-background-light), 0.1); }
+.-emu-layout
+  body.-emu
+  .sheet.active-effect-sheet
+  .changes-list
+  li:nth-of-type(even) {
+  background-color: rgba(var(--color-background-light), 0.1);
+}
 
 .-emu-layout body.-emu .window-app[id*="actor-flags-"] form {
-  overflow: hidden; }
-  .-emu-layout body.-emu .window-app[id*="actor-flags-"] form::after {
-    display: none; }
+  overflow: hidden;
+}
+.-emu-layout body.-emu .window-app[id*="actor-flags-"] form::after {
+  display: none;
+}
 
 .-emu-layout body.-emu .window-app[id*="actor-flags-"] form .form-body {
   flex: 1 1 auto;
-  overflow: auto; }
+  overflow: auto;
+}
 
 body.-emu .window-app[id*="actor-flags-"] form .form-footer {
   -webkit-border-before: rgba(var(--color-border), 1) 1px solid;
-          border-block-start: rgba(var(--color-border), 1) 1px solid; }
-  .-emu-layout body.-emu .window-app[id*="actor-flags-"] form .form-footer {
-    flex: 0 0 auto;
-    -webkit-padding-before: var(--emu-space-sm);
-            padding-block-start: var(--emu-space-sm); }
+  border-block-start: rgba(var(--color-border), 1) 1px solid;
+}
+.-emu-layout body.-emu .window-app[id*="actor-flags-"] form .form-footer {
+  flex: 0 0 auto;
+  -webkit-padding-before: var(--emu-space-sm);
+  padding-block-start: var(--emu-space-sm);
+}
 
 body.-emu #av-config form .sheet-tabs {
   -webkit-border-after: rgba(var(--color-primary), 1) 2px solid;
-          border-block-end: rgba(var(--color-primary), 1) 2px solid; }
-  .-emu-layout body.-emu #av-config form .sheet-tabs {
-    flex: 0 0 auto; }
+  border-block-end: rgba(var(--color-primary), 1) 2px solid;
+}
+.-emu-layout body.-emu #av-config form .sheet-tabs {
+  flex: 0 0 auto;
+}
 
 .-emu-layout body.-emu #av-config form > button {
   -webkit-margin-before: var(--emu-space-sm);
-          margin-block-start: var(--emu-space-sm); }
+  margin-block-start: var(--emu-space-sm);
+}
 
 .-emu-layout body.-emu .window-app[id*="chat-popout-"] .window-content {
-  padding: 0; }
+  padding: 0;
+}
 
 body.-emu .window-app[id*="chat-popout-"] .window-content .chat-message {
   background: none;
-  border: none; }
-  .-emu-layout body.-emu .window-app[id*="chat-popout-"] .window-content .chat-message {
-    margin: 0;
-    padding: var(--emu-space-sm); }
+  border: none;
+}
+.-emu-layout
+  body.-emu
+  .window-app[id*="chat-popout-"]
+  .window-content
+  .chat-message {
+  margin: 0;
+  padding: var(--emu-space-sm);
+}
 
 .-emu-layout body.-emu #client-settings.window-app.form .window-content {
-  padding: var(--emu-space-sm); }
+  padding: var(--emu-space-sm);
+}
 
 body.-emu #client-settings.window-app.form nav.tabs {
   -webkit-border-after: rgba(var(--color-primary), 1) 2px solid;
-          border-block-end: rgba(var(--color-primary), 1) 2px solid; }
-  .-emu-layout body.-emu #client-settings.window-app.form nav.tabs {
-    flex: 0 0 auto;
-    height: initial;
-    line-height: initial; }
-  .-emu-layout body.-emu #client-settings.window-app.form nav.tabs .item {
-    padding: var(--emu-space-sm); }
+  border-block-end: rgba(var(--color-primary), 1) 2px solid;
+}
+.-emu-layout body.-emu #client-settings.window-app.form nav.tabs {
+  flex: 0 0 auto;
+  height: initial;
+  line-height: initial;
+}
+.-emu-layout body.-emu #client-settings.window-app.form nav.tabs .item {
+  padding: var(--emu-space-sm);
+}
 
 body.-emu #client-settings.window-app.form #config-tabs {
-  border: none; }
-  .-emu-layout body.-emu #client-settings.window-app.form #config-tabs {
-    flex: 1 1 auto;
-    overflow-y: auto; }
+  border: none;
+}
+.-emu-layout body.-emu #client-settings.window-app.form #config-tabs {
+  flex: 1 1 auto;
+  overflow-y: auto;
+}
 
-.-emu-layout body.-emu #client-settings.window-app.form section.content h2.module-header {
+.-emu-layout
+  body.-emu
+  #client-settings.window-app.form
+  section.content
+  h2.module-header {
   -webkit-margin-before: var(--emu-space-md);
-          margin-block-start: var(--emu-space-md);
+  margin-block-start: var(--emu-space-md);
   -webkit-margin-after: var(--emu-space-base);
-          margin-block-end: var(--emu-space-base); }
+  margin-block-end: var(--emu-space-base);
+}
 
-.-emu-layout body.-emu #client-settings.window-app.form section.content .submenu > button {
+.-emu-layout
+  body.-emu
+  #client-settings.window-app.form
+  section.content
+  .submenu
+  > button {
   height: initial;
-  font-size: var(--emu-font-size-lg); }
-  .-emu-layout body.-emu #client-settings.window-app.form section.content .submenu > button label {
-    padding: 0;
-    pointer-events: none; }
+  font-size: var(--emu-font-size-lg);
+}
+.-emu-layout
+  body.-emu
+  #client-settings.window-app.form
+  section.content
+  .submenu
+  > button
+  label {
+  padding: 0;
+  pointer-events: none;
+}
 
-.-emu-layout body.-emu #client-settings.window-app.form section.content .submenu > label {
-  line-height: initial; }
+.-emu-layout
+  body.-emu
+  #client-settings.window-app.form
+  section.content
+  .submenu
+  > label {
+  line-height: initial;
+}
 
 body.-emu #client-settings.window-app.form section.content .settings-list {
-  border: none; }
-  .-emu-layout body.-emu #client-settings.window-app.form section.content .settings-list {
-    max-height: 100%;
-    overflow: initial;
-    padding: 0; }
+  border: none;
+}
+.-emu-layout
+  body.-emu
+  #client-settings.window-app.form
+  section.content
+  .settings-list {
+  max-height: 100%;
+  overflow: initial;
+  padding: 0;
+}
 
-.-emu-layout body.-emu #client-settings.window-app.form form .form-group button label {
-  font-size: var(--emu-font-size-lg); }
+.-emu-layout
+  body.-emu
+  #client-settings.window-app.form
+  form
+  .form-group
+  button
+  label {
+  font-size: var(--emu-font-size-lg);
+}
 
-.-emu-layout body.-emu #client-settings.window-app.form .form-group.submenu .notes {
+.-emu-layout
+  body.-emu
+  #client-settings.window-app.form
+  .form-group.submenu
+  .notes {
   -webkit-margin-before: var(--emu-space-sm);
-          margin-block-start: var(--emu-space-sm); }
+  margin-block-start: var(--emu-space-sm);
+}
 
 .-emu-layout body.-emu #client-settings.window-app.form .sheet-footer {
   flex: 0 0 auto;
   flex-wrap: nowrap;
   padding: 0;
   -webkit-padding-before: var(--emu-space-sm);
-          padding-block-start: var(--emu-space-sm); }
+  padding-block-start: var(--emu-space-sm);
+}
 
 body.-emu #client-settings.window-app.form .sheet-footer button {
-  border: none; }
-  .-emu-layout body.-emu #client-settings.window-app.form .sheet-footer button {
-    margin: 0; }
-    .-emu-layout body.-emu #client-settings.window-app.form .sheet-footer button + button {
-      -webkit-margin-start: var(--emu-space-base);
-              margin-inline-start: var(--emu-space-base); }
+  border: none;
+}
+.-emu-layout body.-emu #client-settings.window-app.form .sheet-footer button {
+  margin: 0;
+}
+.-emu-layout
+  body.-emu
+  #client-settings.window-app.form
+  .sheet-footer
+  button
+  + button {
+  -webkit-margin-start: var(--emu-space-base);
+  margin-inline-start: var(--emu-space-base);
+}
 
 .-emu-layout body.-emu .sheet[id*="combatant-config-"] .form-group + footer {
   -webkit-margin-before: var(--emu-space-sm);
-          margin-block-start: var(--emu-space-sm); }
+  margin-block-start: var(--emu-space-sm);
+}
 
-.-emu-layout body.-emu .sheet[id*="combatant-config-"] .form-fields label.checkbox input[type="checkbox"] {
+.-emu-layout
+  body.-emu
+  .sheet[id*="combatant-config-"]
+  .form-fields
+  label.checkbox
+  input[type="checkbox"] {
   -webkit-margin-end: var(--emu-space-base);
-          margin-inline-end: var(--emu-space-base); }
+  margin-inline-end: var(--emu-space-base);
+}
 
 .-emu-layout body.-emu #default-token-config .sheet-footer {
   bottom: 0;
   flex: 0 0 auto;
   padding: 0;
   -webkit-padding-before: var(--emu-space-sm);
-          padding-block-start: var(--emu-space-sm);
+  padding-block-start: var(--emu-space-sm);
   position: -webkit-sticky;
-  position: sticky; }
+  position: sticky;
+}
 
 body.-emu #drawing-config form .sheet-tabs {
   -webkit-border-after: rgba(var(--color-primary), 1) 2px solid;
-          border-block-end: rgba(var(--color-primary), 1) 2px solid; }
-  .-emu-layout body.-emu #drawing-config form .sheet-tabs {
-    flex: 0 0 auto;
-    line-height: 1; }
+  border-block-end: rgba(var(--color-primary), 1) 2px solid;
+}
+.-emu-layout body.-emu #drawing-config form .sheet-tabs {
+  flex: 0 0 auto;
+  line-height: 1;
+}
 
 .-emu-layout body.-emu #drawing-config form > .tab {
   -webkit-padding-before: var(--emu-space-sm);
-          padding-block-start: var(--emu-space-sm); }
+  padding-block-start: var(--emu-space-sm);
+}
 
 .-emu-layout body.-emu .filepicker.window-app .filepicker-header {
   flex: 0 0 auto;
-  position: relative; }
+  position: relative;
+}
 
 body.-emu .filepicker.window-app .filepicker-header .units {
-  color: rgba(var(--color-text), 1); }
-  .-emu-layout body.-emu .filepicker.window-app .filepicker-header .units {
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    display: block;
-    flex: 0 0 auto;
-    font-size: var(--emu-font-size-sm);
-    line-height: initial;
-    margin: 0 var(--emu-space-base); }
+  color: rgba(var(--color-text), 1);
+}
+.-emu-layout body.-emu .filepicker.window-app .filepicker-header .units {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  display: block;
+  flex: 0 0 auto;
+  font-size: var(--emu-font-size-sm);
+  line-height: initial;
+  margin: 0 var(--emu-space-base);
+}
 
-.-emu-layout body.-emu .filepicker.window-app .filepicker-header .current-dir button > i {
-  margin: 0; }
+.-emu-layout
+  body.-emu
+  .filepicker.window-app
+  .filepicker-header
+  .current-dir
+  button
+  > i {
+  margin: 0;
+}
 
-.-emu-layout body.-emu .filepicker.window-app .filepicker-header .current-dir button + .form-fields {
-  margin: 0 var(--emu-space-base); }
+.-emu-layout
+  body.-emu
+  .filepicker.window-app
+  .filepicker-header
+  .current-dir
+  button
+  + .form-fields {
+  margin: 0 var(--emu-space-base);
+}
 
 .-emu-layout body.-emu .filepicker.window-app .filepicker-body {
   flex: 1 1 auto;
   max-height: 100%;
   min-height: 12.5rem;
   overflow-y: auto;
-  position: relative; }
+  position: relative;
+}
 
 .-emu-layout body.-emu .filepicker.window-app .filepicker-body.thumbs .file {
-  padding: var(--emu-space-base); }
-  .-emu-layout body.-emu .filepicker.window-app .filepicker-body.thumbs .file img {
-    -webkit-margin-end: var(--emu-space-base);
-            margin-inline-end: var(--emu-space-base);
-    max-width: var(--emu-space-button);
-    max-height: var(--emu-space-button); }
+  padding: var(--emu-space-base);
+}
+.-emu-layout
+  body.-emu
+  .filepicker.window-app
+  .filepicker-body.thumbs
+  .file
+  img {
+  -webkit-margin-end: var(--emu-space-base);
+  margin-inline-end: var(--emu-space-base);
+  max-width: var(--emu-space-button);
+  max-height: var(--emu-space-button);
+}
 
-.-emu-layout body.-emu .filepicker.window-app .filepicker-body.tiles .tiles-list {
-  grid-template-columns: repeat(5, 20%); }
+.-emu-layout
+  body.-emu
+  .filepicker.window-app
+  .filepicker-body.tiles
+  .tiles-list {
+  grid-template-columns: repeat(5, 20%);
+}
 
 .-emu-layout body.-emu .filepicker.window-app .filepicker-body.tiles .file {
   align-items: center;
@@ -4736,78 +13494,107 @@ body.-emu .filepicker.window-app .filepicker-header .units {
   max-width: 100%;
   min-height: 6.25rem;
   padding: var(--emu-space-base);
-  width: 100%; }
-  .-emu-layout body.-emu .filepicker.window-app .filepicker-body.tiles .file img {
-    max-height: 100%;
-    max-width: 100%; }
+  width: 100%;
+}
+.-emu-layout body.-emu .filepicker.window-app .filepicker-body.tiles .file img {
+  max-height: 100%;
+  max-width: 100%;
+}
 
 body.-emu .filepicker.window-app .filepicker-body.images .file {
   border: 0;
   -webkit-border-after: rgba(var(--color-border), 1) 1px solid;
-          border-block-end: rgba(var(--color-border), 1) 1px solid; }
-  .-emu-layout body.-emu .filepicker.window-app .filepicker-body.images .file {
-    display: grid;
-    grid-template-areas: "title" "image";
-    grid-template-rows: -webkit-min-content 1fr;
-    grid-template-rows: min-content 1fr;
-    justify-content: center;
-    padding: var(--emu-space-base); }
-  body.-emu .filepicker.window-app .filepicker-body.images .file .filename {
-    background-color: rgba(var(--color-background-darkest), 0.8);
-    border-radius: 0;
-    color: rgba(var(--color-text-lightest), 1); }
-    .-emu-layout body.-emu .filepicker.window-app .filepicker-body.images .file .filename {
-      max-width: 100%;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
-      display: block;
-      font-size: var(--emu-font-size-md);
-      grid-area: title;
-      left: auto;
-      line-height: 1;
-      margin: 0;
-      padding: var(--emu-space-base);
-      position: relative;
-      text-align: center;
-      width: 100%; }
-  .-emu-layout body.-emu .filepicker.window-app .filepicker-body.images .file img {
-    grid-area: image; }
+  border-block-end: rgba(var(--color-border), 1) 1px solid;
+}
+.-emu-layout body.-emu .filepicker.window-app .filepicker-body.images .file {
+  display: grid;
+  grid-template-areas: "title" "image";
+  grid-template-rows: -webkit-min-content 1fr;
+  grid-template-rows: min-content 1fr;
+  justify-content: center;
+  padding: var(--emu-space-base);
+}
+body.-emu .filepicker.window-app .filepicker-body.images .file .filename {
+  background-color: rgba(var(--color-background-darkest), 0.8);
+  border-radius: 0;
+  color: rgba(var(--color-text-lightest), 1);
+}
+.-emu-layout
+  body.-emu
+  .filepicker.window-app
+  .filepicker-body.images
+  .file
+  .filename {
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  display: block;
+  font-size: var(--emu-font-size-md);
+  grid-area: title;
+  left: auto;
+  line-height: 1;
+  margin: 0;
+  padding: var(--emu-space-base);
+  position: relative;
+  text-align: center;
+  width: 100%;
+}
+.-emu-layout
+  body.-emu
+  .filepicker.window-app
+  .filepicker-body.images
+  .file
+  img {
+  grid-area: image;
+}
 
 .-emu-layout body.-emu .filepicker.window-app form.filepicker-body {
   display: grid;
   grid-template-rows: -webkit-min-content 1fr -webkit-min-content;
-  grid-template-rows: min-content 1fr min-content; }
+  grid-template-rows: min-content 1fr min-content;
+}
 
 .-emu-layout body.-emu .filepicker.window-app section.filepicker-body {
   display: flex;
   flex-direction: column;
   -webkit-margin-before: var(--emu-space-sm);
-          margin-block-start: var(--emu-space-sm);
-  position: relative; }
+  margin-block-start: var(--emu-space-sm);
+  position: relative;
+}
 
 .-emu-layout body.-emu .filepicker.window-app .filepicker-footer {
   flex: 0 0 auto;
   -webkit-margin-before: var(--emu-space-sm);
-          margin-block-start: var(--emu-space-sm);
-  position: relative; }
-  .-emu-layout body.-emu .filepicker.window-app .filepicker-footer:empty {
-    display: none; }
+  margin-block-start: var(--emu-space-sm);
+  position: relative;
+}
+.-emu-layout body.-emu .filepicker.window-app .filepicker-footer:empty {
+  display: none;
+}
 
 .-emu-layout body.-emu .filepicker.window-app .display-modes .display-mode {
   flex: 1 1 auto;
   -webkit-margin-start: var(--emu-space-base);
-          margin-inline-start: var(--emu-space-base);
-  width: auto; }
-  .-emu-layout body.-emu .filepicker.window-app .display-modes .display-mode:first-child {
-    -webkit-margin-start: 0;
-            margin-inline-start: 0; }
-  .-emu-layout body.-emu .filepicker.window-app .display-modes .display-mode > i {
-    margin: 0; }
+  margin-inline-start: var(--emu-space-base);
+  width: auto;
+}
+.-emu-layout
+  body.-emu
+  .filepicker.window-app
+  .display-modes
+  .display-mode:first-child {
+  -webkit-margin-start: 0;
+  margin-inline-start: 0;
+}
+.-emu-layout body.-emu .filepicker.window-app .display-modes .display-mode > i {
+  margin: 0;
+}
 
 body.-emu .filepicker.window-app .display-modes .display-mode.active {
   background-color: rgba(var(--color-primary), 1);
-  color: rgba(var(--color-text-lightest), 1); }
+  color: rgba(var(--color-text-lightest), 1);
+}
 
 .-emu-layout body.-emu .filepicker.window-app .directory {
   background: none;
@@ -4821,347 +13608,692 @@ body.-emu .filepicker.window-app .display-modes .display-mode.active {
   overflow-y: auto;
   position: relative;
   margin: 0;
-  width: 100%; }
-  .-emu-layout body.-emu .filepicker.window-app .directory + .directory {
-    border: rgba(var(--color-folder-directory), 1) 1px solid;
-    -webkit-margin-before: var(--emu-space-base);
-            margin-block-start: var(--emu-space-base);
-    padding: var(--emu-space-base); }
+  width: 100%;
+}
+.-emu-layout body.-emu .filepicker.window-app .directory + .directory {
+  border: rgba(var(--color-folder-directory), 1) 1px solid;
+  -webkit-margin-before: var(--emu-space-base);
+  margin-block-start: var(--emu-space-base);
+  padding: var(--emu-space-base);
+}
 
 body.-emu .filepicker.window-app .directory .dir,
 body.-emu .filepicker.window-app .directory .file {
   text-shadow: none;
-  transition: background 0.3s cubic-bezier(0.075, 0.82, 0.165, 1), box-shadow 0.3s cubic-bezier(0.075, 0.82, 0.165, 1), color 0.3s cubic-bezier(0.075, 0.82, 0.165, 1); }
-  .-emu-layout body.-emu .filepicker.window-app .directory .dir, .-emu-layout
-  body.-emu .filepicker.window-app .directory .file {
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    align-items: center;
-    cursor: pointer;
-    display: flex;
-    font-size: var(--emu-font-size-md);
-    font-weight: normal;
-    height: auto;
-    line-height: var(--emu-space-button);
-    padding: 0 var(--emu-space-sm);
-    position: relative; }
-  body.-emu .filepicker.window-app .directory .dir:last-child,
-  body.-emu .filepicker.window-app .directory .file:last-child {
-    -webkit-border-after: 0;
-            border-block-end: 0; }
-  body.-emu .filepicker.window-app .directory .dir:hover,
-  body.-emu .filepicker.window-app .directory .file:hover {
-    background-color: rgba(var(--color-primary), 1);
-    box-shadow: inset 0 0 0 2px rgba(var(--color-white), 1);
-    color: rgba(var(--color-text-lightest), 1); }
-  body.-emu .filepicker.window-app .directory .dir:focus,
-  body.-emu .filepicker.window-app .directory .file:focus {
-    box-shadow: inset 0 0 0 2px rgba(var(--color-primary), 1), inset 0 0 0 3px rgba(var(--color-white), 1), 0 1px 2px 0 rgba(var(--color-black), 0.3); }
+  transition: background 0.3s cubic-bezier(0.075, 0.82, 0.165, 1),
+    box-shadow 0.3s cubic-bezier(0.075, 0.82, 0.165, 1),
+    color 0.3s cubic-bezier(0.075, 0.82, 0.165, 1);
+}
+.-emu-layout body.-emu .filepicker.window-app .directory .dir,
+.-emu-layout body.-emu .filepicker.window-app .directory .file {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  align-items: center;
+  cursor: pointer;
+  display: flex;
+  font-size: var(--emu-font-size-md);
+  font-weight: normal;
+  height: auto;
+  line-height: var(--emu-space-button);
+  padding: 0 var(--emu-space-sm);
+  position: relative;
+}
+body.-emu .filepicker.window-app .directory .dir:last-child,
+body.-emu .filepicker.window-app .directory .file:last-child {
+  -webkit-border-after: 0;
+  border-block-end: 0;
+}
+body.-emu .filepicker.window-app .directory .dir:hover,
+body.-emu .filepicker.window-app .directory .file:hover {
+  background-color: rgba(var(--color-primary), 1);
+  box-shadow: inset 0 0 0 2px rgba(var(--color-white), 1);
+  color: rgba(var(--color-text-lightest), 1);
+}
+body.-emu .filepicker.window-app .directory .dir:focus,
+body.-emu .filepicker.window-app .directory .file:focus {
+  box-shadow: inset 0 0 0 2px rgba(var(--color-primary), 1),
+    inset 0 0 0 3px rgba(var(--color-white), 1),
+    0 1px 2px 0 rgba(var(--color-black), 0.3);
+}
 
 body.-emu .filepicker.window-app .directory .dir {
   background-color: rgba(var(--color-folder-header), 0.9);
   -webkit-border-after: rgba(var(--color-border), 1) 1px solid;
-          border-block-end: rgba(var(--color-border), 1) 1px solid;
-  color: rgba(var(--color-text), 1); }
+  border-block-end: rgba(var(--color-border), 1) 1px solid;
+  color: rgba(var(--color-text), 1);
+}
 
 body.-emu .filepicker.window-app .directory .file {
   background-color: rgba(var(--color-folder-directory), 0.9);
   -webkit-border-after: rgba(var(--color-border), 1) 1px solid;
-          border-block-end: rgba(var(--color-border), 1) 1px solid;
-  color: rgba(var(--color-text-lightest), 1); }
+  border-block-end: rgba(var(--color-border), 1) 1px solid;
+  color: rgba(var(--color-text-lightest), 1);
+}
 
-.-emu-layout body.-emu .sheet[id*="folder-edit-"] label.checkbox + label.checkbox {
+.-emu-layout
+  body.-emu
+  .sheet[id*="folder-edit-"]
+  label.checkbox
+  + label.checkbox {
   -webkit-margin-start: var(--emu-space-sm);
-          margin-inline-start: var(--emu-space-sm); }
+  margin-inline-start: var(--emu-space-sm);
+}
 
 .-emu-layout body.-emu .journal-sheet.sheet.window-app .window-content form {
   display: flex;
   flex-direction: row;
   flex-wrap: wrap;
-  padding: 0; }
-  .-emu-layout body.-emu .journal-sheet.sheet.window-app .window-content form > * {
-    flex: 0 0 100%; }
-  .-emu-layout body.-emu .journal-sheet.sheet.window-app .window-content form > input[type="text"] {
-    flex: 1 1 calc(70% - var(--emu-space-base)); }
-  .-emu-layout body.-emu .journal-sheet.sheet.window-app .window-content form > select {
-    flex: 1 1 calc(30% - 2.25rem);
-    -webkit-margin-start: var(--emu-space-base);
-            margin-inline-start: var(--emu-space-base);
-    -webkit-margin-end: 2.25rem;
-            margin-inline-end: 2.25rem; }
-  .-emu-layout body.-emu .journal-sheet.sheet.window-app .window-content form > button {
-    height: var(--emu-space-button);
-    -webkit-margin-before: 0;
-            margin-block-start: 0;
-    max-width: 100%; }
+  padding: 0;
+}
+.-emu-layout
+  body.-emu
+  .journal-sheet.sheet.window-app
+  .window-content
+  form
+  > * {
+  flex: 0 0 100%;
+}
+.-emu-layout
+  body.-emu
+  .journal-sheet.sheet.window-app
+  .window-content
+  form
+  > input[type="text"] {
+  flex: 1 1 calc(70% - var(--emu-space-base));
+}
+.-emu-layout
+  body.-emu
+  .journal-sheet.sheet.window-app
+  .window-content
+  form
+  > select {
+  flex: 1 1 calc(30% - 2.25rem);
+  -webkit-margin-start: var(--emu-space-base);
+  margin-inline-start: var(--emu-space-base);
+  -webkit-margin-end: 2.25rem;
+  margin-inline-end: 2.25rem;
+}
+.-emu-layout
+  body.-emu
+  .journal-sheet.sheet.window-app
+  .window-content
+  form
+  > button {
+  height: var(--emu-space-button);
+  -webkit-margin-before: 0;
+  margin-block-start: 0;
+  max-width: 100%;
+}
 
-.-emu-layout.-emu-compact body.-emu .journal-sheet.sheet.window-app .window-content form > select {
+.-emu-layout.-emu-compact
+  body.-emu
+  .journal-sheet.sheet.window-app
+  .window-content
+  form
+  > select {
   flex: 1 1 calc(30% - 1.75rem);
   -webkit-margin-end: 1.75rem;
-          margin-inline-end: 1.75rem; }
+  margin-inline-end: 1.75rem;
+}
 
-.-emu-layout body.-emu .journal-sheet.sheet.window-app .window-content form .editor {
+.-emu-layout
+  body.-emu
+  .journal-sheet.sheet.window-app
+  .window-content
+  form
+  .editor {
   height: calc(100% - 4.375rem);
   -webkit-margin-before: var(--emu-space-base);
-          margin-block-start: var(--emu-space-base);
-  overflow: visible; }
+  margin-block-start: var(--emu-space-base);
+  overflow: visible;
+}
 
-.-emu-layout.-emu-compact body.-emu .journal-sheet.sheet.window-app .window-content form .editor {
-  height: calc(100% - 3.625rem); }
+.-emu-layout.-emu-compact
+  body.-emu
+  .journal-sheet.sheet.window-app
+  .window-content
+  form
+  .editor {
+  height: calc(100% - 3.625rem);
+}
 
-.-emu-layout body.-emu .journal-sheet.sheet.window-app .window-content .editor-edit {
+.-emu-layout
+  body.-emu
+  .journal-sheet.sheet.window-app
+  .window-content
+  .editor-edit {
   display: inline-flex;
   height: var(--emu-space-button);
   position: absolute;
   right: 0;
   top: -2.25rem;
-  width: var(--emu-space-button); }
-  .-emu-layout body.-emu .journal-sheet.sheet.window-app .window-content .editor-edit > i {
-    margin: 0; }
+  width: var(--emu-space-button);
+}
+.-emu-layout
+  body.-emu
+  .journal-sheet.sheet.window-app
+  .window-content
+  .editor-edit
+  > i {
+  margin: 0;
+}
 
-.-emu-layout.-emu-compact body.-emu .journal-sheet.sheet.window-app .window-content .editor-edit {
-  top: -1.75rem; }
+.-emu-layout.-emu-compact
+  body.-emu
+  .journal-sheet.sheet.window-app
+  .window-content
+  .editor-edit {
+  top: -1.75rem;
+}
 
-body.-emu .journal-sheet.sheet.window-app .window-content .lightbox-image ~ .form-group.title,
-body.-emu .journal-sheet.sheet.window-app .window-content .lightbox-image ~ .form-group.picker {
-  background-color: transparent; }
-  body.-emu .journal-sheet.sheet.window-app .window-content .lightbox-image ~ .form-group.title input,
-  body.-emu .journal-sheet.sheet.window-app .window-content .lightbox-image ~ .form-group.picker input {
-    background-color: rgba(var(--color-background-lightest), 1); }
+body.-emu
+  .journal-sheet.sheet.window-app
+  .window-content
+  .lightbox-image
+  ~ .form-group.title,
+body.-emu
+  .journal-sheet.sheet.window-app
+  .window-content
+  .lightbox-image
+  ~ .form-group.picker {
+  background-color: transparent;
+}
+body.-emu
+  .journal-sheet.sheet.window-app
+  .window-content
+  .lightbox-image
+  ~ .form-group.title
+  input,
+body.-emu
+  .journal-sheet.sheet.window-app
+  .window-content
+  .lightbox-image
+  ~ .form-group.picker
+  input {
+  background-color: rgba(var(--color-background-lightest), 1);
+}
 
 body.-emu .sheet[id*="macro-config-"] .sheet-header h1 {
   -webkit-border-after: none;
-          border-block-end: none; }
+  border-block-end: none;
+}
 
 .-emu-layout body.-emu #module-management {
-  min-height: 0; }
+  min-height: 0;
+}
 
 .-emu-layout body.-emu #module-management .list-filters .filter {
-  font-weight: normal; }
+  font-weight: normal;
+}
 
 .-emu-layout body.-emu #module-management .list-filters input {
   -webkit-margin-end: var(--emu-space-base);
-          margin-inline-end: var(--emu-space-base);
+  margin-inline-end: var(--emu-space-base);
   -webkit-margin-after: var(--emu-space-base);
-          margin-block-end: var(--emu-space-base); }
+  margin-block-end: var(--emu-space-base);
+}
 
 .-emu-layout body.-emu #module-management .list-filters .expand {
   height: auto;
   justify-content: center;
   margin: 0;
   -webkit-margin-start: var(--emu-space-base);
-          margin-inline-start: var(--emu-space-base);
+  margin-inline-start: var(--emu-space-base);
   -webkit-margin-after: var(--emu-space-base);
-          margin-block-end: var(--emu-space-base);
-  padding: 0; }
-  .-emu-layout body.-emu #module-management .list-filters .expand > i {
-    margin: 0; }
+  margin-block-end: var(--emu-space-base);
+  padding: 0;
+}
+.-emu-layout body.-emu #module-management .list-filters .expand > i {
+  margin: 0;
+}
 
 .-emu-layout body.-emu #module-management .package-list {
   border: none;
   height: 37.5rem;
   margin: 0;
   max-height: initial;
-  padding: var(--emu-space-sm) 0; }
+  padding: var(--emu-space-sm) 0;
+}
 
 body.-emu #module-management .package {
   -webkit-border-after: rgba(var(--color-border), 1) 1px solid;
-          border-block-end: rgba(var(--color-border), 1) 1px solid; }
-  .-emu-layout body.-emu #module-management .package {
-    padding: var(--emu-space-sm); }
-  body.-emu #module-management .package[data-module-name="ernies-modern-layout"] {
-    background-color: rgba(var(--color-primary), 0.8); }
-    body.-emu #module-management .package[data-module-name="ernies-modern-layout"] a,
-    body.-emu #module-management .package[data-module-name="ernies-modern-layout"] .package-title,
-    body.-emu #module-management .package[data-module-name="ernies-modern-layout"] .package-description,
-    body.-emu #module-management .package[data-module-name="ernies-modern-layout"] .package-metadata {
-      color: rgba(var(--color-text-lightest), 1); }
-  body.-emu #module-management .package:last-child {
-    -webkit-border-after: none;
-            border-block-end: none; }
-  body.-emu #module-management .package .tag {
-    border: none;
-    border-radius: var(--emu-border-radius-controls, 0);
-    color: rgba(var(--color-text-lightest), 1); }
-    .-emu-layout body.-emu #module-management .package .tag {
-      align-items: center;
-      display: inline-flex;
-      font-size: var(--emu-font-size-sm);
-      height: auto;
-      justify-content: center;
-      line-height: initial;
-      margin: 0;
-      -webkit-margin-start: var(--emu-space-xs);
-              margin-inline-start: var(--emu-space-xs);
-      padding: var(--emu-space-base); }
+  border-block-end: rgba(var(--color-border), 1) 1px solid;
+}
+.-emu-layout body.-emu #module-management .package {
+  padding: var(--emu-space-sm);
+}
+body.-emu #module-management .package[data-module-name="ernies-modern-layout"] {
+  background-color: rgba(var(--color-primary), 0.8);
+}
+body.-emu
+  #module-management
+  .package[data-module-name="ernies-modern-layout"]
+  a,
+body.-emu
+  #module-management
+  .package[data-module-name="ernies-modern-layout"]
+  .package-title,
+body.-emu
+  #module-management
+  .package[data-module-name="ernies-modern-layout"]
+  .package-description,
+body.-emu
+  #module-management
+  .package[data-module-name="ernies-modern-layout"]
+  .package-metadata {
+  color: rgba(var(--color-text-lightest), 1);
+}
+body.-emu #module-management .package:last-child {
+  -webkit-border-after: none;
+  border-block-end: none;
+}
+body.-emu #module-management .package .tag {
+  border: none;
+  border-radius: var(--emu-border-radius-controls, 0);
+  color: rgba(var(--color-text-lightest), 1);
+}
+.-emu-layout body.-emu #module-management .package .tag {
+  align-items: center;
+  display: inline-flex;
+  font-size: var(--emu-font-size-sm);
+  height: auto;
+  justify-content: center;
+  line-height: initial;
+  margin: 0;
+  -webkit-margin-start: var(--emu-space-xs);
+  margin-inline-start: var(--emu-space-xs);
+  padding: var(--emu-space-base);
+}
 
 .-emu-layout body.-emu #module-management .package-overview {
-  align-items: center; }
+  align-items: center;
+}
 
 body.-emu #module-management .package-title {
-  color: rgba(var(--color-text), 1); }
-  .-emu-layout body.-emu #module-management .package-title {
-    align-items: center;
-    display: flex;
-    font-size: var(--emu-font-size-lg);
-    font-weight: normal;
-    height: initial;
-    line-height: 1;
-    text-decoration: none; }
-  .-emu-layout body.-emu #module-management .package-title input {
-    -webkit-margin-end: var(--emu-space-sm);
-            margin-inline-end: var(--emu-space-sm); }
+  color: rgba(var(--color-text), 1);
+}
+.-emu-layout body.-emu #module-management .package-title {
+  align-items: center;
+  display: flex;
+  font-size: var(--emu-font-size-lg);
+  font-weight: normal;
+  height: initial;
+  line-height: 1;
+  text-decoration: none;
+}
+.-emu-layout body.-emu #module-management .package-title input {
+  -webkit-margin-end: var(--emu-space-sm);
+  margin-inline-end: var(--emu-space-sm);
+}
 
 body.-emu #module-management .package-description {
-  color: rgba(var(--color-text-darker), 1); }
+  color: rgba(var(--color-text-darker), 1);
+}
 
 body.-emu #module-management .package-metadata {
-  color: rgba(var(--color-text), 1); }
-  .-emu-layout body.-emu #module-management .package-metadata {
-    font-size: var(--emu-font-size-sm); }
+  color: rgba(var(--color-text), 1);
+}
+.-emu-layout body.-emu #module-management .package-metadata {
+  font-size: var(--emu-font-size-sm);
+}
 
 .-emu-layout body.-emu #module-management form {
   display: flex;
-  flex-direction: column; }
+  flex-direction: column;
+}
 
 .-emu-layout body.-emu #module-management form > .notes {
   -webkit-margin-after: var(--emu-space-sm);
-          margin-block-end: var(--emu-space-sm); }
+  margin-block-end: var(--emu-space-sm);
+}
 
 .-emu-layout body.-emu #module-management form > footer {
   flex: 0 0 auto;
   flex-wrap: nowrap;
   padding: 0;
   -webkit-padding-before: var(--emu-space-sm);
-          padding-block-start: var(--emu-space-sm); }
+  padding-block-start: var(--emu-space-sm);
+}
 
 .-emu-layout body.-emu .sheet.roll-table-config .sheet-header {
   -webkit-margin-after: var(--emu-space-base);
-          margin-block-end: var(--emu-space-base); }
+  margin-block-end: var(--emu-space-base);
+}
 
 body.-emu .sheet.roll-table-config .sheet-header h1 {
-  border: none; }
-  .-emu-layout body.-emu .sheet.roll-table-config .sheet-header h1 {
-    margin: 0; }
+  border: none;
+}
+.-emu-layout body.-emu .sheet.roll-table-config .sheet-header h1 {
+  margin: 0;
+}
 
 .-emu-layout body.-emu .sheet.roll-table-config .table-results .table-result {
   display: grid;
-  grid-template-columns: 2.5rem 8rem 1fr 3.75rem 5rem 3.75rem; }
-  .-emu-layout body.-emu .sheet.roll-table-config .table-results .table-result:nth-of-type(odd):not(.table-header) {
-    background-color: rgba(var(--color-background-light), 0.1); }
-  .-emu-layout body.-emu .sheet.roll-table-config .table-results .table-result select + input {
-    -webkit-margin-start: var(--emu-space-base);
-            margin-inline-start: var(--emu-space-base); }
+  grid-template-columns: 2.5rem 8rem 1fr 3.75rem 5rem 3.75rem;
+}
+.-emu-layout
+  body.-emu
+  .sheet.roll-table-config
+  .table-results
+  .table-result:nth-of-type(odd):not(.table-header) {
+  background-color: rgba(var(--color-background-light), 0.1);
+}
+.-emu-layout
+  body.-emu
+  .sheet.roll-table-config
+  .table-results
+  .table-result
+  select
+  + input {
+  -webkit-margin-start: var(--emu-space-base);
+  margin-inline-start: var(--emu-space-base);
+}
 
 .-emu-layout body.-emu .sheet.scene-sheet form h3.form-header {
   -webkit-margin-before: var(--emu-space-sm);
-          margin-block-start: var(--emu-space-sm); }
+  margin-block-start: var(--emu-space-sm);
+}
 
 .-emu-layout body.-emu .sheet[id*="tile-config-"] form > .tab {
   -webkit-padding-before: var(--emu-space-sm);
-          padding-block-start: var(--emu-space-sm); }
+  padding-block-start: var(--emu-space-sm);
+}
 
 body.-emu .sheet[id*="token-config-"] .note {
   -webkit-border-after: none;
-          border-block-end: none; }
+  border-block-end: none;
+}
 
-.-emu-layout body.-emu .window-app[id*="trait-selector-"] .window-content form > ol, .-emu-layout
-body.-emu .window-app[id*="trait-selector-"] .window-content form > ul {
-  margin: 0; }
+.-emu-layout
+  body.-emu
+  .window-app[id*="trait-selector-"]
+  .window-content
+  form
+  > ol,
+.-emu-layout
+  body.-emu
+  .window-app[id*="trait-selector-"]
+  .window-content
+  form
+  > ul {
+  margin: 0;
+}
 
-.-emu-layout body.-emu .window-app[id*="trait-selector-"] .window-content form > ol li, .-emu-layout
-body.-emu .window-app[id*="trait-selector-"] .window-content form > ul li {
+.-emu-layout
+  body.-emu
+  .window-app[id*="trait-selector-"]
+  .window-content
+  form
+  > ol
+  li,
+.-emu-layout
+  body.-emu
+  .window-app[id*="trait-selector-"]
+  .window-content
+  form
+  > ul
+  li {
   -webkit-margin-after: var(--emu-space-base);
-          margin-block-end: var(--emu-space-base); }
-  .-emu-layout body.-emu .window-app[id*="trait-selector-"] .window-content form > ol li:last-child, .-emu-layout
-  body.-emu .window-app[id*="trait-selector-"] .window-content form > ul li:last-child {
-    -webkit-margin-after: 0;
-            margin-block-end: 0; }
+  margin-block-end: var(--emu-space-base);
+}
+.-emu-layout
+  body.-emu
+  .window-app[id*="trait-selector-"]
+  .window-content
+  form
+  > ol
+  li:last-child,
+.-emu-layout
+  body.-emu
+  .window-app[id*="trait-selector-"]
+  .window-content
+  form
+  > ul
+  li:last-child {
+  -webkit-margin-after: 0;
+  margin-block-end: 0;
+}
 
 body.-emu .window-app[id*="trait-selector-"] .window-content form > ol li,
 body.-emu .window-app[id*="trait-selector-"] .window-content form > ol label,
 body.-emu .window-app[id*="trait-selector-"] .window-content form > ul li,
 body.-emu .window-app[id*="trait-selector-"] .window-content form > ul label {
-  color: rgba(var(--color-text), 1); }
-  .-emu-layout body.-emu .window-app[id*="trait-selector-"] .window-content form > ol li, .-emu-layout
-  body.-emu .window-app[id*="trait-selector-"] .window-content form > ol label, .-emu-layout
-  body.-emu .window-app[id*="trait-selector-"] .window-content form > ul li, .-emu-layout
-  body.-emu .window-app[id*="trait-selector-"] .window-content form > ul label {
-    align-items: center;
-    display: flex; }
+  color: rgba(var(--color-text), 1);
+}
+.-emu-layout
+  body.-emu
+  .window-app[id*="trait-selector-"]
+  .window-content
+  form
+  > ol
+  li,
+.-emu-layout
+  body.-emu
+  .window-app[id*="trait-selector-"]
+  .window-content
+  form
+  > ol
+  label,
+.-emu-layout
+  body.-emu
+  .window-app[id*="trait-selector-"]
+  .window-content
+  form
+  > ul
+  li,
+.-emu-layout
+  body.-emu
+  .window-app[id*="trait-selector-"]
+  .window-content
+  form
+  > ul
+  label {
+  align-items: center;
+  display: flex;
+}
 
-.-emu-layout body.-emu .window-app[id*="trait-selector-"] .window-content form > ol label.checkbox, .-emu-layout
-body.-emu .window-app[id*="trait-selector-"] .window-content form > ul label.checkbox {
+.-emu-layout
+  body.-emu
+  .window-app[id*="trait-selector-"]
+  .window-content
+  form
+  > ol
+  label.checkbox,
+.-emu-layout
+  body.-emu
+  .window-app[id*="trait-selector-"]
+  .window-content
+  form
+  > ul
+  label.checkbox {
   height: auto;
   font-size: var(--emu-font-size-md);
-  line-height: initial; }
-  .-emu-layout body.-emu .window-app[id*="trait-selector-"] .window-content form > ol label.checkbox > input, .-emu-layout
-  body.-emu .window-app[id*="trait-selector-"] .window-content form > ul label.checkbox > input {
-    -webkit-margin-end: var(--emu-space-base);
-            margin-inline-end: var(--emu-space-base); }
+  line-height: initial;
+}
+.-emu-layout
+  body.-emu
+  .window-app[id*="trait-selector-"]
+  .window-content
+  form
+  > ol
+  label.checkbox
+  > input,
+.-emu-layout
+  body.-emu
+  .window-app[id*="trait-selector-"]
+  .window-content
+  form
+  > ul
+  label.checkbox
+  > input {
+  -webkit-margin-end: var(--emu-space-base);
+  margin-inline-end: var(--emu-space-base);
+}
 
 .-emu-layout body.-emu .user-config.sheet.window-app .form-group label {
-  font-weight: normal; }
+  font-weight: normal;
+}
 
 .-emu-layout body.-emu .user-config.sheet.window-app .form-group.stacked {
   align-items: initial;
-  flex-direction: row; }
-  .-emu-layout body.-emu .user-config.sheet.window-app .form-group.stacked label {
-    flex: 0 0 auto;
-    justify-content: flex-start; }
-    .-emu-layout body.-emu .user-config.sheet.window-app .form-group.stacked label #available-characters {
-      -webkit-padding-before: var(--emu-space-base);
-              padding-block-start: var(--emu-space-base); }
-  .-emu-layout body.-emu .user-config.sheet.window-app .form-group.stacked .directory-list {
-    max-height: 100%;
-    width: 100%; }
+  flex-direction: row;
+}
+.-emu-layout body.-emu .user-config.sheet.window-app .form-group.stacked label {
+  flex: 0 0 auto;
+  justify-content: flex-start;
+}
+.-emu-layout
+  body.-emu
+  .user-config.sheet.window-app
+  .form-group.stacked
+  label
+  #available-characters {
+  -webkit-padding-before: var(--emu-space-base);
+  padding-block-start: var(--emu-space-base);
+}
+.-emu-layout
+  body.-emu
+  .user-config.sheet.window-app
+  .form-group.stacked
+  .directory-list {
+  max-height: 100%;
+  width: 100%;
+}
 
 body.-emu .user-config.sheet.window-app #characters .directory-item,
 body.-emu .user-config.sheet.window-app .directory-item {
   border: none;
-  box-shadow: none; }
-  .-emu-layout body.-emu .user-config.sheet.window-app #characters .directory-item, .-emu-layout
-  body.-emu .user-config.sheet.window-app .directory-item {
-    -webkit-margin-start: 0;
-            margin-inline-start: 0;
-    -webkit-margin-end: 0;
-            margin-inline-end: 0; }
-  .-emu-layout body.-emu .user-config.sheet.window-app #characters .directory-item.context h3, .-emu-layout
-  body.-emu .user-config.sheet.window-app .directory-item.context h3 {
-    font-weight: normal; }
-  body.-emu .user-config.sheet.window-app #characters .directory-item label,
-  body.-emu .user-config.sheet.window-app .directory-item label {
-    color: rgba(var(--color-text), 1); }
-    .-emu-layout body.-emu .user-config.sheet.window-app #characters .directory-item label, .-emu-layout
-    body.-emu .user-config.sheet.window-app .directory-item label {
-      font-weight: normal; }
+  box-shadow: none;
+}
+.-emu-layout
+  body.-emu
+  .user-config.sheet.window-app
+  #characters
+  .directory-item,
+.-emu-layout body.-emu .user-config.sheet.window-app .directory-item {
+  -webkit-margin-start: 0;
+  margin-inline-start: 0;
+  -webkit-margin-end: 0;
+  margin-inline-end: 0;
+}
+.-emu-layout
+  body.-emu
+  .user-config.sheet.window-app
+  #characters
+  .directory-item.context
+  h3,
+.-emu-layout
+  body.-emu
+  .user-config.sheet.window-app
+  .directory-item.context
+  h3 {
+  font-weight: normal;
+}
+body.-emu .user-config.sheet.window-app #characters .directory-item label,
+body.-emu .user-config.sheet.window-app .directory-item label {
+  color: rgba(var(--color-text), 1);
+}
+.-emu-layout
+  body.-emu
+  .user-config.sheet.window-app
+  #characters
+  .directory-item
+  label,
+.-emu-layout body.-emu .user-config.sheet.window-app .directory-item label {
+  font-weight: normal;
+}
 
 body.-emu .better-npc-sheet-container .better-npc-sheet {
-  background-image: none; }
+  background-image: none;
+}
 
-.-emu-layout body.-emu .window-app[id*="chat-popout-"] .chat-message .chat-card .die-result-overlay-br, .-emu-layout
-body.-emu #sidebar #chat #chat-log .chat-message .chat-card .die-result-overlay-br {
-  padding: 0 var(--emu-space-xs); }
+.-emu-layout
+  body.-emu
+  .window-app[id*="chat-popout-"]
+  .chat-message
+  .chat-card
+  .die-result-overlay-br,
+.-emu-layout
+  body.-emu
+  #sidebar
+  #chat
+  #chat-log
+  .chat-message
+  .chat-card
+  .die-result-overlay-br {
+  padding: 0 var(--emu-space-xs);
+}
 
-.-emu-layout body.-emu .window-app[id*="chat-popout-"] .chat-message .chat-card .die-result-overlay-br button, .-emu-layout
-body.-emu #sidebar #chat #chat-log .chat-message .chat-card .die-result-overlay-br button {
-  margin: 0 var(--emu-space-xs); }
+.-emu-layout
+  body.-emu
+  .window-app[id*="chat-popout-"]
+  .chat-message
+  .chat-card
+  .die-result-overlay-br
+  button,
+.-emu-layout
+  body.-emu
+  #sidebar
+  #chat
+  #chat-log
+  .chat-message
+  .chat-card
+  .die-result-overlay-br
+  button {
+  margin: 0 var(--emu-space-xs);
+}
 
-.-emu-layout body.-emu .window-app[id*="chat-popout-"] .chat-message .chat-card .red-dual .dice-row .dice-row-item:not(.tooltip), .-emu-layout
-body.-emu #sidebar #chat #chat-log .chat-message .chat-card .red-dual .dice-row .dice-row-item:not(.tooltip) {
+.-emu-layout
+  body.-emu
+  .window-app[id*="chat-popout-"]
+  .chat-message
+  .chat-card
+  .red-dual
+  .dice-row
+  .dice-row-item:not(.tooltip),
+.-emu-layout
+  body.-emu
+  #sidebar
+  #chat
+  #chat-log
+  .chat-message
+  .chat-card
+  .red-dual
+  .dice-row
+  .dice-row-item:not(.tooltip) {
   align-items: center;
   display: flex;
   justify-content: center;
   margin: 0;
-  min-height: var(--emu-space-button); }
+  min-height: var(--emu-space-button);
+}
 
-.-emu-layout body.-emu .window-app[id*="chat-popout-"] .chat-message .chat-card .red-dual .dice-row .dice-total + .dice-total, .-emu-layout
-body.-emu #sidebar #chat #chat-log .chat-message .chat-card .red-dual .dice-row .dice-total + .dice-total {
+.-emu-layout
+  body.-emu
+  .window-app[id*="chat-popout-"]
+  .chat-message
+  .chat-card
+  .red-dual
+  .dice-row
+  .dice-total
+  + .dice-total,
+.-emu-layout
+  body.-emu
+  #sidebar
+  #chat
+  #chat-log
+  .chat-message
+  .chat-card
+  .red-dual
+  .dice-row
+  .dice-total
+  + .dice-total {
   -webkit-margin-before: 0;
-          margin-block-start: 0;
+  margin-block-start: 0;
   -webkit-margin-start: var(--emu-space-base);
-          margin-inline-start: var(--emu-space-base); }
+  margin-inline-start: var(--emu-space-base);
+}
 
 body.-emu #calendar-time-container,
 body.-emu #calendar-weather-container {
@@ -5169,491 +14301,1068 @@ body.-emu #calendar-weather-container {
   background-image: var(--emu-image-background, none);
   border: rgba(var(--color-border), 1) 1px solid;
   border-radius: var(--emu-border-radius-default, 0);
-  box-shadow: none; }
-  .-emu-layout body.-emu #calendar-time-container, .-emu-layout
-  body.-emu #calendar-weather-container {
-    height: -webkit-fit-content;
-    height: -moz-fit-content;
-    height: fit-content;
-    padding: var(--emu-space-sm);
-    z-index: 10; }
-  body.-emu #calendar-time-container #calendar-header,
-  body.-emu #calendar-time-container .calendar--clock,
-  body.-emu #calendar-weather-container #calendar-header,
-  body.-emu #calendar-weather-container .calendar--clock {
-    background: transparent; }
-    .-emu-layout body.-emu #calendar-time-container #calendar-header, .-emu-layout
-    body.-emu #calendar-time-container .calendar--clock, .-emu-layout
-    body.-emu #calendar-weather-container #calendar-header, .-emu-layout
-    body.-emu #calendar-weather-container .calendar--clock {
-      display: grid;
-      height: auto;
-      gap: var(--emu-space-base);
-      grid-template-columns: 3.25rem 1fr 3.25rem;
-      padding: 0; }
-    .-emu-layout body.-emu #calendar-time-container #calendar-header .header-navigation, .-emu-layout
-    body.-emu #calendar-time-container #calendar-header .day-time-cues, .-emu-layout
-    body.-emu #calendar-time-container .calendar--clock .header-navigation, .-emu-layout
-    body.-emu #calendar-time-container .calendar--clock .day-time-cues, .-emu-layout
-    body.-emu #calendar-weather-container #calendar-header .header-navigation, .-emu-layout
-    body.-emu #calendar-weather-container #calendar-header .day-time-cues, .-emu-layout
-    body.-emu #calendar-weather-container .calendar--clock .header-navigation, .-emu-layout
-    body.-emu #calendar-weather-container .calendar--clock .day-time-cues {
-      justify-content: initial;
-      padding: 0;
-      transition: opacity 0.3s cubic-bezier(0.77, 0, 0.175, 1); }
-      .-emu-layout body.-emu #calendar-time-container #calendar-header .header-navigation:last-child, .-emu-layout
-      body.-emu #calendar-time-container #calendar-header .day-time-cues:last-child, .-emu-layout
-      body.-emu #calendar-time-container .calendar--clock .header-navigation:last-child, .-emu-layout
-      body.-emu #calendar-time-container .calendar--clock .day-time-cues:last-child, .-emu-layout
-      body.-emu #calendar-weather-container #calendar-header .header-navigation:last-child, .-emu-layout
-      body.-emu #calendar-weather-container #calendar-header .day-time-cues:last-child, .-emu-layout
-      body.-emu #calendar-weather-container .calendar--clock .header-navigation:last-child, .-emu-layout
-      body.-emu #calendar-weather-container .calendar--clock .day-time-cues:last-child {
-        justify-content: flex-end; }
-        .-emu-layout body.-emu #calendar-time-container #calendar-header .header-navigation:last-child .calendar-btn, .-emu-layout
-        body.-emu #calendar-time-container #calendar-header .day-time-cues:last-child .calendar-btn, .-emu-layout
-        body.-emu #calendar-time-container .calendar--clock .header-navigation:last-child .calendar-btn, .-emu-layout
-        body.-emu #calendar-time-container .calendar--clock .day-time-cues:last-child .calendar-btn, .-emu-layout
-        body.-emu #calendar-weather-container #calendar-header .header-navigation:last-child .calendar-btn, .-emu-layout
-        body.-emu #calendar-weather-container #calendar-header .day-time-cues:last-child .calendar-btn, .-emu-layout
-        body.-emu #calendar-weather-container .calendar--clock .header-navigation:last-child .calendar-btn, .-emu-layout
-        body.-emu #calendar-weather-container .calendar--clock .day-time-cues:last-child .calendar-btn {
-          -webkit-margin-start: var(--emu-space-base);
-                  margin-inline-start: var(--emu-space-base);
-          -webkit-margin-end: 0;
-                  margin-inline-end: 0; }
-      .-emu-layout body.-emu #calendar-time-container #calendar-header .header-navigation .calendar-btn, .-emu-layout
-      body.-emu #calendar-time-container #calendar-header .day-time-cues .calendar-btn, .-emu-layout
-      body.-emu #calendar-time-container .calendar--clock .header-navigation .calendar-btn, .-emu-layout
-      body.-emu #calendar-time-container .calendar--clock .day-time-cues .calendar-btn, .-emu-layout
-      body.-emu #calendar-weather-container #calendar-header .header-navigation .calendar-btn, .-emu-layout
-      body.-emu #calendar-weather-container #calendar-header .day-time-cues .calendar-btn, .-emu-layout
-      body.-emu #calendar-weather-container .calendar--clock .header-navigation .calendar-btn, .-emu-layout
-      body.-emu #calendar-weather-container .calendar--clock .day-time-cues .calendar-btn {
-        -webkit-margin-end: var(--emu-space-base);
-                margin-inline-end: var(--emu-space-base); }
-    .-emu-layout body.-emu #calendar-time-container #calendar-header #calendar--move-handle, .-emu-layout
-    body.-emu #calendar-time-container #calendar-header #start-stop-clock, .-emu-layout
-    body.-emu #calendar-time-container .calendar--clock #calendar--move-handle, .-emu-layout
-    body.-emu #calendar-time-container .calendar--clock #start-stop-clock, .-emu-layout
-    body.-emu #calendar-weather-container #calendar-header #calendar--move-handle, .-emu-layout
-    body.-emu #calendar-weather-container #calendar-header #start-stop-clock, .-emu-layout
-    body.-emu #calendar-weather-container .calendar--clock #calendar--move-handle, .-emu-layout
-    body.-emu #calendar-weather-container .calendar--clock #start-stop-clock {
-      font-size: var(--emu-font-size-md); }
-  .-emu-layout body.-emu #calendar-time-container .calendar--clock, .-emu-layout
-  body.-emu #calendar-weather-container .calendar--clock {
-    -webkit-margin-before: var(--emu-space-base);
-            margin-block-start: var(--emu-space-base); }
-  body.-emu #calendar-time-container #calendar--date-display,
-  body.-emu #calendar-weather-container #calendar--date-display {
-    border: none; }
-    .-emu-layout body.-emu #calendar-time-container #calendar--date-display h2, .-emu-layout
-    body.-emu #calendar-weather-container #calendar--date-display h2 {
-      font-size: var(--emu-font-size-md);
-      padding: var(--emu-space-base); }
-  .-emu-layout body.-emu #calendar-time-container .calendar--time-controls, .-emu-layout
-  body.-emu #calendar-weather-container .calendar--time-controls {
-    -webkit-margin-before: var(--emu-space-sm);
-            margin-block-start: var(--emu-space-sm);
-    transition: opacity 0.3s cubic-bezier(0.77, 0, 0.175, 1); }
-  .-emu-layout body.-emu #calendar-time-container .calendar--time-controls .advance-btn, .-emu-layout
-  body.-emu #calendar-weather-container .calendar--time-controls .advance-btn {
-    font-size: var(--emu-font-size-md);
-    -webkit-margin-end: var(--emu-space-xs);
-            margin-inline-end: var(--emu-space-xs);
-    padding: var(--emu-space-base); }
-    .-emu-layout body.-emu #calendar-time-container .calendar--time-controls .advance-btn:last-of-type, .-emu-layout
-    body.-emu #calendar-weather-container .calendar--time-controls .advance-btn:last-of-type {
-      -webkit-margin-end: 0;
-              margin-inline-end: 0; }
-  body.-emu #calendar-time-container .calendar-btn,
-  body.-emu #calendar-time-container #season-indicator,
-  body.-emu #calendar-weather-container .calendar-btn,
-  body.-emu #calendar-weather-container #season-indicator {
-    color: rgba(var(--color-text-lightest), 1);
-    transition: background 0.3s cubic-bezier(0.075, 0.82, 0.165, 1), box-shadow 0.3s cubic-bezier(0.075, 0.82, 0.165, 1), color 0.3s cubic-bezier(0.075, 0.82, 0.165, 1); }
-    .-emu-layout body.-emu #calendar-time-container .calendar-btn, .-emu-layout
-    body.-emu #calendar-time-container #season-indicator, .-emu-layout
-    body.-emu #calendar-weather-container .calendar-btn, .-emu-layout
-    body.-emu #calendar-weather-container #season-indicator {
-      width: 1.125rem;
-      height: 1.125rem;
-      align-items: center;
-      cursor: pointer;
-      display: flex;
-      flex: 0 0 auto;
-      font-size: var(--emu-font-size-md);
-      justify-content: center;
-      line-height: 1;
-      margin: 0;
-      opacity: 0.5;
-      overflow: hidden;
-      padding: var(--emu-space-xs); }
-    body.-emu #calendar-time-container .calendar-btn:hover,
-    body.-emu #calendar-time-container #season-indicator:hover,
-    body.-emu #calendar-weather-container .calendar-btn:hover,
-    body.-emu #calendar-weather-container #season-indicator:hover {
-      color: rgba(var(--color-primary), 1);
-      opacity: 1; }
+  box-shadow: none;
+}
+.-emu-layout body.-emu #calendar-time-container,
+.-emu-layout body.-emu #calendar-weather-container {
+  height: -webkit-fit-content;
+  height: -moz-fit-content;
+  height: fit-content;
+  padding: var(--emu-space-sm);
+  z-index: 10;
+}
+body.-emu #calendar-time-container #calendar-header,
+body.-emu #calendar-time-container .calendar--clock,
+body.-emu #calendar-weather-container #calendar-header,
+body.-emu #calendar-weather-container .calendar--clock {
+  background: transparent;
+}
+.-emu-layout body.-emu #calendar-time-container #calendar-header,
+.-emu-layout body.-emu #calendar-time-container .calendar--clock,
+.-emu-layout body.-emu #calendar-weather-container #calendar-header,
+.-emu-layout body.-emu #calendar-weather-container .calendar--clock {
+  display: grid;
+  height: auto;
+  gap: var(--emu-space-base);
+  grid-template-columns: 3.25rem 1fr 3.25rem;
+  padding: 0;
+}
+.-emu-layout
+  body.-emu
+  #calendar-time-container
+  #calendar-header
+  .header-navigation,
+.-emu-layout body.-emu #calendar-time-container #calendar-header .day-time-cues,
+.-emu-layout
+  body.-emu
+  #calendar-time-container
+  .calendar--clock
+  .header-navigation,
+.-emu-layout body.-emu #calendar-time-container .calendar--clock .day-time-cues,
+.-emu-layout
+  body.-emu
+  #calendar-weather-container
+  #calendar-header
+  .header-navigation,
+.-emu-layout
+  body.-emu
+  #calendar-weather-container
+  #calendar-header
+  .day-time-cues,
+.-emu-layout
+  body.-emu
+  #calendar-weather-container
+  .calendar--clock
+  .header-navigation,
+.-emu-layout
+  body.-emu
+  #calendar-weather-container
+  .calendar--clock
+  .day-time-cues {
+  justify-content: initial;
+  padding: 0;
+  transition: opacity 0.3s cubic-bezier(0.77, 0, 0.175, 1);
+}
+.-emu-layout
+  body.-emu
+  #calendar-time-container
+  #calendar-header
+  .header-navigation:last-child,
+.-emu-layout
+  body.-emu
+  #calendar-time-container
+  #calendar-header
+  .day-time-cues:last-child,
+.-emu-layout
+  body.-emu
+  #calendar-time-container
+  .calendar--clock
+  .header-navigation:last-child,
+.-emu-layout
+  body.-emu
+  #calendar-time-container
+  .calendar--clock
+  .day-time-cues:last-child,
+.-emu-layout
+  body.-emu
+  #calendar-weather-container
+  #calendar-header
+  .header-navigation:last-child,
+.-emu-layout
+  body.-emu
+  #calendar-weather-container
+  #calendar-header
+  .day-time-cues:last-child,
+.-emu-layout
+  body.-emu
+  #calendar-weather-container
+  .calendar--clock
+  .header-navigation:last-child,
+.-emu-layout
+  body.-emu
+  #calendar-weather-container
+  .calendar--clock
+  .day-time-cues:last-child {
+  justify-content: flex-end;
+}
+.-emu-layout
+  body.-emu
+  #calendar-time-container
+  #calendar-header
+  .header-navigation:last-child
+  .calendar-btn,
+.-emu-layout
+  body.-emu
+  #calendar-time-container
+  #calendar-header
+  .day-time-cues:last-child
+  .calendar-btn,
+.-emu-layout
+  body.-emu
+  #calendar-time-container
+  .calendar--clock
+  .header-navigation:last-child
+  .calendar-btn,
+.-emu-layout
+  body.-emu
+  #calendar-time-container
+  .calendar--clock
+  .day-time-cues:last-child
+  .calendar-btn,
+.-emu-layout
+  body.-emu
+  #calendar-weather-container
+  #calendar-header
+  .header-navigation:last-child
+  .calendar-btn,
+.-emu-layout
+  body.-emu
+  #calendar-weather-container
+  #calendar-header
+  .day-time-cues:last-child
+  .calendar-btn,
+.-emu-layout
+  body.-emu
+  #calendar-weather-container
+  .calendar--clock
+  .header-navigation:last-child
+  .calendar-btn,
+.-emu-layout
+  body.-emu
+  #calendar-weather-container
+  .calendar--clock
+  .day-time-cues:last-child
+  .calendar-btn {
+  -webkit-margin-start: var(--emu-space-base);
+  margin-inline-start: var(--emu-space-base);
+  -webkit-margin-end: 0;
+  margin-inline-end: 0;
+}
+.-emu-layout
+  body.-emu
+  #calendar-time-container
+  #calendar-header
+  .header-navigation
+  .calendar-btn,
+.-emu-layout
+  body.-emu
+  #calendar-time-container
+  #calendar-header
+  .day-time-cues
+  .calendar-btn,
+.-emu-layout
+  body.-emu
+  #calendar-time-container
+  .calendar--clock
+  .header-navigation
+  .calendar-btn,
+.-emu-layout
+  body.-emu
+  #calendar-time-container
+  .calendar--clock
+  .day-time-cues
+  .calendar-btn,
+.-emu-layout
+  body.-emu
+  #calendar-weather-container
+  #calendar-header
+  .header-navigation
+  .calendar-btn,
+.-emu-layout
+  body.-emu
+  #calendar-weather-container
+  #calendar-header
+  .day-time-cues
+  .calendar-btn,
+.-emu-layout
+  body.-emu
+  #calendar-weather-container
+  .calendar--clock
+  .header-navigation
+  .calendar-btn,
+.-emu-layout
+  body.-emu
+  #calendar-weather-container
+  .calendar--clock
+  .day-time-cues
+  .calendar-btn {
+  -webkit-margin-end: var(--emu-space-base);
+  margin-inline-end: var(--emu-space-base);
+}
+.-emu-layout
+  body.-emu
+  #calendar-time-container
+  #calendar-header
+  #calendar--move-handle,
+.-emu-layout
+  body.-emu
+  #calendar-time-container
+  #calendar-header
+  #start-stop-clock,
+.-emu-layout
+  body.-emu
+  #calendar-time-container
+  .calendar--clock
+  #calendar--move-handle,
+.-emu-layout
+  body.-emu
+  #calendar-time-container
+  .calendar--clock
+  #start-stop-clock,
+.-emu-layout
+  body.-emu
+  #calendar-weather-container
+  #calendar-header
+  #calendar--move-handle,
+.-emu-layout
+  body.-emu
+  #calendar-weather-container
+  #calendar-header
+  #start-stop-clock,
+.-emu-layout
+  body.-emu
+  #calendar-weather-container
+  .calendar--clock
+  #calendar--move-handle,
+.-emu-layout
+  body.-emu
+  #calendar-weather-container
+  .calendar--clock
+  #start-stop-clock {
+  font-size: var(--emu-font-size-md);
+}
+.-emu-layout body.-emu #calendar-time-container .calendar--clock,
+.-emu-layout body.-emu #calendar-weather-container .calendar--clock {
+  -webkit-margin-before: var(--emu-space-base);
+  margin-block-start: var(--emu-space-base);
+}
+body.-emu #calendar-time-container #calendar--date-display,
+body.-emu #calendar-weather-container #calendar--date-display {
+  border: none;
+}
+.-emu-layout body.-emu #calendar-time-container #calendar--date-display h2,
+.-emu-layout body.-emu #calendar-weather-container #calendar--date-display h2 {
+  font-size: var(--emu-font-size-md);
+  padding: var(--emu-space-base);
+}
+.-emu-layout body.-emu #calendar-time-container .calendar--time-controls,
+.-emu-layout body.-emu #calendar-weather-container .calendar--time-controls {
+  -webkit-margin-before: var(--emu-space-sm);
+  margin-block-start: var(--emu-space-sm);
+  transition: opacity 0.3s cubic-bezier(0.77, 0, 0.175, 1);
+}
+.-emu-layout
+  body.-emu
+  #calendar-time-container
+  .calendar--time-controls
+  .advance-btn,
+.-emu-layout
+  body.-emu
+  #calendar-weather-container
+  .calendar--time-controls
+  .advance-btn {
+  font-size: var(--emu-font-size-md);
+  -webkit-margin-end: var(--emu-space-xs);
+  margin-inline-end: var(--emu-space-xs);
+  padding: var(--emu-space-base);
+}
+.-emu-layout
+  body.-emu
+  #calendar-time-container
+  .calendar--time-controls
+  .advance-btn:last-of-type,
+.-emu-layout
+  body.-emu
+  #calendar-weather-container
+  .calendar--time-controls
+  .advance-btn:last-of-type {
+  -webkit-margin-end: 0;
+  margin-inline-end: 0;
+}
+body.-emu #calendar-time-container .calendar-btn,
+body.-emu #calendar-time-container #season-indicator,
+body.-emu #calendar-weather-container .calendar-btn,
+body.-emu #calendar-weather-container #season-indicator {
+  color: rgba(var(--color-text-lightest), 1);
+  transition: background 0.3s cubic-bezier(0.075, 0.82, 0.165, 1),
+    box-shadow 0.3s cubic-bezier(0.075, 0.82, 0.165, 1),
+    color 0.3s cubic-bezier(0.075, 0.82, 0.165, 1);
+}
+.-emu-layout body.-emu #calendar-time-container .calendar-btn,
+.-emu-layout body.-emu #calendar-time-container #season-indicator,
+.-emu-layout body.-emu #calendar-weather-container .calendar-btn,
+.-emu-layout body.-emu #calendar-weather-container #season-indicator {
+  width: 1.125rem;
+  height: 1.125rem;
+  align-items: center;
+  cursor: pointer;
+  display: flex;
+  flex: 0 0 auto;
+  font-size: var(--emu-font-size-md);
+  justify-content: center;
+  line-height: 1;
+  margin: 0;
+  opacity: 0.5;
+  overflow: hidden;
+  padding: var(--emu-space-xs);
+}
+body.-emu #calendar-time-container .calendar-btn:hover,
+body.-emu #calendar-time-container #season-indicator:hover,
+body.-emu #calendar-weather-container .calendar-btn:hover,
+body.-emu #calendar-weather-container #season-indicator:hover {
+  color: rgba(var(--color-primary), 1);
+  opacity: 1;
+}
 
 body.-emu #weather {
-  transition: padding 0.3s cubic-bezier(0.77, 0, 0.175, 1), opacity 0.3s cubic-bezier(0.77, 0, 0.175, 1), width 0.3s cubic-bezier(0.77, 0, 0.175, 1); }
+  transition: padding 0.3s cubic-bezier(0.77, 0, 0.175, 1),
+    opacity 0.3s cubic-bezier(0.77, 0, 0.175, 1),
+    width 0.3s cubic-bezier(0.77, 0, 0.175, 1);
+}
 
 body.-emu #calendar-weather--container {
-  border: none; }
-  .-emu-layout body.-emu #calendar-weather--container {
-    width: 15.625rem; }
-  body.-emu #calendar-weather--container header {
-    background: transparent; }
-    .-emu-layout body.-emu #calendar-weather--container header {
-      flex: 0 0 auto;
-      padding: 0; }
-      .-emu-layout body.-emu #calendar-weather--container header select {
-        -webkit-margin-end: var(--emu-space-base);
-                margin-inline-end: var(--emu-space-base); }
-    body.-emu #calendar-weather--container header #calendar-weather--temp,
-    body.-emu #calendar-weather--container header #calendar-weather-regenerate {
-      border: none; }
-  body.-emu #calendar-weather--container .calendar-weather--content {
-    background-color: rgba(var(--color-black), 0.1);
-    border: none; }
+  border: none;
+}
+.-emu-layout body.-emu #calendar-weather--container {
+  width: 15.625rem;
+}
+body.-emu #calendar-weather--container header {
+  background: transparent;
+}
+.-emu-layout body.-emu #calendar-weather--container header {
+  flex: 0 0 auto;
+  padding: 0;
+}
+.-emu-layout body.-emu #calendar-weather--container header select {
+  -webkit-margin-end: var(--emu-space-base);
+  margin-inline-end: var(--emu-space-base);
+}
+body.-emu #calendar-weather--container header #calendar-weather--temp,
+body.-emu #calendar-weather--container header #calendar-weather-regenerate {
+  border: none;
+}
+body.-emu #calendar-weather--container .calendar-weather--content {
+  background-color: rgba(var(--color-black), 0.1);
+  border: none;
+}
 
 .-emu-layout body.-emu .calendar--content {
-  padding: 0; }
+  padding: 0;
+}
 
-.-emu-layout body.-emu .calendar-weather-ltd .day-time-cues, .-emu-layout
-body.-emu .calendar-weather-ltd .header-navigation {
+.-emu-layout body.-emu .calendar-weather-ltd .day-time-cues,
+.-emu-layout body.-emu .calendar-weather-ltd .header-navigation {
   display: flex;
   pointer-events: none;
-  visibility: hidden; }
+  visibility: hidden;
+}
 
 body.-emu #calendar-events-form {
-  background: transparent; }
-  .-emu-layout body.-emu #calendar-events-form button {
-    -webkit-margin-after: var(--emu-space-base);
-            margin-block-end: var(--emu-space-base); }
-  body.-emu #calendar-events-form button:hover {
-    box-shadow: inset 0 0 0 2px rgba(var(--color-white), 1) !important; }
+  background: transparent;
+}
+.-emu-layout body.-emu #calendar-events-form button {
+  -webkit-margin-after: var(--emu-space-base);
+  margin-block-end: var(--emu-space-base);
+}
+body.-emu #calendar-events-form button:hover {
+  box-shadow: inset 0 0 0 2px rgba(var(--color-white), 1) !important;
+}
 
 body.-emu .window-app.form .calendar-form-container {
-  background: transparent; }
-  body.-emu .window-app.form .calendar-form-container input#calendar-form-cDay-input,
-  body.-emu .window-app.form .calendar-form-container input#calendar-form-year-input,
-  body.-emu .window-app.form .calendar-form-container input#calendar-form-era-input,
-  body.-emu .window-app.form .calendar-form-container input#calendar-form-hour-input,
-  body.-emu .window-app.form .calendar-form-container input#calendar-form-minute-input,
-  body.-emu .window-app.form .calendar-form-container input#calendar-form-second-input {
-    background: rgba(var(--color-background-lightest), 1);
-    border: rgba(var(--color-border-lighter), 1) 1px solid;
-    border-radius: var(--emu-border-radius-forms, 0); }
-  .-emu-layout body.-emu .window-app.form .calendar-form-container input[type="radio"] {
-    -webkit-margin-start: var(--emu-space-md);
-            margin-inline-start: var(--emu-space-md); }
-  .-emu-layout body.-emu .window-app.form .calendar-form-container .calendar-form-weekday-del > i, .-emu-layout
-  body.-emu .window-app.form .calendar-form-container .calendar-form-month-del > i {
-    margin: 0; }
-  body.-emu .window-app.form .calendar-form-container .calendar-form-weekday-container,
-  body.-emu .window-app.form .calendar-form-container .calendar-form-month-container {
-    -webkit-border-after: 0;
-            border-block-end: 0; }
-    .-emu-layout body.-emu .window-app.form .calendar-form-container .calendar-form-weekday-container, .-emu-layout
-    body.-emu .window-app.form .calendar-form-container .calendar-form-month-container {
-      -webkit-margin-after: var(--emu-space-sm);
-              margin-block-end: var(--emu-space-sm); }
-  .-emu-layout body.-emu .window-app.form .calendar-form-container footer button {
-    -webkit-margin-before: var(--emu-space-base);
-            margin-block-start: var(--emu-space-base); }
+  background: transparent;
+}
+body.-emu
+  .window-app.form
+  .calendar-form-container
+  input#calendar-form-cDay-input,
+body.-emu
+  .window-app.form
+  .calendar-form-container
+  input#calendar-form-year-input,
+body.-emu
+  .window-app.form
+  .calendar-form-container
+  input#calendar-form-era-input,
+body.-emu
+  .window-app.form
+  .calendar-form-container
+  input#calendar-form-hour-input,
+body.-emu
+  .window-app.form
+  .calendar-form-container
+  input#calendar-form-minute-input,
+body.-emu
+  .window-app.form
+  .calendar-form-container
+  input#calendar-form-second-input {
+  background: rgba(var(--color-background-lightest), 1);
+  border: rgba(var(--color-border-lighter), 1) 1px solid;
+  border-radius: var(--emu-border-radius-forms, 0);
+}
+.-emu-layout
+  body.-emu
+  .window-app.form
+  .calendar-form-container
+  input[type="radio"] {
+  -webkit-margin-start: var(--emu-space-md);
+  margin-inline-start: var(--emu-space-md);
+}
+.-emu-layout
+  body.-emu
+  .window-app.form
+  .calendar-form-container
+  .calendar-form-weekday-del
+  > i,
+.-emu-layout
+  body.-emu
+  .window-app.form
+  .calendar-form-container
+  .calendar-form-month-del
+  > i {
+  margin: 0;
+}
+body.-emu
+  .window-app.form
+  .calendar-form-container
+  .calendar-form-weekday-container,
+body.-emu
+  .window-app.form
+  .calendar-form-container
+  .calendar-form-month-container {
+  -webkit-border-after: 0;
+  border-block-end: 0;
+}
+.-emu-layout
+  body.-emu
+  .window-app.form
+  .calendar-form-container
+  .calendar-form-weekday-container,
+.-emu-layout
+  body.-emu
+  .window-app.form
+  .calendar-form-container
+  .calendar-form-month-container {
+  -webkit-margin-after: var(--emu-space-sm);
+  margin-block-end: var(--emu-space-sm);
+}
+.-emu-layout body.-emu .window-app.form .calendar-form-container footer button {
+  -webkit-margin-before: var(--emu-space-base);
+  margin-block-start: var(--emu-space-base);
+}
 
 body.-emu .typing-notify {
   background-color: rgba(var(--color-primary), 1);
   border-radius: 0;
-  color: rgba(var(--color-text-lightest), 1); }
-  body.-emu .typing-notify .dot {
-    background-color: rgba(var(--color-white), 1); }
+  color: rgba(var(--color-text-lightest), 1);
+}
+body.-emu .typing-notify .dot {
+  background-color: rgba(var(--color-white), 1);
+}
 
 .-emu-layout body.-emu #chat-log .message .message-header img {
   margin: var(--emu-space-xs) 0;
   -webkit-margin-end: var(--emu-space-base);
-          margin-inline-end: var(--emu-space-base); }
+  margin-inline-end: var(--emu-space-base);
+}
 
-.-emu-layout body.-emu #sidebar #combat #combat-tracker .combatant .ce-image-wrapper, .-emu-layout
-body.-emu .sidebar-popout #combat #combat-tracker .combatant .ce-image-wrapper {
+.-emu-layout
+  body.-emu
+  #sidebar
+  #combat
+  #combat-tracker
+  .combatant
+  .ce-image-wrapper,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #combat
+  #combat-tracker
+  .combatant
+  .ce-image-wrapper {
   width: var(--emu-space-button);
   height: var(--emu-space-button);
   cursor: default;
   flex: 0 0 auto;
   -webkit-margin-end: var(--emu-space-sm);
-          margin-inline-end: var(--emu-space-sm);
-  position: relative; }
+  margin-inline-end: var(--emu-space-sm);
+  position: relative;
+}
 
-.-emu-layout body.-emu #sidebar #combat #combat-tracker .combatant .ce-image-wrapper .token-image, .-emu-layout
-body.-emu .sidebar-popout #combat #combat-tracker .combatant .ce-image-wrapper .token-image {
+.-emu-layout
+  body.-emu
+  #sidebar
+  #combat
+  #combat-tracker
+  .combatant
+  .ce-image-wrapper
+  .token-image,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #combat
+  #combat-tracker
+  .combatant
+  .ce-image-wrapper
+  .token-image {
   width: 100%;
   height: 100%;
-  margin: 0; }
+  margin: 0;
+}
 
-.-emu-layout body.-emu #sidebar #combat #combat-tracker .combatant .ce-image-wrapper svg, .-emu-layout
-body.-emu .sidebar-popout #combat #combat-tracker .combatant .ce-image-wrapper svg {
-  box-shadow: none; }
+.-emu-layout
+  body.-emu
+  #sidebar
+  #combat
+  #combat-tracker
+  .combatant
+  .ce-image-wrapper
+  svg,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #combat
+  #combat-tracker
+  .combatant
+  .ce-image-wrapper
+  svg {
+  box-shadow: none;
+}
 
 body.-emu #sidebar #combat #combat-tracker .combatant .ce-modify-hp-wrapper,
-body.-emu .sidebar-popout #combat #combat-tracker .combatant .ce-modify-hp-wrapper {
-  color: rgba(var(--color-text-lightest), 1); }
-  .-emu-layout body.-emu #sidebar #combat #combat-tracker .combatant .ce-modify-hp-wrapper, .-emu-layout
-  body.-emu .sidebar-popout #combat #combat-tracker .combatant .ce-modify-hp-wrapper {
-    align-items: center;
-    display: flex;
-    flex: 0 0 auto;
-    font-size: var(--emu-font-size-sm);
-    padding: var(--emu-space-xs); }
-  body.-emu #sidebar #combat #combat-tracker .combatant .ce-modify-hp-wrapper input,
-  body.-emu .sidebar-popout #combat #combat-tracker .combatant .ce-modify-hp-wrapper input {
-    background-color: rgba(var(--color-background-lightest), 1);
-    background-image: var(--emu-image-background-lightest, none); }
-    .-emu-layout body.-emu #sidebar #combat #combat-tracker .combatant .ce-modify-hp-wrapper input, .-emu-layout
-    body.-emu .sidebar-popout #combat #combat-tracker .combatant .ce-modify-hp-wrapper input {
-      height: auto;
-      -webkit-margin-start: var(--emu-space-base);
-              margin-inline-start: var(--emu-space-base);
-      width: var(--emu-space-button-lg); }
+body.-emu
+  .sidebar-popout
+  #combat
+  #combat-tracker
+  .combatant
+  .ce-modify-hp-wrapper {
+  color: rgba(var(--color-text-lightest), 1);
+}
+.-emu-layout
+  body.-emu
+  #sidebar
+  #combat
+  #combat-tracker
+  .combatant
+  .ce-modify-hp-wrapper,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #combat
+  #combat-tracker
+  .combatant
+  .ce-modify-hp-wrapper {
+  align-items: center;
+  display: flex;
+  flex: 0 0 auto;
+  font-size: var(--emu-font-size-sm);
+  padding: var(--emu-space-xs);
+}
+body.-emu
+  #sidebar
+  #combat
+  #combat-tracker
+  .combatant
+  .ce-modify-hp-wrapper
+  input,
+body.-emu
+  .sidebar-popout
+  #combat
+  #combat-tracker
+  .combatant
+  .ce-modify-hp-wrapper
+  input {
+  background-color: rgba(var(--color-background-lightest), 1);
+  background-image: var(--emu-image-background-lightest, none);
+}
+.-emu-layout
+  body.-emu
+  #sidebar
+  #combat
+  #combat-tracker
+  .combatant
+  .ce-modify-hp-wrapper
+  input,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #combat
+  #combat-tracker
+  .combatant
+  .ce-modify-hp-wrapper
+  input {
+  height: auto;
+  -webkit-margin-start: var(--emu-space-base);
+  margin-inline-start: var(--emu-space-base);
+  width: var(--emu-space-button-lg);
+}
 
 .-emu-layout body.-emu #sidebar #chat.small-chat + #combat {
-  flex: 1; }
+  flex: 1;
+}
 
 body.-emu #sidebar .small-chat::after {
-  border-color: rgba(var(--color-primary), 1); }
+  border-color: rgba(var(--color-primary), 1);
+}
 
 body.-emu .combatready-timebar,
 body.-emu .combatready-timebar-fill {
   border-radius: var(--emu-border-radius-default, 0);
-  box-shadow: none; }
-  .-emu-layout body.-emu .combatready-timebar, .-emu-layout
-  body.-emu .combatready-timebar-fill {
-    bottom: 0;
-    height: 0.4375rem;
-    top: auto; }
-  .-emu-layout.-emu-compact body.-emu .combatready-timebar, .-emu-layout.-emu-compact
-  body.-emu .combatready-timebar-fill {
-    height: 0.1875rem; }
+  box-shadow: none;
+}
+.-emu-layout body.-emu .combatready-timebar,
+.-emu-layout body.-emu .combatready-timebar-fill {
+  bottom: 0;
+  height: 0.4375rem;
+  top: auto;
+}
+.-emu-layout.-emu-compact body.-emu .combatready-timebar,
+.-emu-layout.-emu-compact body.-emu .combatready-timebar-fill {
+  height: 0.1875rem;
+}
 
 body.-emu .combatready-timebar {
-  background: rgba(var(--color-background-darkest), 0.2); }
+  background: rgba(var(--color-background-darkest), 0.2);
+}
 
 body.-emu .combatready-timebar-fill {
   background-color: rgba(var(--color-primary), 1);
-  color: rgba(var(--color-text-lightest), 1); }
-  .-emu-layout body.-emu .combatready-timebar-fill .combatready-timebaricon {
-    display: none; }
+  color: rgba(var(--color-text-lightest), 1);
+}
+.-emu-layout body.-emu .combatready-timebar-fill .combatready-timebaricon {
+  display: none;
+}
 
 body.-emu #sidebar #combat #combat-tracker .token-resource input,
 body.-emu .sidebar-popout #combat #combat-tracker .token-resource input {
   border: none;
-  color: rgba(var(--color-text-lightest), 1); }
-  .-emu-layout body.-emu #sidebar #combat #combat-tracker .token-resource input, .-emu-layout
-  body.-emu .sidebar-popout #combat #combat-tracker .token-resource input {
-    width: var(--emu-space-button-sm);
-    height: var(--emu-space-button-sm);
-    padding: 0;
-    text-align: center; }
+  color: rgba(var(--color-text-lightest), 1);
+}
+.-emu-layout body.-emu #sidebar #combat #combat-tracker .token-resource input,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #combat
+  #combat-tracker
+  .token-resource
+  input {
+  width: var(--emu-space-button-sm);
+  height: var(--emu-space-button-sm);
+  padding: 0;
+  text-align: center;
+}
 
-.-emu-layout body.-emu #sidebar #combat .add-temporary, .-emu-layout
-body.-emu .sidebar-popout #combat .add-temporary {
+.-emu-layout body.-emu #sidebar #combat .add-temporary,
+.-emu-layout body.-emu .sidebar-popout #combat .add-temporary {
   margin: var(--emu-space-sm);
   text-shadow: none;
-  width: 100%; }
+  width: 100%;
+}
 
 body.-emu #sidebar #settings #combat-utility-belt h4,
 body.-emu .sidebar-popout #settings #combat-utility-belt h4 {
   -webkit-border-after: rgba(var(--color-border), 1) 1px solid;
-          border-block-end: rgba(var(--color-border), 1) 1px solid;
-  color: rgba(var(--color-text-lightest), 1); }
-  .-emu-layout body.-emu #sidebar #settings #combat-utility-belt h4, .-emu-layout
-  body.-emu .sidebar-popout #settings #combat-utility-belt h4 {
-    -webkit-margin-before: var(--emu-space-md);
-            margin-block-start: var(--emu-space-md); }
+  border-block-end: rgba(var(--color-border), 1) 1px solid;
+  color: rgba(var(--color-text-lightest), 1);
+}
+.-emu-layout body.-emu #sidebar #settings #combat-utility-belt h4,
+.-emu-layout body.-emu .sidebar-popout #settings #combat-utility-belt h4 {
+  -webkit-margin-before: var(--emu-space-md);
+  margin-block-start: var(--emu-space-md);
+}
 
 body.-emu #combat-utility-belt-about a {
-  text-shadow: none; }
+  text-shadow: none;
+}
 
-.-emu-layout body.-emu #cub-puter::before, .-emu-layout body.-emu #cub-puter::after {
-  display: none; }
+.-emu-layout body.-emu #cub-puter::before,
+.-emu-layout body.-emu #cub-puter::after {
+  display: none;
+}
 
 body.-emu #cub-puter .terminal {
-  color: rgba(var(--color-primary), 1); }
+  color: rgba(var(--color-primary), 1);
+}
 
 .-emu-layout body.-emu .compendium-browser-btn {
-  flex: 1 1 auto; }
+  flex: 1 1 auto;
+}
 
 body.-emu .compendium-footer {
-  flex: 1 1 auto; }
+  flex: 1 1 auto;
+}
 
 .-emu-layout body.-emu .compendium-browser.window-app {
-  overflow: hidden; }
+  overflow: hidden;
+}
 
 .-emu-layout body.-emu .compendium-browser.window-app .tabs {
-  max-height: 100%; }
+  max-height: 100%;
+}
 
-.-emu-layout body.-emu .compendium-browser.window-app .control-area, .-emu-layout
-body.-emu .compendium-browser.window-app .list-area {
+.-emu-layout body.-emu .compendium-browser.window-app .control-area,
+.-emu-layout body.-emu .compendium-browser.window-app .list-area {
   overflow-x: hidden;
   overflow-y: auto;
-  padding: var(--emu-space-base); }
+  padding: var(--emu-space-base);
+}
 
 body.-emu .compendium-browser.window-app .filtercontainer {
   border: none;
   -webkit-border-after: rgba(var(--color-border), 1) 1px solid;
-          border-block-end: rgba(var(--color-border), 1) 1px solid;
-  border-radius: 0; }
-  .-emu-layout body.-emu .compendium-browser.window-app .filtercontainer {
-    -webkit-margin-after: var(--emu-space-base);
-            margin-block-end: var(--emu-space-base); }
-    .-emu-layout body.-emu .compendium-browser.window-app .filtercontainer:last-child {
-      -webkit-margin-after: 0;
-              margin-block-end: 0; }
-    .-emu-layout body.-emu .compendium-browser.window-app .filtercontainer > div {
-      margin: var(--emu-space-base) 0; }
-  body.-emu .compendium-browser.window-app .filtercontainer:last-child {
-    border: none; }
-  body.-emu .compendium-browser.window-app .filtercontainer .multiselect {
-    background: rgba(var(--color-background), 0.1);
-    border: none;
-    border-radius: 0; }
-    .-emu-layout body.-emu .compendium-browser.window-app .filtercontainer .multiselect {
-      line-height: 1;
-      margin: 0;
-      padding: var(--emu-space-base); }
-  .-emu-layout body.-emu .compendium-browser.window-app .filtercontainer dd {
-    display: inline-flex; }
-    .-emu-layout body.-emu .compendium-browser.window-app .filtercontainer dd select {
-      flex: 1 1 auto;
-      width: auto; }
-      .-emu-layout body.-emu .compendium-browser.window-app .filtercontainer dd select + input {
-        -webkit-border-start: none;
-                border-inline-start: none;
-        flex: 1 1 100%; }
+  border-block-end: rgba(var(--color-border), 1) 1px solid;
+  border-radius: 0;
+}
+.-emu-layout body.-emu .compendium-browser.window-app .filtercontainer {
+  -webkit-margin-after: var(--emu-space-base);
+  margin-block-end: var(--emu-space-base);
+}
+.-emu-layout
+  body.-emu
+  .compendium-browser.window-app
+  .filtercontainer:last-child {
+  -webkit-margin-after: 0;
+  margin-block-end: 0;
+}
+.-emu-layout body.-emu .compendium-browser.window-app .filtercontainer > div {
+  margin: var(--emu-space-base) 0;
+}
+body.-emu .compendium-browser.window-app .filtercontainer:last-child {
+  border: none;
+}
+body.-emu .compendium-browser.window-app .filtercontainer .multiselect {
+  background: rgba(var(--color-background), 0.1);
+  border: none;
+  border-radius: 0;
+}
+.-emu-layout
+  body.-emu
+  .compendium-browser.window-app
+  .filtercontainer
+  .multiselect {
+  line-height: 1;
+  margin: 0;
+  padding: var(--emu-space-base);
+}
+.-emu-layout body.-emu .compendium-browser.window-app .filtercontainer dd {
+  display: inline-flex;
+}
+.-emu-layout
+  body.-emu
+  .compendium-browser.window-app
+  .filtercontainer
+  dd
+  select {
+  flex: 1 1 auto;
+  width: auto;
+}
+.-emu-layout
+  body.-emu
+  .compendium-browser.window-app
+  .filtercontainer
+  dd
+  select
+  + input {
+  -webkit-border-start: none;
+  border-inline-start: none;
+  flex: 1 1 100%;
+}
 
 body.-emu .compendium-browser.window-app .settings-group {
   border: none;
-  border-radius: 0; }
-  .-emu-layout body.-emu .compendium-browser.window-app .settings-group {
-    margin: 0;
-    padding: var(--emu-space-base); }
-  .-emu-layout body.-emu .compendium-browser.window-app .settings-group label {
-    align-items: center;
-    display: flex;
-    padding: var(--emu-space-base); }
-    .-emu-layout body.-emu .compendium-browser.window-app .settings-group label:nth-of-type(even) {
-      background-color: rgba(var(--color-background-light), 0.1); }
-    .-emu-layout body.-emu .compendium-browser.window-app .settings-group label input[type="checkbox"] {
-      -webkit-margin-end: var(--emu-space-sm);
-              margin-inline-end: var(--emu-space-sm); }
-    .-emu-layout body.-emu .compendium-browser.window-app .settings-group label h4 {
-      margin: 0; }
+  border-radius: 0;
+}
+.-emu-layout body.-emu .compendium-browser.window-app .settings-group {
+  margin: 0;
+  padding: var(--emu-space-base);
+}
+.-emu-layout body.-emu .compendium-browser.window-app .settings-group label {
+  align-items: center;
+  display: flex;
+  padding: var(--emu-space-base);
+}
+.-emu-layout
+  body.-emu
+  .compendium-browser.window-app
+  .settings-group
+  label:nth-of-type(even) {
+  background-color: rgba(var(--color-background-light), 0.1);
+}
+.-emu-layout
+  body.-emu
+  .compendium-browser.window-app
+  .settings-group
+  label
+  input[type="checkbox"] {
+  -webkit-margin-end: var(--emu-space-sm);
+  margin-inline-end: var(--emu-space-sm);
+}
+.-emu-layout body.-emu .compendium-browser.window-app .settings-group label h4 {
+  margin: 0;
+}
 
 body.-emu .compendium-browser.window-app ul {
   margin: 0;
-  padding: 0; }
+  padding: 0;
+}
 
-.-emu-layout body.-emu #sidebar #compendium > ul.directory-list > .directory-item, .-emu-layout
-body.-emu .sidebar-popout #compendium > ul.directory-list > .directory-item {
+.-emu-layout
+  body.-emu
+  #sidebar
+  #compendium
+  > ul.directory-list
+  > .directory-item,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #compendium
+  > ul.directory-list
+  > .directory-item {
   margin: 0;
   -webkit-margin-after: var(--emu-space-base);
-          margin-block-end: var(--emu-space-base);
-  padding: 0; }
-  .-emu-layout body.-emu #sidebar #compendium > ul.directory-list > .directory-item .compendium-pack, .-emu-layout
-  body.-emu .sidebar-popout #compendium > ul.directory-list > .directory-item .compendium-pack {
-    cursor: pointer;
-    line-height: 1 !important;
-    margin: var(--emu-space-base) !important;
-    padding: 0 var(--emu-space-sm) !important; }
-    .-emu-layout body.-emu #sidebar #compendium > ul.directory-list > .directory-item .compendium-pack:hover, .-emu-layout
-    body.-emu .sidebar-popout #compendium > ul.directory-list > .directory-item .compendium-pack:hover {
-      background-color: rgba(var(--color-primary), 1); }
-      .-emu-layout body.-emu #sidebar #compendium > ul.directory-list > .directory-item .compendium-pack:hover .pack-title,
-      .-emu-layout body.-emu #sidebar #compendium > ul.directory-list > .directory-item .compendium-pack:hover .compendium-footer, .-emu-layout
-      body.-emu .sidebar-popout #compendium > ul.directory-list > .directory-item .compendium-pack:hover .pack-title,
-      .-emu-layout
-      body.-emu .sidebar-popout #compendium > ul.directory-list > .directory-item .compendium-pack:hover .compendium-footer {
-        color: rgba(var(--color-text-lightest), 1); }
-    .-emu-layout body.-emu #sidebar #compendium > ul.directory-list > .directory-item .compendium-pack .pack-title,
-    .-emu-layout body.-emu #sidebar #compendium > ul.directory-list > .directory-item .compendium-pack .compendium-footer, .-emu-layout
-    body.-emu .sidebar-popout #compendium > ul.directory-list > .directory-item .compendium-pack .pack-title,
-    .-emu-layout
-    body.-emu .sidebar-popout #compendium > ul.directory-list > .directory-item .compendium-pack .compendium-footer {
-      color: rgba(var(--color-text), 1); }
-    .-emu-layout body.-emu #sidebar #compendium > ul.directory-list > .directory-item .compendium-pack .pack-title, .-emu-layout
-    body.-emu .sidebar-popout #compendium > ul.directory-list > .directory-item .compendium-pack .pack-title {
-      margin: 0 !important; }
-    .-emu-layout body.-emu #sidebar #compendium > ul.directory-list > .directory-item .compendium-pack i.folder, .-emu-layout
-    body.-emu .sidebar-popout #compendium > ul.directory-list > .directory-item .compendium-pack i.folder {
-      border: none; }
+  margin-block-end: var(--emu-space-base);
+  padding: 0;
+}
+.-emu-layout
+  body.-emu
+  #sidebar
+  #compendium
+  > ul.directory-list
+  > .directory-item
+  .compendium-pack,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #compendium
+  > ul.directory-list
+  > .directory-item
+  .compendium-pack {
+  cursor: pointer;
+  line-height: 1 !important;
+  margin: var(--emu-space-base) !important;
+  padding: 0 var(--emu-space-sm) !important;
+}
+.-emu-layout
+  body.-emu
+  #sidebar
+  #compendium
+  > ul.directory-list
+  > .directory-item
+  .compendium-pack:hover,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #compendium
+  > ul.directory-list
+  > .directory-item
+  .compendium-pack:hover {
+  background-color: rgba(var(--color-primary), 1);
+}
+.-emu-layout
+  body.-emu
+  #sidebar
+  #compendium
+  > ul.directory-list
+  > .directory-item
+  .compendium-pack:hover
+  .pack-title,
+.-emu-layout
+  body.-emu
+  #sidebar
+  #compendium
+  > ul.directory-list
+  > .directory-item
+  .compendium-pack:hover
+  .compendium-footer,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #compendium
+  > ul.directory-list
+  > .directory-item
+  .compendium-pack:hover
+  .pack-title,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #compendium
+  > ul.directory-list
+  > .directory-item
+  .compendium-pack:hover
+  .compendium-footer {
+  color: rgba(var(--color-text-lightest), 1);
+}
+.-emu-layout
+  body.-emu
+  #sidebar
+  #compendium
+  > ul.directory-list
+  > .directory-item
+  .compendium-pack
+  .pack-title,
+.-emu-layout
+  body.-emu
+  #sidebar
+  #compendium
+  > ul.directory-list
+  > .directory-item
+  .compendium-pack
+  .compendium-footer,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #compendium
+  > ul.directory-list
+  > .directory-item
+  .compendium-pack
+  .pack-title,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #compendium
+  > ul.directory-list
+  > .directory-item
+  .compendium-pack
+  .compendium-footer {
+  color: rgba(var(--color-text), 1);
+}
+.-emu-layout
+  body.-emu
+  #sidebar
+  #compendium
+  > ul.directory-list
+  > .directory-item
+  .compendium-pack
+  .pack-title,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #compendium
+  > ul.directory-list
+  > .directory-item
+  .compendium-pack
+  .pack-title {
+  margin: 0 !important;
+}
+.-emu-layout
+  body.-emu
+  #sidebar
+  #compendium
+  > ul.directory-list
+  > .directory-item
+  .compendium-pack
+  i.folder,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #compendium
+  > ul.directory-list
+  > .directory-item
+  .compendium-pack
+  i.folder {
+  border: none;
+}
 
 .-emu-layout body.-emu #custom-hotbar {
-  z-index: 10; }
+  z-index: 10;
+}
 
 .-emu-layout body.-emu #dfcp-rt-buttons {
   justify-content: flex-end;
-  margin: 0 !important; }
+  margin: 0 !important;
+}
 
 body.-emu #dfcp-rt-buttons button {
-  background: transparent; }
-  .-emu-layout body.-emu #dfcp-rt-buttons button {
-    font-size: var(--emu-font-size-md);
-    margin: 0;
-    min-height: 0;
-    max-height: 100%; }
-  .-emu-layout body.-emu #dfcp-rt-buttons button.chat-archive {
-    -webkit-margin-start: var(--emu-space-base) !important;
-            margin-inline-start: var(--emu-space-base) !important; }
-  body.-emu #dfcp-rt-buttons button > i {
-    color: rgba(var(--color-text-lightest), 1); }
-    .-emu-layout body.-emu #dfcp-rt-buttons button > i {
-      font-size: var(--emu-font-size-md);
-      height: auto;
-      line-height: 1;
-      margin: 0;
-      width: auto; }
+  background: transparent;
+}
+.-emu-layout body.-emu #dfcp-rt-buttons button {
+  font-size: var(--emu-font-size-md);
+  margin: 0;
+  min-height: 0;
+  max-height: 100%;
+}
+.-emu-layout body.-emu #dfcp-rt-buttons button.chat-archive {
+  -webkit-margin-start: var(--emu-space-base) !important;
+  margin-inline-start: var(--emu-space-base) !important;
+}
+body.-emu #dfcp-rt-buttons button > i {
+  color: rgba(var(--color-text-lightest), 1);
+}
+.-emu-layout body.-emu #dfcp-rt-buttons button > i {
+  font-size: var(--emu-font-size-md);
+  height: auto;
+  line-height: 1;
+  margin: 0;
+  width: auto;
+}
 
 body.-emu #sidebar #settings #df-chat-enhance-settings h4,
 body.-emu .sidebar-popout #settings #df-chat-enhance-settings h4 {
   -webkit-border-after: rgba(var(--color-border-lighter), 1) 1px solid;
-          border-block-end: rgba(var(--color-border-lighter), 1) 1px solid;
-  color: rgba(var(--color-text-lightest), 1); }
-  .-emu-layout body.-emu #sidebar #settings #df-chat-enhance-settings h4, .-emu-layout
-  body.-emu .sidebar-popout #settings #df-chat-enhance-settings h4 {
-    -webkit-margin-before: var(--emu-space-md) !important;
-            margin-block-start: var(--emu-space-md) !important; }
+  border-block-end: rgba(var(--color-border-lighter), 1) 1px solid;
+  color: rgba(var(--color-text-lightest), 1);
+}
+.-emu-layout body.-emu #sidebar #settings #df-chat-enhance-settings h4,
+.-emu-layout body.-emu .sidebar-popout #settings #df-chat-enhance-settings h4 {
+  -webkit-margin-before: var(--emu-space-md) !important;
+  margin-block-start: var(--emu-space-md) !important;
+}
 
 body.-emu .app.window-app .archive-new table {
   background-color: transparent;
-  border: none; }
-  .-emu-layout body.-emu .app.window-app .archive-new table tr td {
-    padding: var(--emu-space-base); }
-    .-emu-layout body.-emu .app.window-app .archive-new table tr td button {
-      -webkit-margin-before: var(--emu-space-sm);
-              margin-block-start: var(--emu-space-sm); }
+  border: none;
+}
+.-emu-layout body.-emu .app.window-app .archive-new table tr td {
+  padding: var(--emu-space-base);
+}
+.-emu-layout body.-emu .app.window-app .archive-new table tr td button {
+  -webkit-margin-before: var(--emu-space-sm);
+  margin-block-start: var(--emu-space-sm);
+}
 
 body.-emu .app.window-app #dfca-delete-all {
   background-color: rgba(var(--color-negative), 1);
-  border-color: rgba(var(--color-red-800), 1); }
-  .-emu-layout body.-emu .app.window-app #dfca-delete-all {
-    margin: 0;
-    width: 100%; }
+  border-color: rgba(var(--color-red-800), 1);
+}
+.-emu-layout body.-emu .app.window-app #dfca-delete-all {
+  margin: 0;
+  width: 100%;
+}
 
 .-emu-layout body.-emu #df-curvy-walls-tools {
   display: flex;
   left: 6rem;
-  top: 11.5rem; }
+  top: 11.5rem;
+}
 
 .-emu-layout body.-emu #df-curvy-walls-tools .control-tools {
   flex-direction: column;
   flex: 0 0 auto;
   -webkit-margin-end: var(--emu-space-base);
-          margin-inline-end: var(--emu-space-base);
+  margin-inline-end: var(--emu-space-base);
   pointer-events: none;
-  transition: opacity 0.3s cubic-bezier(0.075, 0.82, 0.165, 1), left 0.3s cubic-bezier(0.075, 0.82, 0.165, 1); }
+  transition: opacity 0.3s cubic-bezier(0.075, 0.82, 0.165, 1),
+    left 0.3s cubic-bezier(0.075, 0.82, 0.165, 1);
+}
 
 body.-emu #df-curvy-walls-tools .control-tool {
   background-color: rgba(var(--color-background-lightest), 1);
@@ -5662,465 +15371,986 @@ body.-emu #df-curvy-walls-tools .control-tool {
   border-radius: var(--emu-border-radius-controls, 0);
   box-shadow: none;
   color: rgba(var(--color-text), 1);
-  transition: background 0.3s cubic-bezier(0.075, 0.82, 0.165, 1), box-shadow 0.3s cubic-bezier(0.075, 0.82, 0.165, 1), color 0.3s cubic-bezier(0.075, 0.82, 0.165, 1), opacity 0.3s cubic-bezier(0.075, 0.82, 0.165, 1); }
-  .-emu-layout body.-emu #df-curvy-walls-tools .control-tool {
-    width: var(--emu-space-button-lg);
-    height: var(--emu-space-button-lg);
-    align-items: center;
-    box-sizing: border-box;
-    cursor: pointer;
-    display: flex;
-    justify-content: center;
-    font-size: var(--emu-font-size-lg);
-    line-height: initial;
-    -webkit-margin-after: var(--emu-space-base);
-            margin-block-end: var(--emu-space-base);
-    pointer-events: all;
-    position: relative; }
-  body.-emu #df-curvy-walls-tools .control-tool:hover {
-    background-color: rgba(var(--color-primary), 1);
-    background-image: none;
-    color: rgba(var(--color-text-lightest), 1); }
-  body.-emu #df-curvy-walls-tools .control-tool.active {
-    background-color: rgba(var(--color-primary), 1);
-    background-image: none; }
+  transition: background 0.3s cubic-bezier(0.075, 0.82, 0.165, 1),
+    box-shadow 0.3s cubic-bezier(0.075, 0.82, 0.165, 1),
+    color 0.3s cubic-bezier(0.075, 0.82, 0.165, 1),
+    opacity 0.3s cubic-bezier(0.075, 0.82, 0.165, 1);
+}
+.-emu-layout body.-emu #df-curvy-walls-tools .control-tool {
+  width: var(--emu-space-button-lg);
+  height: var(--emu-space-button-lg);
+  align-items: center;
+  box-sizing: border-box;
+  cursor: pointer;
+  display: flex;
+  justify-content: center;
+  font-size: var(--emu-font-size-lg);
+  line-height: initial;
+  -webkit-margin-after: var(--emu-space-base);
+  margin-block-end: var(--emu-space-base);
+  pointer-events: all;
+  position: relative;
+}
+body.-emu #df-curvy-walls-tools .control-tool:hover {
+  background-color: rgba(var(--color-primary), 1);
+  background-image: none;
+  color: rgba(var(--color-text-lightest), 1);
+}
+body.-emu #df-curvy-walls-tools .control-tool.active {
+  background-color: rgba(var(--color-primary), 1);
+  background-image: none;
+}
 
 .-emu-layout body.-emu .dialog #drop-folder {
-  margin: 0; }
+  margin: 0;
+}
 
 body.-emu .dice-so-nice .dice-more-theme {
   background: none;
   border: none;
   border-radius: none;
-  box-shadow: none; }
-  .-emu-layout body.-emu .dice-so-nice .dice-more-theme {
-    font-size: var(--emu-font-size-lg);
-    margin: 0;
-    padding: var(--emu-space-sm); }
+  box-shadow: none;
+}
+.-emu-layout body.-emu .dice-so-nice .dice-more-theme {
+  font-size: var(--emu-font-size-lg);
+  margin: 0;
+  padding: var(--emu-space-sm);
+}
 
 .-emu-layout body.-emu .dice-so-nice section.content .settings-list {
   overflow-x: hidden;
-  padding: 0; }
+  padding: 0;
+}
 
-.-emu-layout body.-emu .dice-so-nice section.content .settings-list .sfxs-list .sfx {
+.-emu-layout
+  body.-emu
+  .dice-so-nice
+  section.content
+  .settings-list
+  .sfxs-list
+  .sfx {
   display: grid;
   grid-template-columns: 1fr 1fr 1fr -webkit-min-content -webkit-min-content;
   grid-template-columns: 1fr 1fr 1fr min-content min-content;
-  line-height: initial; }
-  .-emu-layout body.-emu .dice-so-nice section.content .settings-list .sfxs-list .sfx:nth-of-type(odd):not(.table-header) {
-    background-color: rgba(var(--color-background-light), 0.1); }
-  .-emu-layout body.-emu .dice-so-nice section.content .settings-list .sfxs-list .sfx > div {
-    width: auto; }
-    .-emu-layout body.-emu .dice-so-nice section.content .settings-list .sfxs-list .sfx > div.sfx-hidden {
-      display: none; }
-  .-emu-layout body.-emu .dice-so-nice section.content .settings-list .sfxs-list .sfx select + input {
-    -webkit-margin-start: var(--emu-space-base);
-            margin-inline-start: var(--emu-space-base); }
+  line-height: initial;
+}
+.-emu-layout
+  body.-emu
+  .dice-so-nice
+  section.content
+  .settings-list
+  .sfxs-list
+  .sfx:nth-of-type(odd):not(.table-header) {
+  background-color: rgba(var(--color-background-light), 0.1);
+}
+.-emu-layout
+  body.-emu
+  .dice-so-nice
+  section.content
+  .settings-list
+  .sfxs-list
+  .sfx
+  > div {
+  width: auto;
+}
+.-emu-layout
+  body.-emu
+  .dice-so-nice
+  section.content
+  .settings-list
+  .sfxs-list
+  .sfx
+  > div.sfx-hidden {
+  display: none;
+}
+.-emu-layout
+  body.-emu
+  .dice-so-nice
+  section.content
+  .settings-list
+  .sfxs-list
+  .sfx
+  select
+  + input {
+  -webkit-margin-start: var(--emu-space-base);
+  margin-inline-start: var(--emu-space-base);
+}
 
-.-emu-layout body.-emu .dice-so-nice section.content .settings-list .sfxs-list .sfx-header {
+.-emu-layout
+  body.-emu
+  .dice-so-nice
+  section.content
+  .settings-list
+  .sfxs-list
+  .sfx-header {
   grid-template-columns: 1fr 1fr 1fr -webkit-min-content;
-  grid-template-columns: 1fr 1fr 1fr min-content; }
+  grid-template-columns: 1fr 1fr 1fr min-content;
+}
 
-body.-emu .dice-so-nice section.content .settings-list .select2 .select2-selection {
+body.-emu
+  .dice-so-nice
+  section.content
+  .settings-list
+  .select2
+  .select2-selection {
   background-color: transparent;
   border: rgba(var(--color-border-lighter), 1) 1px solid;
-  border-radius: var(--emu-border-radius-forms, 0); }
-  .-emu-layout body.-emu .dice-so-nice section.content .settings-list .select2 .select2-selection {
-    height: auto;
-    min-height: var(--emu-space-button);
-    padding: 0; }
-  .-emu-layout body.-emu .dice-so-nice section.content .settings-list .select2 .select2-selection > ul {
-    margin: 0;
-    padding: 0 var(--emu-space-xs); }
-  body.-emu .dice-so-nice section.content .settings-list .select2 .select2-selection > ul > li {
-    background-color: transparent;
-    border: rgba(var(--color-border), 1) 1px solid;
-    border-radius: var(--emu-border-radius-controls, 0); }
-    .-emu-layout body.-emu .dice-so-nice section.content .settings-list .select2 .select2-selection > ul > li {
-      margin: var(--emu-space-xs);
-      padding: 0; }
-    .-emu-layout body.-emu .dice-so-nice section.content .settings-list .select2 .select2-selection > ul > li button {
-      height: var(--emu-space-button-sm); }
+  border-radius: var(--emu-border-radius-forms, 0);
+}
+.-emu-layout
+  body.-emu
+  .dice-so-nice
+  section.content
+  .settings-list
+  .select2
+  .select2-selection {
+  height: auto;
+  min-height: var(--emu-space-button);
+  padding: 0;
+}
+.-emu-layout
+  body.-emu
+  .dice-so-nice
+  section.content
+  .settings-list
+  .select2
+  .select2-selection
+  > ul {
+  margin: 0;
+  padding: 0 var(--emu-space-xs);
+}
+body.-emu
+  .dice-so-nice
+  section.content
+  .settings-list
+  .select2
+  .select2-selection
+  > ul
+  > li {
+  background-color: transparent;
+  border: rgba(var(--color-border), 1) 1px solid;
+  border-radius: var(--emu-border-radius-controls, 0);
+}
+.-emu-layout
+  body.-emu
+  .dice-so-nice
+  section.content
+  .settings-list
+  .select2
+  .select2-selection
+  > ul
+  > li {
+  margin: var(--emu-space-xs);
+  padding: 0;
+}
+.-emu-layout
+  body.-emu
+  .dice-so-nice
+  section.content
+  .settings-list
+  .select2
+  .select2-selection
+  > ul
+  > li
+  button {
+  height: var(--emu-space-button-sm);
+}
 
 body.-emu #sidebar #chat section.dice-tray,
 body.-emu .sidebar-popout #chat section.dice-tray {
   -webkit-border-before: rgba(var(--color-border), 1) 1px solid;
-          border-block-start: rgba(var(--color-border), 1) 1px solid; }
-  .-emu-layout body.-emu #sidebar #chat section.dice-tray, .-emu-layout
-  body.-emu .sidebar-popout #chat section.dice-tray {
-    flex-direction: column; }
-  .-emu-layout body.-emu #sidebar #chat section.dice-tray > .flexrow, .-emu-layout
-  body.-emu .sidebar-popout #chat section.dice-tray > .flexrow {
-    margin: 0;
-    width: 100%; }
-    .-emu-layout body.-emu #sidebar #chat section.dice-tray > .flexrow + .flexrow, .-emu-layout
-    body.-emu .sidebar-popout #chat section.dice-tray > .flexrow + .flexrow {
-      -webkit-margin-before: var(--emu-space-base);
-              margin-block-start: var(--emu-space-base); }
-  body.-emu #sidebar #chat section.dice-tray button.dice-tray__button,
-  body.-emu #sidebar #chat section.dice-tray button.dice-tray__ad,
-  body.-emu #sidebar #chat section.dice-tray button.dice-tray__math,
-  body.-emu #sidebar #chat section.dice-tray button.dice-tray__roll,
-  body.-emu .sidebar-popout #chat section.dice-tray button.dice-tray__button,
-  body.-emu .sidebar-popout #chat section.dice-tray button.dice-tray__ad,
-  body.-emu .sidebar-popout #chat section.dice-tray button.dice-tray__math,
-  body.-emu .sidebar-popout #chat section.dice-tray button.dice-tray__roll {
-    box-shadow: none; }
-    .-emu-layout body.-emu #sidebar #chat section.dice-tray button.dice-tray__button, .-emu-layout
-    body.-emu #sidebar #chat section.dice-tray button.dice-tray__ad, .-emu-layout
-    body.-emu #sidebar #chat section.dice-tray button.dice-tray__math, .-emu-layout
-    body.-emu #sidebar #chat section.dice-tray button.dice-tray__roll, .-emu-layout
-    body.-emu .sidebar-popout #chat section.dice-tray button.dice-tray__button, .-emu-layout
-    body.-emu .sidebar-popout #chat section.dice-tray button.dice-tray__ad, .-emu-layout
-    body.-emu .sidebar-popout #chat section.dice-tray button.dice-tray__math, .-emu-layout
-    body.-emu .sidebar-popout #chat section.dice-tray button.dice-tray__roll {
-      flex: 1 1 auto;
-      font-weight: normal;
-      margin: 0;
-      -webkit-margin-end: var(--emu-space-base);
-              margin-inline-end: var(--emu-space-base); }
-    .-emu-layout body.-emu #sidebar #chat section.dice-tray button.dice-tray__button:last-child, .-emu-layout
-    body.-emu #sidebar #chat section.dice-tray button.dice-tray__ad:last-child, .-emu-layout
-    body.-emu #sidebar #chat section.dice-tray button.dice-tray__math:last-child, .-emu-layout
-    body.-emu #sidebar #chat section.dice-tray button.dice-tray__roll:last-child, .-emu-layout
-    body.-emu .sidebar-popout #chat section.dice-tray button.dice-tray__button:last-child, .-emu-layout
-    body.-emu .sidebar-popout #chat section.dice-tray button.dice-tray__ad:last-child, .-emu-layout
-    body.-emu .sidebar-popout #chat section.dice-tray button.dice-tray__math:last-child, .-emu-layout
-    body.-emu .sidebar-popout #chat section.dice-tray button.dice-tray__roll:last-child {
-      -webkit-margin-end: 0;
-              margin-inline-end: 0; }
-  .-emu-layout body.-emu #sidebar #chat section.dice-tray button.dice-tray__button, .-emu-layout
-  body.-emu .sidebar-popout #chat section.dice-tray button.dice-tray__button {
-    -webkit-margin-start: 0;
-            margin-inline-start: 0;
-    padding: var(--emu-space-base) var(--emu-space-sm); }
-  body.-emu #sidebar #chat section.dice-tray button.dice-tray__button:hover svg *,
-  body.-emu .sidebar-popout #chat section.dice-tray button.dice-tray__button:hover svg * {
-    fill: rgba(var(--color-white), 1); }
-  body.-emu #sidebar #chat section.dice-tray button.dice-tray__button svg,
-  body.-emu .sidebar-popout #chat section.dice-tray button.dice-tray__button svg {
-    transition: initial; }
-  body.-emu #sidebar #chat section.dice-tray .dice-tray__flag,
-  body.-emu .sidebar-popout #chat section.dice-tray .dice-tray__flag {
-    background-color: rgba(var(--color-primary), 1);
-    border-radius: 0;
-    color: rgba(var(--color-text-lightest), 1);
-    transition: max-height 0.1s cubic-bezier(0.77, 0, 0.175, 1); }
-    .-emu-layout body.-emu #sidebar #chat section.dice-tray .dice-tray__flag, .-emu-layout
-    body.-emu .sidebar-popout #chat section.dice-tray .dice-tray__flag {
-      bottom: 100%;
-      left: 0;
-      position: absolute;
-      width: 100%;
-      height: var(--emu-space-button-xs);
-      align-items: center;
-      display: flex;
-      font-size: var(--emu-font-size-md);
-      justify-content: center;
-      line-height: 1;
-      max-height: var(--emu-space-button-xs);
-      overflow: hidden;
-      width: 100%; }
-      .-emu-layout body.-emu #sidebar #chat section.dice-tray .dice-tray__flag.hide, .-emu-layout
-      body.-emu .sidebar-popout #chat section.dice-tray .dice-tray__flag.hide {
-        max-height: 0; }
-  .-emu-layout body.-emu #sidebar #chat section.dice-tray button.dice-tray__math, .-emu-layout
-  body.-emu #sidebar #chat section.dice-tray button.dice-tray__roll, .-emu-layout
-  body.-emu .sidebar-popout #chat section.dice-tray button.dice-tray__math, .-emu-layout
-  body.-emu .sidebar-popout #chat section.dice-tray button.dice-tray__roll {
-    width: auto;
-    height: var(--emu-space-button);
-    flex: 0 0 auto; }
-  .-emu-layout body.-emu #sidebar #chat section.dice-tray button.dice-tray__math--add, .-emu-layout
-  body.-emu #sidebar #chat section.dice-tray button.dice-tray__math--sub, .-emu-layout
-  body.-emu .sidebar-popout #chat section.dice-tray button.dice-tray__math--add, .-emu-layout
-  body.-emu .sidebar-popout #chat section.dice-tray button.dice-tray__math--sub {
-    min-width: var(--emu-space-button); }
-  body.-emu #sidebar #chat section.dice-tray button.dice-tray__advantage:hover,
-  body.-emu #sidebar #chat section.dice-tray button.dice-tray__math--add:hover,
-  body.-emu .sidebar-popout #chat section.dice-tray button.dice-tray__advantage:hover,
-  body.-emu .sidebar-popout #chat section.dice-tray button.dice-tray__math--add:hover {
-    background-color: rgba(var(--color-positive), 1); }
-  body.-emu #sidebar #chat section.dice-tray button.dice-tray__disadvantage:hover,
-  body.-emu #sidebar #chat section.dice-tray button.dice-tray__math--sub:hover,
-  body.-emu .sidebar-popout #chat section.dice-tray button.dice-tray__disadvantage:hover,
-  body.-emu .sidebar-popout #chat section.dice-tray button.dice-tray__math--sub:hover {
-    background-color: rgba(var(--color-negative), 1); }
-  body.-emu #sidebar #chat section.dice-tray input.dice-tray__input,
-  body.-emu .sidebar-popout #chat section.dice-tray input.dice-tray__input {
-    background-color: rgba(var(--color-background-lightest), 1); }
-    .-emu-layout body.-emu #sidebar #chat section.dice-tray input.dice-tray__input, .-emu-layout
-    body.-emu .sidebar-popout #chat section.dice-tray input.dice-tray__input {
-      -webkit-margin-end: var(--emu-space-base);
-              margin-inline-end: var(--emu-space-base); }
-  .-emu-layout body.-emu #sidebar #chat section.dice-tray .dice-tray__stacked, .-emu-layout
-  body.-emu .sidebar-popout #chat section.dice-tray .dice-tray__stacked {
-    height: var(--emu-space-button);
-    -webkit-margin-end: var(--emu-space-base);
-            margin-inline-end: var(--emu-space-base); }
-  .-emu-layout body.-emu #sidebar #chat section.dice-tray button.dice-tray__ad, .-emu-layout
-  body.-emu .sidebar-popout #chat section.dice-tray button.dice-tray__ad {
-    font-size: var(--emu-font-size-xs);
-    margin: 0;
-    padding: 0; }
-  body.-emu #sidebar #chat section.dice-tray button.dice-tray__ad.dice-tray__disadvantage,
-  body.-emu .sidebar-popout #chat section.dice-tray button.dice-tray__ad.dice-tray__disadvantage {
-    -webkit-border-before: rgba(var(--color-border), 1) 1px solid;
-            border-block-start: rgba(var(--color-border), 1) 1px solid; }
+  border-block-start: rgba(var(--color-border), 1) 1px solid;
+}
+.-emu-layout body.-emu #sidebar #chat section.dice-tray,
+.-emu-layout body.-emu .sidebar-popout #chat section.dice-tray {
+  flex-direction: column;
+}
+.-emu-layout body.-emu #sidebar #chat section.dice-tray > .flexrow,
+.-emu-layout body.-emu .sidebar-popout #chat section.dice-tray > .flexrow {
+  margin: 0;
+  width: 100%;
+}
+.-emu-layout body.-emu #sidebar #chat section.dice-tray > .flexrow + .flexrow,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #chat
+  section.dice-tray
+  > .flexrow
+  + .flexrow {
+  -webkit-margin-before: var(--emu-space-base);
+  margin-block-start: var(--emu-space-base);
+}
+body.-emu #sidebar #chat section.dice-tray button.dice-tray__button,
+body.-emu #sidebar #chat section.dice-tray button.dice-tray__ad,
+body.-emu #sidebar #chat section.dice-tray button.dice-tray__math,
+body.-emu #sidebar #chat section.dice-tray button.dice-tray__roll,
+body.-emu .sidebar-popout #chat section.dice-tray button.dice-tray__button,
+body.-emu .sidebar-popout #chat section.dice-tray button.dice-tray__ad,
+body.-emu .sidebar-popout #chat section.dice-tray button.dice-tray__math,
+body.-emu .sidebar-popout #chat section.dice-tray button.dice-tray__roll {
+  box-shadow: none;
+}
+.-emu-layout
+  body.-emu
+  #sidebar
+  #chat
+  section.dice-tray
+  button.dice-tray__button,
+.-emu-layout body.-emu #sidebar #chat section.dice-tray button.dice-tray__ad,
+.-emu-layout body.-emu #sidebar #chat section.dice-tray button.dice-tray__math,
+.-emu-layout body.-emu #sidebar #chat section.dice-tray button.dice-tray__roll,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #chat
+  section.dice-tray
+  button.dice-tray__button,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #chat
+  section.dice-tray
+  button.dice-tray__ad,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #chat
+  section.dice-tray
+  button.dice-tray__math,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #chat
+  section.dice-tray
+  button.dice-tray__roll {
+  flex: 1 1 auto;
+  font-weight: normal;
+  margin: 0;
+  -webkit-margin-end: var(--emu-space-base);
+  margin-inline-end: var(--emu-space-base);
+}
+.-emu-layout
+  body.-emu
+  #sidebar
+  #chat
+  section.dice-tray
+  button.dice-tray__button:last-child,
+.-emu-layout
+  body.-emu
+  #sidebar
+  #chat
+  section.dice-tray
+  button.dice-tray__ad:last-child,
+.-emu-layout
+  body.-emu
+  #sidebar
+  #chat
+  section.dice-tray
+  button.dice-tray__math:last-child,
+.-emu-layout
+  body.-emu
+  #sidebar
+  #chat
+  section.dice-tray
+  button.dice-tray__roll:last-child,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #chat
+  section.dice-tray
+  button.dice-tray__button:last-child,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #chat
+  section.dice-tray
+  button.dice-tray__ad:last-child,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #chat
+  section.dice-tray
+  button.dice-tray__math:last-child,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #chat
+  section.dice-tray
+  button.dice-tray__roll:last-child {
+  -webkit-margin-end: 0;
+  margin-inline-end: 0;
+}
+.-emu-layout
+  body.-emu
+  #sidebar
+  #chat
+  section.dice-tray
+  button.dice-tray__button,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #chat
+  section.dice-tray
+  button.dice-tray__button {
+  -webkit-margin-start: 0;
+  margin-inline-start: 0;
+  padding: var(--emu-space-base) var(--emu-space-sm);
+}
+body.-emu #sidebar #chat section.dice-tray button.dice-tray__button:hover svg *,
+body.-emu
+  .sidebar-popout
+  #chat
+  section.dice-tray
+  button.dice-tray__button:hover
+  svg
+  * {
+  fill: rgba(var(--color-white), 1);
+}
+body.-emu #sidebar #chat section.dice-tray button.dice-tray__button svg,
+body.-emu .sidebar-popout #chat section.dice-tray button.dice-tray__button svg {
+  transition: initial;
+}
+body.-emu #sidebar #chat section.dice-tray .dice-tray__flag,
+body.-emu .sidebar-popout #chat section.dice-tray .dice-tray__flag {
+  background-color: rgba(var(--color-primary), 1);
+  border-radius: 0;
+  color: rgba(var(--color-text-lightest), 1);
+  transition: max-height 0.1s cubic-bezier(0.77, 0, 0.175, 1);
+}
+.-emu-layout body.-emu #sidebar #chat section.dice-tray .dice-tray__flag,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #chat
+  section.dice-tray
+  .dice-tray__flag {
+  bottom: 100%;
+  left: 0;
+  position: absolute;
+  width: 100%;
+  height: var(--emu-space-button-xs);
+  align-items: center;
+  display: flex;
+  font-size: var(--emu-font-size-md);
+  justify-content: center;
+  line-height: 1;
+  max-height: var(--emu-space-button-xs);
+  overflow: hidden;
+  width: 100%;
+}
+.-emu-layout body.-emu #sidebar #chat section.dice-tray .dice-tray__flag.hide,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #chat
+  section.dice-tray
+  .dice-tray__flag.hide {
+  max-height: 0;
+}
+.-emu-layout body.-emu #sidebar #chat section.dice-tray button.dice-tray__math,
+.-emu-layout body.-emu #sidebar #chat section.dice-tray button.dice-tray__roll,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #chat
+  section.dice-tray
+  button.dice-tray__math,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #chat
+  section.dice-tray
+  button.dice-tray__roll {
+  width: auto;
+  height: var(--emu-space-button);
+  flex: 0 0 auto;
+}
+.-emu-layout
+  body.-emu
+  #sidebar
+  #chat
+  section.dice-tray
+  button.dice-tray__math--add,
+.-emu-layout
+  body.-emu
+  #sidebar
+  #chat
+  section.dice-tray
+  button.dice-tray__math--sub,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #chat
+  section.dice-tray
+  button.dice-tray__math--add,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #chat
+  section.dice-tray
+  button.dice-tray__math--sub {
+  min-width: var(--emu-space-button);
+}
+body.-emu #sidebar #chat section.dice-tray button.dice-tray__advantage:hover,
+body.-emu #sidebar #chat section.dice-tray button.dice-tray__math--add:hover,
+body.-emu
+  .sidebar-popout
+  #chat
+  section.dice-tray
+  button.dice-tray__advantage:hover,
+body.-emu
+  .sidebar-popout
+  #chat
+  section.dice-tray
+  button.dice-tray__math--add:hover {
+  background-color: rgba(var(--color-positive), 1);
+}
+body.-emu #sidebar #chat section.dice-tray button.dice-tray__disadvantage:hover,
+body.-emu #sidebar #chat section.dice-tray button.dice-tray__math--sub:hover,
+body.-emu
+  .sidebar-popout
+  #chat
+  section.dice-tray
+  button.dice-tray__disadvantage:hover,
+body.-emu
+  .sidebar-popout
+  #chat
+  section.dice-tray
+  button.dice-tray__math--sub:hover {
+  background-color: rgba(var(--color-negative), 1);
+}
+body.-emu #sidebar #chat section.dice-tray input.dice-tray__input,
+body.-emu .sidebar-popout #chat section.dice-tray input.dice-tray__input {
+  background-color: rgba(var(--color-background-lightest), 1);
+}
+.-emu-layout body.-emu #sidebar #chat section.dice-tray input.dice-tray__input,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #chat
+  section.dice-tray
+  input.dice-tray__input {
+  -webkit-margin-end: var(--emu-space-base);
+  margin-inline-end: var(--emu-space-base);
+}
+.-emu-layout body.-emu #sidebar #chat section.dice-tray .dice-tray__stacked,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #chat
+  section.dice-tray
+  .dice-tray__stacked {
+  height: var(--emu-space-button);
+  -webkit-margin-end: var(--emu-space-base);
+  margin-inline-end: var(--emu-space-base);
+}
+.-emu-layout body.-emu #sidebar #chat section.dice-tray button.dice-tray__ad,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #chat
+  section.dice-tray
+  button.dice-tray__ad {
+  font-size: var(--emu-font-size-xs);
+  margin: 0;
+  padding: 0;
+}
+body.-emu
+  #sidebar
+  #chat
+  section.dice-tray
+  button.dice-tray__ad.dice-tray__disadvantage,
+body.-emu
+  .sidebar-popout
+  #chat
+  section.dice-tray
+  button.dice-tray__ad.dice-tray__disadvantage {
+  -webkit-border-before: rgba(var(--color-border), 1) 1px solid;
+  border-block-start: rgba(var(--color-border), 1) 1px solid;
+}
 
 .-emu-layout body.-emu .dialog--dice-calculator.window-app .dice-calculator {
   -webkit-margin-before: var(--emu-space-sm);
-          margin-block-start: var(--emu-space-sm);
+  margin-block-start: var(--emu-space-sm);
   -webkit-margin-after: 0;
-          margin-block-end: 0; }
-  .-emu-layout body.-emu .dialog--dice-calculator.window-app .dice-calculator .dice-calculator__input > label {
-    font-size: var(--emu-font-size-lg);
-    -webkit-padding-end: var(--emu-space-sm);
-            padding-inline-end: var(--emu-space-sm); }
+  margin-block-end: 0;
+}
+.-emu-layout
+  body.-emu
+  .dialog--dice-calculator.window-app
+  .dice-calculator
+  .dice-calculator__input
+  > label {
+  font-size: var(--emu-font-size-lg);
+  -webkit-padding-end: var(--emu-space-sm);
+  padding-inline-end: var(--emu-space-sm);
+}
 
 body.-emu .dialog--dice-calculator.window-app .dice-calculator > button,
-body.-emu .dialog--dice-calculator.window-app .dice-calculator .dice-calculator--button {
-  color: rgba(var(--color-text-lightest), 1); }
-  .-emu-layout body.-emu .dialog--dice-calculator.window-app .dice-calculator > button, .-emu-layout
-  body.-emu .dialog--dice-calculator.window-app .dice-calculator .dice-calculator--button {
-    font-weight: normal; }
-    .-emu-layout body.-emu .dialog--dice-calculator.window-app .dice-calculator > button + button, .-emu-layout
-    body.-emu .dialog--dice-calculator.window-app .dice-calculator .dice-calculator--button + button {
-      margin: 0; }
+body.-emu
+  .dialog--dice-calculator.window-app
+  .dice-calculator
+  .dice-calculator--button {
+  color: rgba(var(--color-text-lightest), 1);
+}
+.-emu-layout
+  body.-emu
+  .dialog--dice-calculator.window-app
+  .dice-calculator
+  > button,
+.-emu-layout
+  body.-emu
+  .dialog--dice-calculator.window-app
+  .dice-calculator
+  .dice-calculator--button {
+  font-weight: normal;
+}
+.-emu-layout
+  body.-emu
+  .dialog--dice-calculator.window-app
+  .dice-calculator
+  > button
+  + button,
+.-emu-layout
+  body.-emu
+  .dialog--dice-calculator.window-app
+  .dice-calculator
+  .dice-calculator--button
+  + button {
+  margin: 0;
+}
 
-.-emu-layout body.-emu #sidebar .dnd5ehelpers .dice-result, .-emu-layout
-body.-emu .sidebar-popout .dnd5ehelpers .dice-result {
+.-emu-layout body.-emu #sidebar .dnd5ehelpers .dice-result,
+.-emu-layout body.-emu .sidebar-popout .dnd5ehelpers .dice-result {
   -webkit-margin-before: var(--emu-space-base);
-          margin-block-start: var(--emu-space-base); }
+  margin-block-start: var(--emu-space-base);
+}
 
 body.-emu #sidebar .dnd5ehelpers .dice-result .desc,
 body.-emu .sidebar-popout .dnd5ehelpers .dice-result .desc {
-  background-color: rgba(var(--color-background-light), var(--emu-background-opacity-window, 1));
+  background-color: rgba(
+    var(--color-background-light),
+    var(--emu-background-opacity-window, 1)
+  );
   border: rgba(var(--color-border), 1) 1px solid;
   border-radius: var(--emu-border-radius-default, 0);
   box-shadow: 0 2px 4px rgba(var(--color-black), 1);
-  color: rgba(var(--color-text-lightest), 1); }
-  .-emu-layout body.-emu #sidebar .dnd5ehelpers .dice-result .desc, .-emu-layout
-  body.-emu .sidebar-popout .dnd5ehelpers .dice-result .desc {
-    font-size: var(--emu-font-size-sm);
-    padding: var(--emu-space-sm); }
+  color: rgba(var(--color-text-lightest), 1);
+}
+.-emu-layout body.-emu #sidebar .dnd5ehelpers .dice-result .desc,
+.-emu-layout body.-emu .sidebar-popout .dnd5ehelpers .dice-result .desc {
+  font-size: var(--emu-font-size-sm);
+  padding: var(--emu-space-sm);
+}
 
-.-emu-layout body.-emu #sidebar .dnd5ehelpers .cover-button, .-emu-layout
-body.-emu .sidebar-popout .dnd5ehelpers .cover-button {
+.-emu-layout body.-emu #sidebar .dnd5ehelpers .cover-button,
+.-emu-layout body.-emu .sidebar-popout .dnd5ehelpers .cover-button {
   flex-direction: row-reverse;
   margin: 0;
   -webkit-margin-before: var(--emu-space-base);
-          margin-block-start: var(--emu-space-base); }
-  .-emu-layout body.-emu #sidebar .dnd5ehelpers .cover-button img, .-emu-layout
-  body.-emu .sidebar-popout .dnd5ehelpers .cover-button img {
-    margin: 0;
-    -webkit-margin-start: var(--emu-space-base);
-            margin-inline-start: var(--emu-space-base);
-    width: var(--emu-space-button-xs); }
+  margin-block-start: var(--emu-space-base);
+}
+.-emu-layout body.-emu #sidebar .dnd5ehelpers .cover-button img,
+.-emu-layout body.-emu .sidebar-popout .dnd5ehelpers .cover-button img {
+  margin: 0;
+  -webkit-margin-start: var(--emu-space-base);
+  margin-inline-start: var(--emu-space-base);
+  width: var(--emu-space-button-xs);
+}
 
 .-emu-layout body.-emu .ddb-muncher.window-app .tab {
   -webkit-margin-before: var(--emu-space-sm);
-          margin-block-start: var(--emu-space-sm); }
+  margin-block-start: var(--emu-space-sm);
+}
 
-.-emu-layout body.-emu .ddb-muncher.window-app .munching-generic-config, .-emu-layout
-body.-emu .ddb-muncher.window-app .munching-spell-config, .-emu-layout
-body.-emu .ddb-muncher.window-app .munching-item-config, .-emu-layout
-body.-emu .ddb-muncher.window-app .munching-monster-config {
+.-emu-layout body.-emu .ddb-muncher.window-app .munching-generic-config,
+.-emu-layout body.-emu .ddb-muncher.window-app .munching-spell-config,
+.-emu-layout body.-emu .ddb-muncher.window-app .munching-item-config,
+.-emu-layout body.-emu .ddb-muncher.window-app .munching-monster-config {
   align-items: center;
   display: flex;
   -webkit-margin-after: var(--emu-space-sm);
-          margin-block-end: var(--emu-space-sm); }
-  .-emu-layout body.-emu .ddb-muncher.window-app .munching-generic-config input[type="checkbox"], .-emu-layout
-  body.-emu .ddb-muncher.window-app .munching-spell-config input[type="checkbox"], .-emu-layout
-  body.-emu .ddb-muncher.window-app .munching-item-config input[type="checkbox"], .-emu-layout
-  body.-emu .ddb-muncher.window-app .munching-monster-config input[type="checkbox"] {
-    -webkit-margin-end: var(--emu-space-base);
-            margin-inline-end: var(--emu-space-base); }
+  margin-block-end: var(--emu-space-sm);
+}
+.-emu-layout
+  body.-emu
+  .ddb-muncher.window-app
+  .munching-generic-config
+  input[type="checkbox"],
+.-emu-layout
+  body.-emu
+  .ddb-muncher.window-app
+  .munching-spell-config
+  input[type="checkbox"],
+.-emu-layout
+  body.-emu
+  .ddb-muncher.window-app
+  .munching-item-config
+  input[type="checkbox"],
+.-emu-layout
+  body.-emu
+  .ddb-muncher.window-app
+  .munching-monster-config
+  input[type="checkbox"] {
+  -webkit-margin-end: var(--emu-space-base);
+  margin-inline-end: var(--emu-space-base);
+}
 
-.-emu-layout body.-emu .ddb-muncher.window-app #munch-adventure-config-start, .-emu-layout
-body.-emu .ddb-muncher.window-app #munch-adventure-import-start {
+.-emu-layout body.-emu .ddb-muncher.window-app #munch-adventure-config-start,
+.-emu-layout body.-emu .ddb-muncher.window-app #munch-adventure-import-start {
   -webkit-margin-after: var(--emu-space-sm);
-          margin-block-end: var(--emu-space-sm);
-  width: auto; }
+  margin-block-end: var(--emu-space-sm);
+  width: auto;
+}
 
-.-emu-layout body.-emu .ddb-muncher.window-app #munch-feats-start, .-emu-layout
-body.-emu .ddb-muncher.window-app #munch-races-start, .-emu-layout
-body.-emu .ddb-muncher.window-app #munch-classes-start {
+.-emu-layout body.-emu .ddb-muncher.window-app #munch-feats-start,
+.-emu-layout body.-emu .ddb-muncher.window-app #munch-races-start,
+.-emu-layout body.-emu .ddb-muncher.window-app #munch-classes-start {
   margin: 0;
   -webkit-margin-after: var(--emu-space-sm);
-          margin-block-end: var(--emu-space-sm); }
+  margin-block-end: var(--emu-space-sm);
+}
 
-.-emu-layout body.-emu #ddb-importer-settings-compendium #ddb-importer-settings hr {
-  display: none; }
+.-emu-layout
+  body.-emu
+  #ddb-importer-settings-compendium
+  #ddb-importer-settings
+  hr {
+  display: none;
+}
 
 .-emu-layout body.-emu #ddb-importer-settings-compendium .form-group h3 {
   flex: 1 1 auto;
-  margin: 0; }
+  margin: 0;
+}
 
 .-emu-layout body.-emu #ddb-importer-settings-compendium .form-group select {
-  flex: 1 1 auto !important; }
+  flex: 1 1 auto !important;
+}
 
-.-emu-layout body.-emu #ddb-importer-settings-compendium .munching-compendium-setting {
+.-emu-layout
+  body.-emu
+  #ddb-importer-settings-compendium
+  .munching-compendium-setting {
   align-items: center;
   display: flex;
-  margin: var(--emu-space-sm) 0; }
-  .-emu-layout body.-emu #ddb-importer-settings-compendium .munching-compendium-setting input[type="checkbox"] {
-    -webkit-margin-end: var(--emu-space-base);
-            margin-inline-end: var(--emu-space-base); }
+  margin: var(--emu-space-sm) 0;
+}
+.-emu-layout
+  body.-emu
+  #ddb-importer-settings-compendium
+  .munching-compendium-setting
+  input[type="checkbox"] {
+  -webkit-margin-end: var(--emu-space-base);
+  margin-inline-end: var(--emu-space-base);
+}
 
-.-emu-layout body.-emu .active-effect-sheet[id*="ActiveEffectsConfig-"] .tab > div:last-of-type:not(.form-group) {
+.-emu-layout
+  body.-emu
+  .active-effect-sheet[id*="ActiveEffectsConfig-"]
+  .tab
+  > div:last-of-type:not(.form-group) {
   border: none !important;
   padding: 0 !important;
-  text-align: initial !important; }
+  text-align: initial !important;
+}
 
-.-emu-layout body.-emu .active-effect-sheet[id*="ActiveEffectsConfig-"] .tab .effect-change textarea {
+.-emu-layout
+  body.-emu
+  .active-effect-sheet[id*="ActiveEffectsConfig-"]
+  .tab
+  .effect-change
+  textarea {
   min-height: var(--emu-space-button);
   -webkit-padding-before: calc(var(--emu-space-base) + var(--emu-space-xs));
-          padding-block-start: calc(var(--emu-space-base) + var(--emu-space-xs));
+  padding-block-start: calc(var(--emu-space-base) + var(--emu-space-xs));
   -webkit-padding-after: calc(var(--emu-space-base) + var(--emu-space-xs));
-          padding-block-end: calc(var(--emu-space-base) + var(--emu-space-xs)); }
+  padding-block-end: calc(var(--emu-space-base) + var(--emu-space-xs));
+}
 
-body.-emu .active-effect-sheet[id*="ActiveEffectsConfig-"] .effect-special-duration {
+body.-emu
+  .active-effect-sheet[id*="ActiveEffectsConfig-"]
+  .effect-special-duration {
   background-color: rgba(var(--color-background), 0.05);
-  background-image: var(--emu-image-background, none); }
-  .-emu-layout body.-emu .active-effect-sheet[id*="ActiveEffectsConfig-"] .effect-special-duration {
-    align-items: center;
-    padding: var(--emu-space-base) var(--emu-space-sm); }
-    .-emu-layout body.-emu .active-effect-sheet[id*="ActiveEffectsConfig-"] .effect-special-duration > div {
-      align-content: initial !important;
-      width: auto !important; }
-    .-emu-layout body.-emu .active-effect-sheet[id*="ActiveEffectsConfig-"] .effect-special-duration > div:not(.effect-controls) {
-      text-align: initial !important;
-      width: auto !important; }
-  body.-emu .active-effect-sheet[id*="ActiveEffectsConfig-"] .effect-special-duration .effect-control {
-    color: rgba(var(--color-text), 1); }
+  background-image: var(--emu-image-background, none);
+}
+.-emu-layout
+  body.-emu
+  .active-effect-sheet[id*="ActiveEffectsConfig-"]
+  .effect-special-duration {
+  align-items: center;
+  padding: var(--emu-space-base) var(--emu-space-sm);
+}
+.-emu-layout
+  body.-emu
+  .active-effect-sheet[id*="ActiveEffectsConfig-"]
+  .effect-special-duration
+  > div {
+  align-content: initial !important;
+  width: auto !important;
+}
+.-emu-layout
+  body.-emu
+  .active-effect-sheet[id*="ActiveEffectsConfig-"]
+  .effect-special-duration
+  > div:not(.effect-controls) {
+  text-align: initial !important;
+  width: auto !important;
+}
+body.-emu
+  .active-effect-sheet[id*="ActiveEffectsConfig-"]
+  .effect-special-duration
+  .effect-control {
+  color: rgba(var(--color-text), 1);
+}
 
-body.-emu .active-effect-sheet[id*="ActiveEffectsConfig-"] .special-duration-list .effect-special-duration {
-  background-color: transparent; }
-
-.-emu-layout body.-emu .active-effect-sheet[id*="ActiveEffectsConfig-"] .changes-list .effect-change .keylist {
-  -webkit-margin-start: var(--emu-space-base);
-          margin-inline-start: var(--emu-space-base); }
-
-.-emu-layout body.-emu .window-app[id*="ActiveEffects-"] .window-content > form {
-  display: flex;
-  flex-direction: column; }
-  .-emu-layout body.-emu .window-app[id*="ActiveEffects-"] .window-content > form > section {
-    flex: 1 1 auto;
-    overflow-y: auto; }
-    .-emu-layout body.-emu .window-app[id*="ActiveEffects-"] .window-content > form > section:first-child {
-      flex: 0 0 auto; }
-      .-emu-layout body.-emu .window-app[id*="ActiveEffects-"] .window-content > form > section:first-child > div > div {
-        border: none !important; }
-
-body.-emu .window-app[id*="ActiveEffects-"] .window-content > form ul.filter-list {
-  -webkit-border-before: none;
-          border-block-start: none;
-  -webkit-border-after: rgba(var(--color-primary), 1) 2px solid;
-          border-block-end: rgba(var(--color-primary), 1) 2px solid; }
-  .-emu-layout body.-emu .window-app[id*="ActiveEffects-"] .window-content > form ul.filter-list {
-    display: flex;
-    flex: 0 0 auto;
-    height: initial;
-    line-height: initial;
-    margin: 0;
-    max-width: 100%;
-    position: relative; }
-
-body.-emu .window-app[id*="ActiveEffects-"] .window-content > form li.filter-item {
+body.-emu
+  .active-effect-sheet[id*="ActiveEffectsConfig-"]
+  .special-duration-list
+  .effect-special-duration {
   background-color: transparent;
-  border-radius: var(--emu-border-radius-default, 0) var(--emu-border-radius-default, 0) 0 0;
-  color: rgba(var(--color-text), 1); }
-  .-emu-layout body.-emu .window-app[id*="ActiveEffects-"] .window-content > form li.filter-item {
-    flex: 1;
-    font-size: var(--emu-font-size-md);
-    text-shadow: none; }
+}
 
-.-emu-layout body.-emu .window-app[id*="ActiveEffects-"] .window-content > form .dnd5e.sheet.item {
+.-emu-layout
+  body.-emu
+  .active-effect-sheet[id*="ActiveEffectsConfig-"]
+  .changes-list
+  .effect-change
+  .keylist {
+  -webkit-margin-start: var(--emu-space-base);
+  margin-inline-start: var(--emu-space-base);
+}
+
+.-emu-layout
+  body.-emu
+  .window-app[id*="ActiveEffects-"]
+  .window-content
+  > form {
+  display: flex;
+  flex-direction: column;
+}
+.-emu-layout
+  body.-emu
+  .window-app[id*="ActiveEffects-"]
+  .window-content
+  > form
+  > section {
+  flex: 1 1 auto;
+  overflow-y: auto;
+}
+.-emu-layout
+  body.-emu
+  .window-app[id*="ActiveEffects-"]
+  .window-content
+  > form
+  > section:first-child {
+  flex: 0 0 auto;
+}
+.-emu-layout
+  body.-emu
+  .window-app[id*="ActiveEffects-"]
+  .window-content
+  > form
+  > section:first-child
+  > div
+  > div {
+  border: none !important;
+}
+
+body.-emu
+  .window-app[id*="ActiveEffects-"]
+  .window-content
+  > form
+  ul.filter-list {
+  -webkit-border-before: none;
+  border-block-start: none;
+  -webkit-border-after: rgba(var(--color-primary), 1) 2px solid;
+  border-block-end: rgba(var(--color-primary), 1) 2px solid;
+}
+.-emu-layout
+  body.-emu
+  .window-app[id*="ActiveEffects-"]
+  .window-content
+  > form
+  ul.filter-list {
+  display: flex;
+  flex: 0 0 auto;
+  height: initial;
+  line-height: initial;
+  margin: 0;
+  max-width: 100%;
+  position: relative;
+}
+
+body.-emu
+  .window-app[id*="ActiveEffects-"]
+  .window-content
+  > form
+  li.filter-item {
+  background-color: transparent;
+  border-radius: var(--emu-border-radius-default, 0)
+    var(--emu-border-radius-default, 0) 0 0;
+  color: rgba(var(--color-text), 1);
+}
+.-emu-layout
+  body.-emu
+  .window-app[id*="ActiveEffects-"]
+  .window-content
+  > form
+  li.filter-item {
+  flex: 1;
+  font-size: var(--emu-font-size-md);
+  text-shadow: none;
+}
+
+.-emu-layout
+  body.-emu
+  .window-app[id*="ActiveEffects-"]
+  .window-content
+  > form
+  .dnd5e.sheet.item {
   max-height: 100%;
   min-height: 0;
-  min-width: 0; }
+  min-width: 0;
+}
 
-.-emu-layout body.-emu .window-app[id*="ActiveEffects-"] .window-content > form .dnd5e.sheet.item .effect-header {
+.-emu-layout
+  body.-emu
+  .window-app[id*="ActiveEffects-"]
+  .window-content
+  > form
+  .dnd5e.sheet.item
+  .effect-header {
   display: grid;
   grid-auto-flow: column;
   grid-auto-columns: 1fr;
   flex-wrap: nowrap;
   line-height: 1;
   -webkit-margin-after: 0;
-          margin-block-end: 0; }
+  margin-block-end: 0;
+}
 
-body.-emu .window-app[id*="ActiveEffects-"] .window-content > form .dnd5e.sheet.item .effect-header > div {
+body.-emu
+  .window-app[id*="ActiveEffects-"]
+  .window-content
+  > form
+  .dnd5e.sheet.item
+  .effect-header
+  > div {
   align-items: center;
-  border: none; }
-  .-emu-layout body.-emu .window-app[id*="ActiveEffects-"] .window-content > form .dnd5e.sheet.item .effect-header > div {
-    flex-wrap: nowrap; }
+  border: none;
+}
+.-emu-layout
+  body.-emu
+  .window-app[id*="ActiveEffects-"]
+  .window-content
+  > form
+  .dnd5e.sheet.item
+  .effect-header
+  > div {
+  flex-wrap: nowrap;
+}
 
 .-emu-layout body.-emu #emu-settings form {
   display: flex;
   flex-direction: column;
   max-height: 80vh;
-  overflow: hidden; }
+  overflow: hidden;
+}
 
 body.-emu #emu-settings form h3 {
   -webkit-border-after: rgba(var(--color-border), 1) 1px solid;
-          border-block-end: rgba(var(--color-border), 1) 1px solid; }
-  .-emu-layout body.-emu #emu-settings form h3 {
-    -webkit-margin-before: var(--emu-space-sm);
-            margin-block-start: var(--emu-space-sm); }
+  border-block-end: rgba(var(--color-border), 1) 1px solid;
+}
+.-emu-layout body.-emu #emu-settings form h3 {
+  -webkit-margin-before: var(--emu-space-sm);
+  margin-block-start: var(--emu-space-sm);
+}
 
 .-emu-layout body.-emu #emu-settings .tab > .notes {
   -webkit-margin-before: var(--emu-space-sm);
-          margin-block-start: var(--emu-space-sm); }
+  margin-block-start: var(--emu-space-sm);
+}
 
 .-emu-layout body.-emu #emu-settings .content {
   flex: 1 1 auto;
-  overflow: auto; }
+  overflow: auto;
+}
 
 .-emu-layout body.-emu #emu-settings .sheet-footer {
   flex: 0 0 auto;
   -webkit-padding-before: var(--emu-space-sm);
-          padding-block-start: var(--emu-space-sm); }
+  padding-block-start: var(--emu-space-sm);
+}
 
 body.-emu #sidebar .sidebar-tab .directory-footer button.quest-log-btn,
 body.-emu .sidebar-popout .sidebar-tab .directory-footer button.quest-log-btn {
-  flex: 1 1 auto; }
+  flex: 1 1 auto;
+}
 
 .-emu-layout body.-emu #fui-default-icons .item-type-entry {
   -webkit-margin-after: var(--emu-space-base);
-          margin-block-end: var(--emu-space-base); }
-  .-emu-layout body.-emu #fui-default-icons .item-type-entry img {
-    width: 2.75rem;
-    height: 2.75rem;
-    flex: 0 0 auto; }
-  .-emu-layout body.-emu #fui-default-icons .item-type-entry label {
-    flex: 1 1 auto;
-    margin: 0 var(--emu-space-sm); }
-  .-emu-layout body.-emu #fui-default-icons .item-type-entry input {
-    flex: 1 1 auto;
-    font-size: var(--emu-font-size-md);
-    height: var(--emu-space-button);
-    margin: 0 var(--emu-space-base);
-    min-width: 0; }
-  .-emu-layout body.-emu #fui-default-icons .item-type-entry button.file-picker > i {
-    margin: 0; }
+  margin-block-end: var(--emu-space-base);
+}
+.-emu-layout body.-emu #fui-default-icons .item-type-entry img {
+  width: 2.75rem;
+  height: 2.75rem;
+  flex: 0 0 auto;
+}
+.-emu-layout body.-emu #fui-default-icons .item-type-entry label {
+  flex: 1 1 auto;
+  margin: 0 var(--emu-space-sm);
+}
+.-emu-layout body.-emu #fui-default-icons .item-type-entry input {
+  flex: 1 1 auto;
+  font-size: var(--emu-font-size-md);
+  height: var(--emu-space-button);
+  margin: 0 var(--emu-space-base);
+  min-width: 0;
+}
+.-emu-layout
+  body.-emu
+  #fui-default-icons
+  .item-type-entry
+  button.file-picker
+  > i {
+  margin: 0;
+}
 
 .-emu-layout body.-emu #fui-item-properties .window-content {
-  padding: var(--emu-space-sm); }
-  .-emu-layout body.-emu #fui-item-properties .window-content section {
-    padding: 0; }
-  .-emu-layout body.-emu #fui-item-properties .window-content .nav-body {
-    margin: var(--emu-space-sm) 0; }
-    .-emu-layout body.-emu #fui-item-properties .window-content .nav-body .type-property {
-      -webkit-margin-after: var(--emu-space-base);
-              margin-block-end: var(--emu-space-base); }
-      .-emu-layout body.-emu #fui-item-properties .window-content .nav-body .type-property > label {
-        -webkit-margin-start: var(--emu-space-base);
-                margin-inline-start: var(--emu-space-base); }
+  padding: var(--emu-space-sm);
+}
+.-emu-layout body.-emu #fui-item-properties .window-content section {
+  padding: 0;
+}
+.-emu-layout body.-emu #fui-item-properties .window-content .nav-body {
+  margin: var(--emu-space-sm) 0;
+}
+.-emu-layout
+  body.-emu
+  #fui-item-properties
+  .window-content
+  .nav-body
+  .type-property {
+  -webkit-margin-after: var(--emu-space-base);
+  margin-block-end: var(--emu-space-base);
+}
+.-emu-layout
+  body.-emu
+  #fui-item-properties
+  .window-content
+  .nav-body
+  .type-property
+  > label {
+  -webkit-margin-start: var(--emu-space-base);
+  margin-inline-start: var(--emu-space-base);
+}
 
 body.-emu #fui-item-properties .nav-tabs {
   -webkit-border-before: 2px solid rgba(var(--color-primary), 1);
-          border-block-start: 2px solid rgba(var(--color-primary), 1); }
+  border-block-start: 2px solid rgba(var(--color-primary), 1);
+}
 
 body.-emu .fpsCounter {
   background: none;
@@ -6129,1142 +16359,2143 @@ body.-emu .fpsCounter {
   border: rgba(var(--color-border), 1) 1px solid;
   border-radius: var(--emu-border-radius-default, 0);
   box-shadow: 0 2px 4px rgba(var(--color-black), 1);
-  color: rgba(var(--color-text-lightest), 1); }
-  .-emu-layout body.-emu .fpsCounter {
-    align-items: center;
-    display: flex;
-    flex: 0 0 auto;
-    font-size: var(--emu-font-size-lg);
-    height: var(--emu-space-button);
-    line-height: initial;
-    margin: 0;
-    min-width: var(--emu-space-button);
-    padding: var(--emu-space-xs);
-    text-align: start;
-    width: auto;
-    z-index: 10; }
+  color: rgba(var(--color-text-lightest), 1);
+}
+.-emu-layout body.-emu .fpsCounter {
+  align-items: center;
+  display: flex;
+  flex: 0 0 auto;
+  font-size: var(--emu-font-size-lg);
+  height: var(--emu-space-button);
+  line-height: initial;
+  margin: 0;
+  min-width: var(--emu-space-button);
+  padding: var(--emu-space-xs);
+  text-align: start;
+  width: auto;
+  z-index: 10;
+}
 
 body.-emu #specials-config .fxmaster {
   background-color: rgba(var(--color-background-lightest), 1);
-  background-image: var(--emu-image-background-lightest, none); }
-  body.-emu #specials-config .fxmaster .directory-header {
-    box-shadow: none; }
-    .-emu-layout body.-emu #specials-config .fxmaster .directory-header {
-      flex-direction: row; }
-      .-emu-layout body.-emu #specials-config .fxmaster .directory-header > div {
-        flex: 1 1 auto; }
-        .-emu-layout body.-emu #specials-config .fxmaster .directory-header > div:first-child {
-          -webkit-padding-end: var(--emu-space-base);
-                  padding-inline-end: var(--emu-space-base); }
-          .-emu-layout body.-emu #specials-config .fxmaster .directory-header > div:first-child a i {
-            margin: 0; }
-    body.-emu #specials-config .fxmaster .directory-header a {
-      width: 100%; }
-      body.-emu #specials-config .fxmaster .directory-header a > i {
-        -webkit-margin-start: var(--emu-space-sm);
-                margin-inline-start: var(--emu-space-sm); }
-  body.-emu #specials-config .fxmaster .special-effects {
-    background-color: rgba(var(--color-folder-directory), 1); }
-    body.-emu #specials-config .fxmaster .special-effects .preview {
-      background-color: rgba(var(--color-black), 0.1);
-      border: none; }
-      .-emu-layout body.-emu #specials-config .fxmaster .special-effects .preview {
-        width: var(--emu-space-button);
-        height: var(--emu-space-button);
-        flex: 0 0 auto;
-        margin: var(--emu-space-base);
-        overflow: hidden; }
-        .-emu-layout body.-emu #specials-config .fxmaster .special-effects .preview > video {
-          height: 100%;
-          width: 100%; }
-    .-emu-layout body.-emu #specials-config .fxmaster .special-effects .description {
-      align-items: center;
-      display: flex;
-      padding: var(--emu-space-sm); }
-      .-emu-layout body.-emu #specials-config .fxmaster .special-effects .description h4 {
-        color: rgba(var(--color-text-lightest), 1);
-        font-size: var(--emu-font-size-lg);
-        height: auto;
-        text-indent: 0; }
-    body.-emu #specials-config .fxmaster .special-effects .description .author {
-      color: rgba(var(--color-text-lightest), 1); }
-      .-emu-layout body.-emu #specials-config .fxmaster .special-effects .description .author {
-        font-size: var(--emu-font-size-sm);
-        line-height: 1.2;
-        text-align: left; }
-    .-emu-layout body.-emu #specials-config .fxmaster .special-effects .controls {
-      flex: 0 0 auto;
-      line-height: 1;
-      padding: 0; }
-  .-emu-layout body.-emu #specials-config .fxmaster .directory-item:last-of-type {
-    -webkit-margin-after: var(--emu-space-sm);
-            margin-block-end: var(--emu-space-sm); }
-  .-emu-layout body.-emu #specials-config .fxmaster .directory-footer {
-    display: none; }
+  background-image: var(--emu-image-background-lightest, none);
+}
+body.-emu #specials-config .fxmaster .directory-header {
+  box-shadow: none;
+}
+.-emu-layout body.-emu #specials-config .fxmaster .directory-header {
+  flex-direction: row;
+}
+.-emu-layout body.-emu #specials-config .fxmaster .directory-header > div {
+  flex: 1 1 auto;
+}
+.-emu-layout
+  body.-emu
+  #specials-config
+  .fxmaster
+  .directory-header
+  > div:first-child {
+  -webkit-padding-end: var(--emu-space-base);
+  padding-inline-end: var(--emu-space-base);
+}
+.-emu-layout
+  body.-emu
+  #specials-config
+  .fxmaster
+  .directory-header
+  > div:first-child
+  a
+  i {
+  margin: 0;
+}
+body.-emu #specials-config .fxmaster .directory-header a {
+  width: 100%;
+}
+body.-emu #specials-config .fxmaster .directory-header a > i {
+  -webkit-margin-start: var(--emu-space-sm);
+  margin-inline-start: var(--emu-space-sm);
+}
+body.-emu #specials-config .fxmaster .special-effects {
+  background-color: rgba(var(--color-folder-directory), 1);
+}
+body.-emu #specials-config .fxmaster .special-effects .preview {
+  background-color: rgba(var(--color-black), 0.1);
+  border: none;
+}
+.-emu-layout body.-emu #specials-config .fxmaster .special-effects .preview {
+  width: var(--emu-space-button);
+  height: var(--emu-space-button);
+  flex: 0 0 auto;
+  margin: var(--emu-space-base);
+  overflow: hidden;
+}
+.-emu-layout
+  body.-emu
+  #specials-config
+  .fxmaster
+  .special-effects
+  .preview
+  > video {
+  height: 100%;
+  width: 100%;
+}
+.-emu-layout
+  body.-emu
+  #specials-config
+  .fxmaster
+  .special-effects
+  .description {
+  align-items: center;
+  display: flex;
+  padding: var(--emu-space-sm);
+}
+.-emu-layout
+  body.-emu
+  #specials-config
+  .fxmaster
+  .special-effects
+  .description
+  h4 {
+  color: rgba(var(--color-text-lightest), 1);
+  font-size: var(--emu-font-size-lg);
+  height: auto;
+  text-indent: 0;
+}
+body.-emu #specials-config .fxmaster .special-effects .description .author {
+  color: rgba(var(--color-text-lightest), 1);
+}
+.-emu-layout
+  body.-emu
+  #specials-config
+  .fxmaster
+  .special-effects
+  .description
+  .author {
+  font-size: var(--emu-font-size-sm);
+  line-height: 1.2;
+  text-align: left;
+}
+.-emu-layout body.-emu #specials-config .fxmaster .special-effects .controls {
+  flex: 0 0 auto;
+  line-height: 1;
+  padding: 0;
+}
+.-emu-layout body.-emu #specials-config .fxmaster .directory-item:last-of-type {
+  -webkit-margin-after: var(--emu-space-sm);
+  margin-block-end: var(--emu-space-sm);
+}
+.-emu-layout body.-emu #specials-config .fxmaster .directory-footer {
+  display: none;
+}
 
 body.-emu #effects-config .directory-list {
   background-color: rgba(var(--color-background-lightest), 1);
-  background-image: var(--emu-image-background-lightest, none); }
-  .-emu-layout body.-emu #effects-config .directory-list {
-    height: auto;
-    overflow-x: hidden;
-    overflow-y: auto; }
+  background-image: var(--emu-image-background-lightest, none);
+}
+.-emu-layout body.-emu #effects-config .directory-list {
+  height: auto;
+  overflow-x: hidden;
+  overflow-y: auto;
+}
 
 body.-emu #effects-config .directory-item {
   -webkit-border-after: rgba(var(--color-border), 1) 1px solid;
-          border-block-end: rgba(var(--color-border), 1) 1px solid; }
-  .-emu-layout body.-emu #effects-config .directory-item {
-    padding: var(--emu-space-base); }
-  .-emu-layout body.-emu #effects-config .directory-item header {
-    align-items: center; }
-  body.-emu #effects-config .directory-item header label {
-    color: rgba(var(--color-text), 1);
-    text-shadow: none; }
-    .-emu-layout body.-emu #effects-config .directory-item header label {
-      -webkit-padding-start: var(--emu-space-sm);
-              padding-inline-start: var(--emu-space-sm);
-      text-indent: 0; }
-    body.-emu #effects-config .directory-item header label:hover {
-      color: rgba(var(--color-primary), 1); }
+  border-block-end: rgba(var(--color-border), 1) 1px solid;
+}
+.-emu-layout body.-emu #effects-config .directory-item {
+  padding: var(--emu-space-base);
+}
+.-emu-layout body.-emu #effects-config .directory-item header {
+  align-items: center;
+}
+body.-emu #effects-config .directory-item header label {
+  color: rgba(var(--color-text), 1);
+  text-shadow: none;
+}
+.-emu-layout body.-emu #effects-config .directory-item header label {
+  -webkit-padding-start: var(--emu-space-sm);
+  padding-inline-start: var(--emu-space-sm);
+  text-indent: 0;
+}
+body.-emu #effects-config .directory-item header label:hover {
+  color: rgba(var(--color-primary), 1);
+}
 
 body.-emu #effects-config .form-footer {
   background-color: rgba(var(--color-background-lightest), 1);
-  background-image: var(--emu-image-background-lightest, none); }
-  .-emu-layout body.-emu #effects-config .form-footer {
-    bottom: 0;
-    padding: var(--emu-space-sm);
-    position: -webkit-sticky;
-    position: sticky; }
+  background-image: var(--emu-image-background-lightest, none);
+}
+.-emu-layout body.-emu #effects-config .form-footer {
+  bottom: 0;
+  padding: var(--emu-space-sm);
+  position: -webkit-sticky;
+  position: sticky;
+}
 
-.-emu-layout body.-emu #effects-config input[type="checkbox"] + input[type="color"] {
+.-emu-layout
+  body.-emu
+  #effects-config
+  input[type="checkbox"]
+  + input[type="color"] {
   -webkit-margin-start: var(--emu-space-base);
-          margin-inline-start: var(--emu-space-base); }
+  margin-inline-start: var(--emu-space-base);
+}
 
 .-emu-layout body.-emu #filter-config .window-content form {
-  height: auto; }
+  height: auto;
+}
 
 .-emu-layout body.-emu #filter-config .directory-list {
   height: auto;
   overflow-x: hidden;
   overflow-y: auto;
   -webkit-padding-after: var(--emu-space-sm);
-          padding-block-end: var(--emu-space-sm); }
+  padding-block-end: var(--emu-space-sm);
+}
 
 body.-emu #filter-config .form-footer {
   background-color: rgba(var(--color-background-lightest), 1);
   background-image: var(--emu-image-background-lightest, none);
   -webkit-border-before: rgba(var(--color-border), 1) 1px solid;
-          border-block-start: rgba(var(--color-border), 1) 1px solid; }
-  .-emu-layout body.-emu #filter-config .form-footer {
-    bottom: 0;
-    -webkit-padding-before: var(--emu-space-sm);
-            padding-block-start: var(--emu-space-sm);
-    position: -webkit-sticky;
-    position: sticky; }
+  border-block-start: rgba(var(--color-border), 1) 1px solid;
+}
+.-emu-layout body.-emu #filter-config .form-footer {
+  bottom: 0;
+  -webkit-padding-before: var(--emu-space-sm);
+  padding-block-start: var(--emu-space-sm);
+  position: -webkit-sticky;
+  position: sticky;
+}
 
-.-emu-layout body.-emu #filter-config input[type="checkbox"] + input[type="color"] {
+.-emu-layout
+  body.-emu
+  #filter-config
+  input[type="checkbox"]
+  + input[type="color"] {
   -webkit-margin-start: var(--emu-space-base);
-          margin-inline-start: var(--emu-space-base); }
+  margin-inline-start: var(--emu-space-base);
+}
 
 .-emu-layout body.-emu .app.window-app .open-gm-note > i {
-  margin: 0 var(--emu-space-base); }
+  margin: 0 var(--emu-space-base);
+}
 
 .-emu-layout body.-emu .gm-notes.window-app .controlls {
-  display: flex; }
-  .-emu-layout body.-emu .gm-notes.window-app .controlls button {
-    flex: 1 1 auto; }
+  display: flex;
+}
+.-emu-layout body.-emu .gm-notes.window-app .controlls button {
+  flex: 1 1 auto;
+}
 
 .-emu-layout body.-emu .gm-screen-config.window-app.app table td {
-  padding: var(--emu-space-base); }
+  padding: var(--emu-space-base);
+}
 
 .-emu-layout body.-emu .gm-screen-config.window-app.app table button > i {
-  margin: 0; }
+  margin: 0;
+}
 
 .-emu-layout body.-emu .gm-screen-config.window-app.app table ~ button {
-  width: auto; }
+  width: auto;
+}
 
 .-emu-layout body.-emu .gm-screen-app.gm-screen-drawer.window-app {
-  transition: transform 0.3s cubic-bezier(0.77, 0, 0.175, 1); }
-  .-emu-layout body.-emu .gm-screen-app.gm-screen-drawer.window-app .gm-screen-actions.tabs {
-    position: absolute; }
-    .-emu-layout body.-emu .gm-screen-app.gm-screen-drawer.window-app .gm-screen-actions.tabs button:empty {
-      display: none; }
-    .-emu-layout body.-emu .gm-screen-app.gm-screen-drawer.window-app .gm-screen-actions.tabs .meta-actions {
-      transition-delay: initial;
-      transition: transform 0.3s cubic-bezier(0.77, 0, 0.175, 1); }
-      .-emu-layout body.-emu .gm-screen-app.gm-screen-drawer.window-app .gm-screen-actions.tabs .meta-actions button > i {
-        margin: 0; }
+  transition: transform 0.3s cubic-bezier(0.77, 0, 0.175, 1);
+}
+.-emu-layout
+  body.-emu
+  .gm-screen-app.gm-screen-drawer.window-app
+  .gm-screen-actions.tabs {
+  position: absolute;
+}
+.-emu-layout
+  body.-emu
+  .gm-screen-app.gm-screen-drawer.window-app
+  .gm-screen-actions.tabs
+  button:empty {
+  display: none;
+}
+.-emu-layout
+  body.-emu
+  .gm-screen-app.gm-screen-drawer.window-app
+  .gm-screen-actions.tabs
+  .meta-actions {
+  transition-delay: initial;
+  transition: transform 0.3s cubic-bezier(0.77, 0, 0.175, 1);
+}
+.-emu-layout
+  body.-emu
+  .gm-screen-app.gm-screen-drawer.window-app
+  .gm-screen-actions.tabs
+  .meta-actions
+  button
+  > i {
+  margin: 0;
+}
 
 .-emu-layout body.-emu #healthestimate-style-form .window-content form {
-  padding: var(--emu-space-sm) !important; }
+  padding: var(--emu-space-sm) !important;
+}
 
-.-emu-layout body.-emu #healthestimate-style-form .window-content .sheet-footer {
+.-emu-layout
+  body.-emu
+  #healthestimate-style-form
+  .window-content
+  .sheet-footer {
   bottom: 0;
   position: -webkit-sticky;
-  position: sticky; }
+  position: sticky;
+}
 
 .-emu-layout body.-emu #healthestimate-death-form .sheet-footer button {
   -webkit-margin-before: var(--emu-space-sm);
-          margin-block-start: var(--emu-space-sm); }
+  margin-block-start: var(--emu-space-sm);
+}
 
 body.-emu .chat-notifications.settings nav {
-  background-color: transparent; }
-  .-emu-layout body.-emu .chat-notifications.settings nav {
-    padding: 0; }
+  background-color: transparent;
+}
+.-emu-layout body.-emu .chat-notifications.settings nav {
+  padding: 0;
+}
 
-.-emu-layout body.-emu .chat-notifications.settings .multi-input-row .input-group-col {
-  flex-flow: row; }
-  .-emu-layout body.-emu .chat-notifications.settings .multi-input-row .input-group-col:first-child {
-    flex: 1 1 auto;
-    -webkit-margin-end: var(--emu-space-base);
-            margin-inline-end: var(--emu-space-base); }
-    .-emu-layout body.-emu .chat-notifications.settings .multi-input-row .input-group-col:first-child select {
-      flex: 1 1 100%; }
+.-emu-layout
+  body.-emu
+  .chat-notifications.settings
+  .multi-input-row
+  .input-group-col {
+  flex-flow: row;
+}
+.-emu-layout
+  body.-emu
+  .chat-notifications.settings
+  .multi-input-row
+  .input-group-col:first-child {
+  flex: 1 1 auto;
+  -webkit-margin-end: var(--emu-space-base);
+  margin-inline-end: var(--emu-space-base);
+}
+.-emu-layout
+  body.-emu
+  .chat-notifications.settings
+  .multi-input-row
+  .input-group-col:first-child
+  select {
+  flex: 1 1 100%;
+}
 
 .-emu-layout body.-emu .chat-notifications.settings .multi-input-row > * {
-  margin: 0; }
+  margin: 0;
+}
 
-.-emu-layout body.-emu .sheet[id*="tile-config-"] input[name="isHeyWaitTile"] + button {
+.-emu-layout
+  body.-emu
+  .sheet[id*="tile-config-"]
+  input[name="isHeyWaitTile"]
+  + button {
   -webkit-margin-after: var(--emu-space-sm);
-          margin-block-end: var(--emu-space-sm); }
+  margin-block-end: var(--emu-space-sm);
+}
 
 body.-emu .illandril-chat-enhancements--currentSpeaker {
   align-items: center;
   background-color: rgba(var(--color-background), 0.5);
-  background-image: var(--emu-image-background, none); }
-  .-emu-layout body.-emu .illandril-chat-enhancements--currentSpeaker {
-    display: flex;
-    flex: 0 0 auto;
-    margin: 0;
-    padding: var(--emu-space-base) var(--emu-space-sm); }
-
-.-emu-layout body.-emu .lib-wrapper.settings.window-app .window-content form .package-priority-group {
+  background-image: var(--emu-image-background, none);
+}
+.-emu-layout body.-emu .illandril-chat-enhancements--currentSpeaker {
   display: flex;
-  height: auto; }
-  .-emu-layout body.-emu .lib-wrapper.settings.window-app .window-content form .package-priority-group > div {
-    display: flex;
-    flex-flow: initial;
-    flex: 0 0 auto;
-    float: initial !important;
-    left: auto;
-    margin: 0;
-    -webkit-padding-before: 0 !important;
-            padding-block-start: 0 !important;
-    width: auto !important; }
-    .-emu-layout body.-emu .lib-wrapper.settings.window-app .window-content form .package-priority-group > div button {
-      height: var(--emu-space-button); }
-  .-emu-layout body.-emu .lib-wrapper.settings.window-app .window-content form .package-priority-group .vertical-arrow-btn-group {
-    -webkit-margin-end: var(--emu-space-sm);
-            margin-inline-end: var(--emu-space-sm); }
-  .-emu-layout body.-emu .lib-wrapper.settings.window-app .window-content form .package-priority-group .form-group {
-    flex: 1 1 auto;
-    flex-wrap: wrap; }
-    .-emu-layout body.-emu .lib-wrapper.settings.window-app .window-content form .package-priority-group .form-group > label {
-      flex: 1 1 auto;
-      flex-wrap: wrap; }
+  flex: 0 0 auto;
+  margin: 0;
+  padding: var(--emu-space-base) var(--emu-space-sm);
+}
 
-.-emu-layout body.-emu .lib-wrapper.settings.window-app .window-content form h1 {
-  -webkit-margin-before: var(--emu-space-sm);
-          margin-block-start: var(--emu-space-sm); }
-
-.-emu-layout body.-emu .lib-wrapper.settings.window-app .window-content form select {
+.-emu-layout
+  body.-emu
+  .lib-wrapper.settings.window-app
+  .window-content
+  form
+  .package-priority-group {
+  display: flex;
   height: auto;
-  padding: var(--emu-space-sm); }
+}
+.-emu-layout
+  body.-emu
+  .lib-wrapper.settings.window-app
+  .window-content
+  form
+  .package-priority-group
+  > div {
+  display: flex;
+  flex-flow: initial;
+  flex: 0 0 auto;
+  float: initial !important;
+  left: auto;
+  margin: 0;
+  -webkit-padding-before: 0 !important;
+  padding-block-start: 0 !important;
+  width: auto !important;
+}
+.-emu-layout
+  body.-emu
+  .lib-wrapper.settings.window-app
+  .window-content
+  form
+  .package-priority-group
+  > div
+  button {
+  height: var(--emu-space-button);
+}
+.-emu-layout
+  body.-emu
+  .lib-wrapper.settings.window-app
+  .window-content
+  form
+  .package-priority-group
+  .vertical-arrow-btn-group {
+  -webkit-margin-end: var(--emu-space-sm);
+  margin-inline-end: var(--emu-space-sm);
+}
+.-emu-layout
+  body.-emu
+  .lib-wrapper.settings.window-app
+  .window-content
+  form
+  .package-priority-group
+  .form-group {
+  flex: 1 1 auto;
+  flex-wrap: wrap;
+}
+.-emu-layout
+  body.-emu
+  .lib-wrapper.settings.window-app
+  .window-content
+  form
+  .package-priority-group
+  .form-group
+  > label {
+  flex: 1 1 auto;
+  flex-wrap: wrap;
+}
+
+.-emu-layout
+  body.-emu
+  .lib-wrapper.settings.window-app
+  .window-content
+  form
+  h1 {
+  -webkit-margin-before: var(--emu-space-sm);
+  margin-block-start: var(--emu-space-sm);
+}
+
+.-emu-layout
+  body.-emu
+  .lib-wrapper.settings.window-app
+  .window-content
+  form
+  select {
+  height: auto;
+  padding: var(--emu-space-sm);
+}
 
 .-emu-layout body.-emu #lmrtfy.lmrtfy-parchment .window-content {
   -webkit-padding-after: 0;
-          padding-block-end: 0; }
-  .-emu-layout body.-emu #lmrtfy.lmrtfy-parchment .window-content .form-group.lmrtfy-actor-avatars {
-    justify-content: flex-start; }
-    .-emu-layout body.-emu #lmrtfy.lmrtfy-parchment .window-content .form-group.lmrtfy-actor-avatars input + label {
-      -webkit-margin-end: var(--emu-space-base);
-              margin-inline-end: var(--emu-space-base);
-      padding: 0; }
+  padding-block-end: 0;
+}
+.-emu-layout
+  body.-emu
+  #lmrtfy.lmrtfy-parchment
+  .window-content
+  .form-group.lmrtfy-actor-avatars {
+  justify-content: flex-start;
+}
+.-emu-layout
+  body.-emu
+  #lmrtfy.lmrtfy-parchment
+  .window-content
+  .form-group.lmrtfy-actor-avatars
+  input
+  + label {
+  -webkit-margin-end: var(--emu-space-base);
+  margin-inline-end: var(--emu-space-base);
+  padding: 0;
+}
 
 .-emu-layout body.-emu #lmrtfy.lmrtfy-parchment .lmrtfy-actor {
-  flex: 0 0 auto; }
+  flex: 0 0 auto;
+}
 
-.-emu-layout body.-emu #lmrtfy.lmrtfy-parchment .lmrtfy-actor-avatars input:checked + label {
-  justify-content: center; }
+.-emu-layout
+  body.-emu
+  #lmrtfy.lmrtfy-parchment
+  .lmrtfy-actor-avatars
+  input:checked
+  + label {
+  justify-content: center;
+}
 
-body.-emu #lmrtfy.lmrtfy-parchment .lmrtfy-actor-avatars input:checked + label img {
+body.-emu
+  #lmrtfy.lmrtfy-parchment
+  .lmrtfy-actor-avatars
+  input:checked
+  + label
+  img {
   background-color: transparent;
-  box-shadow: none; }
+  box-shadow: none;
+}
 
 body.-emu #lmrtfy.lmrtfy-parchment .lmrtfy-submit {
   background-color: rgba(var(--color-background-lightest), 1);
   background-image: var(--emu-image-background-lightest, none);
   -webkit-border-before: rgba(var(--color-border), 1) 1px solid;
-          border-block-start: rgba(var(--color-border), 1) 1px solid; }
-  .-emu-layout body.-emu #lmrtfy.lmrtfy-parchment .lmrtfy-submit {
-    bottom: 0;
-    display: flex;
-    flex-wrap: nowrap;
-    padding: var(--emu-space-sm);
-    position: -webkit-sticky;
-    position: sticky; }
+  border-block-start: rgba(var(--color-border), 1) 1px solid;
+}
+.-emu-layout body.-emu #lmrtfy.lmrtfy-parchment .lmrtfy-submit {
+  bottom: 0;
+  display: flex;
+  flex-wrap: nowrap;
+  padding: var(--emu-space-sm);
+  position: -webkit-sticky;
+  position: sticky;
+}
 
-.-emu-layout body.-emu #lmrtfy.lmrtfy-parchment input[type=checkbox] + label {
-  cursor: pointer; }
+.-emu-layout body.-emu #lmrtfy.lmrtfy-parchment input[type="checkbox"] + label {
+  cursor: pointer;
+}
 
-body.-emu #lmrtfy.lmrtfy-parchment input[type=checkbox]:checked + label {
+body.-emu #lmrtfy.lmrtfy-parchment input[type="checkbox"]:checked + label {
   color: rgba(var(--color-primary), 1);
-  font-weight: normal; }
+  font-weight: normal;
+}
 
 .-emu-layout body.-emu #lmrtfy.lmrtfy-parchment select + select {
   -webkit-margin-start: var(--emu-space-base);
-          margin-inline-start: var(--emu-space-base); }
+  margin-inline-start: var(--emu-space-base);
+}
 
-.-emu-layout body.-emu .window-app.sheet[id*="macro-config-"] .macro-editor-expand {
+.-emu-layout
+  body.-emu
+  .window-app.sheet[id*="macro-config-"]
+  .macro-editor-expand {
   bottom: var(--emu-space-base);
   position: absolute !important;
   left: auto;
   right: var(--emu-space-base);
-  top: auto; }
-  .-emu-layout body.-emu .window-app.sheet[id*="macro-config-"] .macro-editor-expand.fullscreen {
-    position: fixed !important;
-    z-index: 16; }
-  .-emu-layout body.-emu .window-app.sheet[id*="macro-config-"] .macro-editor-expand > i {
-    margin: 0; }
+  top: auto;
+}
+.-emu-layout
+  body.-emu
+  .window-app.sheet[id*="macro-config-"]
+  .macro-editor-expand.fullscreen {
+  position: fixed !important;
+  z-index: 16;
+}
+.-emu-layout
+  body.-emu
+  .window-app.sheet[id*="macro-config-"]
+  .macro-editor-expand
+  > i {
+  margin: 0;
+}
 
-.-emu-layout body.-emu .window-app.sheet[id*="macro-config-"] .macro-editor.ace_editor {
+.-emu-layout
+  body.-emu
+  .window-app.sheet[id*="macro-config-"]
+  .macro-editor.ace_editor {
   flex: 1 1 auto;
   height: 100%;
   -webkit-margin-after: var(--emu-space-md);
-          margin-block-end: var(--emu-space-md); }
-  .-emu-layout body.-emu .window-app.sheet[id*="macro-config-"] .macro-editor.ace_editor.fullscreen {
-    height: calc(100% - 10rem);
-    margin: 0;
-    z-index: 15; }
-    .-emu-layout body.-emu .window-app.sheet[id*="macro-config-"] .macro-editor.ace_editor.fullscreen::before {
-      top: 0;
-      right: 0;
-      bottom: 0;
-      left: 0;
-      position: fixed;
-      background-color: rgba(var(--color-black), 0.5);
-      content: ""; }
+  margin-block-end: var(--emu-space-md);
+}
+.-emu-layout
+  body.-emu
+  .window-app.sheet[id*="macro-config-"]
+  .macro-editor.ace_editor.fullscreen {
+  height: calc(100% - 10rem);
+  margin: 0;
+  z-index: 15;
+}
+.-emu-layout
+  body.-emu
+  .window-app.sheet[id*="macro-config-"]
+  .macro-editor.ace_editor.fullscreen::before {
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  position: fixed;
+  background-color: rgba(var(--color-black), 0.5);
+  content: "";
+}
 
 body.-emu #macro-popout.window-app .folder-header.macro-folder-header h3 {
-  margin: 0 !important; }
+  margin: 0 !important;
+}
 
 body.-emu .select-folder.window-app.form .form-folder-list {
   background-color: transparent;
-  border: none; }
+  border: none;
+}
 
 body.-emu #macro-folder-edit .form-macro-list {
   background-color: transparent;
   border: none;
-  border-radius: 0; }
-  .-emu-layout body.-emu #macro-folder-edit .form-macro-list {
-    font-size: var(--emu-font-size-md);
-    padding: 0; }
+  border-radius: 0;
+}
+.-emu-layout body.-emu #macro-folder-edit .form-macro-list {
+  font-size: var(--emu-font-size-md);
+  padding: 0;
+}
 
-.-emu-layout body.-emu #sidebar #playlists .header-actions > .flexrow, .-emu-layout
-body.-emu .sidebar-popout #playlists .header-actions > .flexrow {
+.-emu-layout body.-emu #sidebar #playlists .header-actions > .flexrow,
+.-emu-layout body.-emu .sidebar-popout #playlists .header-actions > .flexrow {
   flex: 0 0 100%;
   -webkit-margin-after: var(--emu-space-base);
-          margin-block-end: var(--emu-space-base); }
+  margin-block-end: var(--emu-space-base);
+}
 
 body.-emu .mess.window-app.settings nav {
-  background-color: transparent; }
-  .-emu-layout body.-emu .mess.window-app.settings nav {
-    padding: 0; }
+  background-color: transparent;
+}
+.-emu-layout body.-emu .mess.window-app.settings nav {
+  padding: 0;
+}
 
 .-emu-layout body.-emu .mess.window-app.settings .form-checkbox-group {
   margin: 0;
-  padding: var(--emu-space-sm); }
-  .-emu-layout body.-emu .mess.window-app.settings .form-checkbox-group > input[type="checkbox"] {
-    width: 0; }
+  padding: var(--emu-space-sm);
+}
+.-emu-layout
+  body.-emu
+  .mess.window-app.settings
+  .form-checkbox-group
+  > input[type="checkbox"] {
+  width: 0;
+}
 
 body.-emu .mess.window-app.settings .form-checkbox-group label {
   box-shadow: none;
-  text-shadow: none; }
-  body.-emu .mess.window-app.settings .form-checkbox-group label:hover {
-    color: rgba(var(--color-primary), 1); }
+  text-shadow: none;
+}
+body.-emu .mess.window-app.settings .form-checkbox-group label:hover {
+  color: rgba(var(--color-primary), 1);
+}
 
 body.-emu .mess.window-app.settings .mess-template-chooser {
   background-color: transparent;
-  border: none; }
-  .-emu-layout body.-emu .mess.window-app.settings .mess-template-chooser {
-    overflow: auto; }
-  .-emu-layout body.-emu .mess.window-app.settings .mess-template-chooser > h3 {
-    -webkit-margin-before: var(--emu-space-sm);
-            margin-block-start: var(--emu-space-sm); }
+  border: none;
+}
+.-emu-layout body.-emu .mess.window-app.settings .mess-template-chooser {
+  overflow: auto;
+}
+.-emu-layout body.-emu .mess.window-app.settings .mess-template-chooser > h3 {
+  -webkit-margin-before: var(--emu-space-sm);
+  margin-block-start: var(--emu-space-sm);
+}
 
-.-emu-layout body.-emu #sidebar #chat #chat-log .midi-qol-item-card.chat-card .card-buttons button[data-action="attack"], .-emu-layout
-body.-emu .sidebar-popout #chat #chat-log .midi-qol-item-card.chat-card .card-buttons button[data-action="attack"] {
+.-emu-layout
+  body.-emu
+  #sidebar
+  #chat
+  #chat-log
+  .midi-qol-item-card.chat-card
+  .card-buttons
+  button[data-action="attack"],
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #chat
+  #chat-log
+  .midi-qol-item-card.chat-card
+  .card-buttons
+  button[data-action="attack"] {
   -webkit-margin-after: var(--emu-space-base);
-          margin-block-end: var(--emu-space-base); }
+  margin-block-end: var(--emu-space-base);
+}
 
 body.-emu #midi-qol-settings .midi-qol-box {
-  border: none; }
-  .-emu-layout body.-emu #midi-qol-settings .midi-qol-box {
-    -webkit-margin-before: var(--emu-space-sm);
-            margin-block-start: var(--emu-space-sm);
-    padding: 0; }
-    .-emu-layout body.-emu #midi-qol-settings .midi-qol-box select[name="showItemDetails"] {
-      width: auto; }
+  border: none;
+}
+.-emu-layout body.-emu #midi-qol-settings .midi-qol-box {
+  -webkit-margin-before: var(--emu-space-sm);
+  margin-block-start: var(--emu-space-sm);
+  padding: 0;
+}
+.-emu-layout
+  body.-emu
+  #midi-qol-settings
+  .midi-qol-box
+  select[name="showItemDetails"] {
+  width: auto;
+}
 
 body.-emu #midi-qol-settings .midi-qol-faint {
-  color: rgba(var(--color-text), 0.8); }
+  color: rgba(var(--color-text), 0.8);
+}
 
 .-emu-layout body.-emu #midi-qol-settings .sheet-footer {
   bottom: 0;
   flex: 0 0 auto;
   padding: 0;
   -webkit-padding-before: var(--emu-space-sm);
-          padding-block-start: var(--emu-space-sm);
+  padding-block-start: var(--emu-space-sm);
   position: -webkit-sticky;
   position: sticky;
-  z-index: 6; }
+  z-index: 6;
+}
 
 .-emu-layout body.-emu #midi-qol-statistics .tab.active[data-tab="config"] {
-  display: flex; }
-  .-emu-layout body.-emu #midi-qol-statistics .tab.active[data-tab="config"] button {
-    flex: 1 1 49%; }
+  display: flex;
+}
+.-emu-layout
+  body.-emu
+  #midi-qol-statistics
+  .tab.active[data-tab="config"]
+  button {
+  flex: 1 1 49%;
+}
 
 .-emu-layout body.-emu #navigation .monks-scene-navigation {
   height: auto;
   -webkit-margin-after: var(--emu-space-base);
-          margin-block-end: var(--emu-space-base);
-  padding: 0; }
+  margin-block-end: var(--emu-space-base);
+  padding: 0;
+}
 
 body.-emu #navigation .monks-scene-navigation .scene-list {
   background-color: transparent;
   border: none;
-  border-radius: var(--emu-border-radius-default, 0); }
-  .-emu-layout body.-emu #navigation .monks-scene-navigation .scene-list {
-    flex-wrap: wrap;
-    margin: 0;
-    padding: 0; }
-  body.-emu #navigation .monks-scene-navigation .scene-list > .nav-item {
-    background-color: transparent;
-    background-image: none;
-    border: none;
-    border-radius: var(--emu-border-radius-default, 0); }
-    .-emu-layout body.-emu #navigation .monks-scene-navigation .scene-list > .nav-item {
-      flex: 0 0 auto;
-      height: auto;
-      line-height: initial;
-      -webkit-margin-after: var(--emu-space-base);
-              margin-block-end: var(--emu-space-base);
-      -webkit-margin-end: var(--emu-space-base);
-              margin-inline-end: var(--emu-space-base);
-      max-width: initial;
-      min-width: initial;
-      padding: 0; }
-    body.-emu #navigation .monks-scene-navigation .scene-list > .nav-item:hover {
-      background-color: transparent; }
-    body.-emu #navigation .monks-scene-navigation .scene-list > .nav-item.active {
-      background-color: transparent; }
-      body.-emu #navigation .monks-scene-navigation .scene-list > .nav-item.active > .scene-name {
-        background-image: none; }
-    body.-emu #navigation .monks-scene-navigation .scene-list > .nav-item > .scene-name {
-      background-color: rgba(var(--color-background-darkest), 0.8);
-      background-image: var(--emu-image-background-controls, none);
-      border: none;
-      border-radius: var(--emu-border-radius-default, 0);
-      box-shadow: none;
-      color: rgba(var(--color-text-lightest), 1);
-      outline: none;
-      text-shadow: none;
-      transition: box-shadow 0.3s cubic-bezier(0.075, 0.82, 0.165, 1), color 0.3s cubic-bezier(0.075, 0.82, 0.165, 1), opacity 0.3s cubic-bezier(0.075, 0.82, 0.165, 1); }
-      .-emu-layout body.-emu #navigation .monks-scene-navigation .scene-list > .nav-item > .scene-name {
-        width: auto;
-        height: 2.25rem;
-        cursor: pointer;
-        display: block;
-        line-height: 2.25rem;
-        margin: 0;
-        max-width: 15rem;
-        min-width: 7rem;
-        padding: 0 var(--emu-space-md);
-        position: relative;
-        text-align: center; }
-      .-emu-layout.-emu-compact body.-emu #navigation .monks-scene-navigation .scene-list > .nav-item > .scene-name {
-        height: 1.75rem;
-        line-height: 1.75rem;
-        min-width: 5.5rem; }
-      body.-emu #navigation .monks-scene-navigation .scene-list > .nav-item > .scene-name:hover {
-        background-image: none; }
-    body.-emu #navigation .monks-scene-navigation .scene-list > .nav-item .active-indicator {
-      color: rgba(var(--color-text-lightest), 1); }
-      .-emu-layout body.-emu #navigation .monks-scene-navigation .scene-list > .nav-item .active-indicator {
-        float: initial;
-        height: auto;
-        line-height: 1;
-        margin: 0;
-        -webkit-margin-end: var(--emu-space-xs);
-                margin-inline-end: var(--emu-space-xs);
-        width: auto; }
-    .-emu-layout body.-emu #navigation .monks-scene-navigation .scene-list > .nav-item .scene-player {
-      flex: 0 0 auto;
-      max-width: 100%; }
-    .-emu-layout body.-emu #navigation .monks-scene-navigation .scene-list > .nav-item .scene-player:last-child {
-      min-width: 0; }
-    body.-emu #navigation .monks-scene-navigation .scene-list > .nav-item .scene-player > div {
-      background-color: transparent;
-      border: none;
-      border-radius: 0;
-      box-shadow: inset 0 0 0 1px rgba(var(--color-primary), 1), inset 0 0 0 2px rgba(var(--color-white), 1), 0 1px 2px 0 rgba(var(--color-black), 0.3);
-      color: transparent; }
-      .-emu-layout body.-emu #navigation .monks-scene-navigation .scene-list > .nav-item .scene-player > div {
-        width: 100%;
-        height: 100%;
-        line-height: 1;
-        position: relative; }
-  .-emu-layout body.-emu #navigation .monks-scene-navigation .scene-list > .folder-header {
-    align-items: center;
-    display: flex;
-    -webkit-margin-end: var(--emu-space-md);
-            margin-inline-end: var(--emu-space-md);
-    padding: 0 var(--emu-space-md); }
-    .-emu-layout body.-emu #navigation .monks-scene-navigation .scene-list > .folder-header > i {
-      -webkit-margin-end: var(--emu-space-base);
-              margin-inline-end: var(--emu-space-base); }
+  border-radius: var(--emu-border-radius-default, 0);
+}
+.-emu-layout body.-emu #navigation .monks-scene-navigation .scene-list {
+  flex-wrap: wrap;
+  margin: 0;
+  padding: 0;
+}
+body.-emu #navigation .monks-scene-navigation .scene-list > .nav-item {
+  background-color: transparent;
+  background-image: none;
+  border: none;
+  border-radius: var(--emu-border-radius-default, 0);
+}
+.-emu-layout
+  body.-emu
+  #navigation
+  .monks-scene-navigation
+  .scene-list
+  > .nav-item {
+  flex: 0 0 auto;
+  height: auto;
+  line-height: initial;
+  -webkit-margin-after: var(--emu-space-base);
+  margin-block-end: var(--emu-space-base);
+  -webkit-margin-end: var(--emu-space-base);
+  margin-inline-end: var(--emu-space-base);
+  max-width: initial;
+  min-width: initial;
+  padding: 0;
+}
+body.-emu #navigation .monks-scene-navigation .scene-list > .nav-item:hover {
+  background-color: transparent;
+}
+body.-emu #navigation .monks-scene-navigation .scene-list > .nav-item.active {
+  background-color: transparent;
+}
+body.-emu
+  #navigation
+  .monks-scene-navigation
+  .scene-list
+  > .nav-item.active
+  > .scene-name {
+  background-image: none;
+}
+body.-emu
+  #navigation
+  .monks-scene-navigation
+  .scene-list
+  > .nav-item
+  > .scene-name {
+  background-color: rgba(var(--color-background-darkest), 0.8);
+  background-image: var(--emu-image-background-controls, none);
+  border: none;
+  border-radius: var(--emu-border-radius-default, 0);
+  box-shadow: none;
+  color: rgba(var(--color-text-lightest), 1);
+  outline: none;
+  text-shadow: none;
+  transition: box-shadow 0.3s cubic-bezier(0.075, 0.82, 0.165, 1),
+    color 0.3s cubic-bezier(0.075, 0.82, 0.165, 1),
+    opacity 0.3s cubic-bezier(0.075, 0.82, 0.165, 1);
+}
+.-emu-layout
+  body.-emu
+  #navigation
+  .monks-scene-navigation
+  .scene-list
+  > .nav-item
+  > .scene-name {
+  width: auto;
+  height: 2.25rem;
+  cursor: pointer;
+  display: block;
+  line-height: 2.25rem;
+  margin: 0;
+  max-width: 15rem;
+  min-width: 7rem;
+  padding: 0 var(--emu-space-md);
+  position: relative;
+  text-align: center;
+}
+.-emu-layout.-emu-compact
+  body.-emu
+  #navigation
+  .monks-scene-navigation
+  .scene-list
+  > .nav-item
+  > .scene-name {
+  height: 1.75rem;
+  line-height: 1.75rem;
+  min-width: 5.5rem;
+}
+body.-emu
+  #navigation
+  .monks-scene-navigation
+  .scene-list
+  > .nav-item
+  > .scene-name:hover {
+  background-image: none;
+}
+body.-emu
+  #navigation
+  .monks-scene-navigation
+  .scene-list
+  > .nav-item
+  .active-indicator {
+  color: rgba(var(--color-text-lightest), 1);
+}
+.-emu-layout
+  body.-emu
+  #navigation
+  .monks-scene-navigation
+  .scene-list
+  > .nav-item
+  .active-indicator {
+  float: initial;
+  height: auto;
+  line-height: 1;
+  margin: 0;
+  -webkit-margin-end: var(--emu-space-xs);
+  margin-inline-end: var(--emu-space-xs);
+  width: auto;
+}
+.-emu-layout
+  body.-emu
+  #navigation
+  .monks-scene-navigation
+  .scene-list
+  > .nav-item
+  .scene-player {
+  flex: 0 0 auto;
+  max-width: 100%;
+}
+.-emu-layout
+  body.-emu
+  #navigation
+  .monks-scene-navigation
+  .scene-list
+  > .nav-item
+  .scene-player:last-child {
+  min-width: 0;
+}
+body.-emu
+  #navigation
+  .monks-scene-navigation
+  .scene-list
+  > .nav-item
+  .scene-player
+  > div {
+  background-color: transparent;
+  border: none;
+  border-radius: 0;
+  box-shadow: inset 0 0 0 1px rgba(var(--color-primary), 1),
+    inset 0 0 0 2px rgba(var(--color-white), 1),
+    0 1px 2px 0 rgba(var(--color-black), 0.3);
+  color: transparent;
+}
+.-emu-layout
+  body.-emu
+  #navigation
+  .monks-scene-navigation
+  .scene-list
+  > .nav-item
+  .scene-player
+  > div {
+  width: 100%;
+  height: 100%;
+  line-height: 1;
+  position: relative;
+}
+.-emu-layout
+  body.-emu
+  #navigation
+  .monks-scene-navigation
+  .scene-list
+  > .folder-header {
+  align-items: center;
+  display: flex;
+  -webkit-margin-end: var(--emu-space-md);
+  margin-inline-end: var(--emu-space-md);
+  padding: 0 var(--emu-space-md);
+}
+.-emu-layout
+  body.-emu
+  #navigation
+  .monks-scene-navigation
+  .scene-list
+  > .folder-header
+  > i {
+  -webkit-margin-end: var(--emu-space-base);
+  margin-inline-end: var(--emu-space-base);
+}
 
-.-emu-layout body.-emu #sidebar #scenes .directory-item.scene h3 a, .-emu-layout
-body.-emu .sidebar-popout #scenes .directory-item.scene h3 a {
-  max-width: 80%; }
-  .-emu-layout body.-emu #sidebar #scenes .directory-item.scene h3 a i, .-emu-layout
-  body.-emu .sidebar-popout #scenes .directory-item.scene h3 a i {
-    -webkit-margin-end: var(--emu-space-base);
-            margin-inline-end: var(--emu-space-base); }
+.-emu-layout body.-emu #sidebar #scenes .directory-item.scene h3 a,
+.-emu-layout body.-emu .sidebar-popout #scenes .directory-item.scene h3 a {
+  max-width: 80%;
+}
+.-emu-layout body.-emu #sidebar #scenes .directory-item.scene h3 a i,
+.-emu-layout body.-emu .sidebar-popout #scenes .directory-item.scene h3 a i {
+  -webkit-margin-end: var(--emu-space-base);
+  margin-inline-end: var(--emu-space-base);
+}
 
 body.-emu #sidebar #scenes .directory-item.scene h3 .permissions,
 body.-emu .sidebar-popout #scenes .directory-item.scene h3 .permissions {
   background-color: transparent;
-  color: rgba(var(--color-text-lightest), 1); }
-  .-emu-layout body.-emu #sidebar #scenes .directory-item.scene h3 .permissions, .-emu-layout
-  body.-emu .sidebar-popout #scenes .directory-item.scene h3 .permissions {
-    align-items: center;
-    display: inline-flex;
-    height: var(--emu-space-button-sm);
-    left: auto;
-    padding: 0 var(--emu-space-base);
-    position: absolute;
-    right: 0;
-    top: var(--emu-space-base);
-    width: auto; }
-    .-emu-layout body.-emu #sidebar #scenes .directory-item.scene h3 .permissions > i, .-emu-layout
-    body.-emu .sidebar-popout #scenes .directory-item.scene h3 .permissions > i {
-      font-size: inherit; }
-  body.-emu #sidebar #scenes .directory-item.scene h3 .permissions > i,
-  body.-emu .sidebar-popout #scenes .directory-item.scene h3 .permissions > i {
-    text-shadow: none; }
+  color: rgba(var(--color-text-lightest), 1);
+}
+.-emu-layout body.-emu #sidebar #scenes .directory-item.scene h3 .permissions,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #scenes
+  .directory-item.scene
+  h3
+  .permissions {
+  align-items: center;
+  display: inline-flex;
+  height: var(--emu-space-button-sm);
+  left: auto;
+  padding: 0 var(--emu-space-base);
+  position: absolute;
+  right: 0;
+  top: var(--emu-space-base);
+  width: auto;
+}
+.-emu-layout
+  body.-emu
+  #sidebar
+  #scenes
+  .directory-item.scene
+  h3
+  .permissions
+  > i,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #scenes
+  .directory-item.scene
+  h3
+  .permissions
+  > i {
+  font-size: inherit;
+}
+body.-emu #sidebar #scenes .directory-item.scene h3 .permissions > i,
+body.-emu .sidebar-popout #scenes .directory-item.scene h3 .permissions > i {
+  text-shadow: none;
+}
 
 body.-emu .moulinette-options {
   background-color: rgba(var(--color-background-darkest), 0.8);
   background-image: var(--emu-image-background-darkest, none);
   border-radius: var(--emu-border-radius-controls, 0);
   box-shadow: none;
-  color: rgba(var(--color-text-lightest), 1); }
-  .-emu-layout body.-emu .moulinette-options {
-    box-sizing: border-box;
-    font-size: var(--emu-font-size-lg);
-    line-height: 1;
-    z-index: 10; }
-  body.-emu .moulinette-options li[data-type="empty"] {
-    pointer-events: none; }
+  color: rgba(var(--color-text-lightest), 1);
+}
+.-emu-layout body.-emu .moulinette-options {
+  box-sizing: border-box;
+  font-size: var(--emu-font-size-lg);
+  line-height: 1;
+  z-index: 10;
+}
+body.-emu .moulinette-options li[data-type="empty"] {
+  pointer-events: none;
+}
 
 .-emu-layout body.-emu #moulinette.forge .window-content form {
   display: grid;
-  grid-template-areas: "nav nav" "body body" "logo logo-text";
+  grid-template-areas:
+    "nav nav"
+    "body body"
+    "logo logo-text";
   grid-template-columns: -webkit-min-content 1fr;
   grid-template-columns: min-content 1fr;
   grid-template-rows: -webkit-min-content 1fr -webkit-min-content;
   grid-template-rows: min-content 1fr min-content;
-  overflow: hidden; }
-  .-emu-layout body.-emu #moulinette.forge .window-content form > nav {
-    grid-area: nav; }
-  .-emu-layout body.-emu #moulinette.forge .window-content form > .main {
-    display: flex;
-    flex-direction: column;
-    grid-area: body;
-    margin: 0;
-    overflow: auto; }
-    .-emu-layout body.-emu #moulinette.forge .window-content form > .main > * {
-      flex: 0 0 auto; }
-    .-emu-layout body.-emu #moulinette.forge .window-content form > .main .list {
-      flex: 1 1 auto; }
-    .-emu-layout body.-emu #moulinette.forge .window-content form > .main .options {
-      align-items: center;
-      display: flex;
-      padding: 0; }
-      .-emu-layout body.-emu #moulinette.forge .window-content form > .main .options input {
-        margin: 0 var(--emu-space-base);
-        width: auto; }
-      .-emu-layout body.-emu #moulinette.forge .window-content form > .main .options .option {
-        align-items: center;
-        display: flex;
-        -webkit-margin-end: var(--emu-space-sm);
-                margin-inline-end: var(--emu-space-sm); }
-        .-emu-layout body.-emu #moulinette.forge .window-content form > .main .options .option > i {
-          margin: 0 var(--emu-space-base); }
-    .-emu-layout body.-emu #moulinette.forge .window-content form > .main .form-group.search button i {
-      margin: 0; }
-    .-emu-layout body.-emu #moulinette.forge .window-content form > .main footer .actions {
-      -webkit-margin-before: var(--emu-space-base);
-              margin-block-start: var(--emu-space-base); }
-      .-emu-layout body.-emu #moulinette.forge .window-content form > .main footer .actions:empty {
-        display: none; }
-  .-emu-layout body.-emu #moulinette.forge .window-content form > .logo {
-    width: 3.5rem;
-    height: 3.5rem;
-    float: initial;
-    grid-area: logo;
-    max-width: initial;
-    padding: 0;
-    -webkit-margin-before: var(--emu-space-sm);
-            margin-block-start: var(--emu-space-sm);
-    -webkit-margin-end: var(--emu-space-sm);
-            margin-inline-end: var(--emu-space-sm); }
-  .-emu-layout body.-emu #moulinette.forge .window-content form > p {
-    grid-area: logo-text;
-    margin: 0;
-    -webkit-margin-before: var(--emu-space-sm);
-            margin-block-start: var(--emu-space-sm); }
+  overflow: hidden;
+}
+.-emu-layout body.-emu #moulinette.forge .window-content form > nav {
+  grid-area: nav;
+}
+.-emu-layout body.-emu #moulinette.forge .window-content form > .main {
+  display: flex;
+  flex-direction: column;
+  grid-area: body;
+  margin: 0;
+  overflow: auto;
+}
+.-emu-layout body.-emu #moulinette.forge .window-content form > .main > * {
+  flex: 0 0 auto;
+}
+.-emu-layout body.-emu #moulinette.forge .window-content form > .main .list {
+  flex: 1 1 auto;
+}
+.-emu-layout body.-emu #moulinette.forge .window-content form > .main .options {
+  align-items: center;
+  display: flex;
+  padding: 0;
+}
+.-emu-layout
+  body.-emu
+  #moulinette.forge
+  .window-content
+  form
+  > .main
+  .options
+  input {
+  margin: 0 var(--emu-space-base);
+  width: auto;
+}
+.-emu-layout
+  body.-emu
+  #moulinette.forge
+  .window-content
+  form
+  > .main
+  .options
+  .option {
+  align-items: center;
+  display: flex;
+  -webkit-margin-end: var(--emu-space-sm);
+  margin-inline-end: var(--emu-space-sm);
+}
+.-emu-layout
+  body.-emu
+  #moulinette.forge
+  .window-content
+  form
+  > .main
+  .options
+  .option
+  > i {
+  margin: 0 var(--emu-space-base);
+}
+.-emu-layout
+  body.-emu
+  #moulinette.forge
+  .window-content
+  form
+  > .main
+  .form-group.search
+  button
+  i {
+  margin: 0;
+}
+.-emu-layout
+  body.-emu
+  #moulinette.forge
+  .window-content
+  form
+  > .main
+  footer
+  .actions {
+  -webkit-margin-before: var(--emu-space-base);
+  margin-block-start: var(--emu-space-base);
+}
+.-emu-layout
+  body.-emu
+  #moulinette.forge
+  .window-content
+  form
+  > .main
+  footer
+  .actions:empty {
+  display: none;
+}
+.-emu-layout body.-emu #moulinette.forge .window-content form > .logo {
+  width: 3.5rem;
+  height: 3.5rem;
+  float: initial;
+  grid-area: logo;
+  max-width: initial;
+  padding: 0;
+  -webkit-margin-before: var(--emu-space-sm);
+  margin-block-start: var(--emu-space-sm);
+  -webkit-margin-end: var(--emu-space-sm);
+  margin-inline-end: var(--emu-space-sm);
+}
+.-emu-layout body.-emu #moulinette.forge .window-content form > p {
+  grid-area: logo-text;
+  margin: 0;
+  -webkit-margin-before: var(--emu-space-sm);
+  margin-block-start: var(--emu-space-sm);
+}
 
 .-emu-layout body.-emu #moulinette.forge.mtte .list {
   height: auto;
   -webkit-margin-before: var(--emu-space-base);
-          margin-block-start: var(--emu-space-base);
-  overflow: auto; }
+  margin-block-start: var(--emu-space-base);
+  overflow: auto;
+}
 
 body.-emu #moulinette.forge.mtte .list > div {
-  padding: var(--emu-space-xs) var(--emu-space-base); }
-  .-emu-layout body.-emu #moulinette.forge.mtte .list > div {
-    background-color: transparent;
-    min-height: 0; }
-    .-emu-layout body.-emu #moulinette.forge.mtte .list > div:nth-of-type(even) {
-      background-color: rgba(var(--color-background-light), 0.1); }
-    .-emu-layout body.-emu #moulinette.forge.mtte .list > div:hover {
-      background-color: rgba(var(--color-primary), 1);
-      color: rgba(var(--color-text-lightest), 1); }
-      .-emu-layout body.-emu #moulinette.forge.mtte .list > div:hover > a {
-        color: rgba(var(--color-text-lightest), 1); }
-    .-emu-layout body.-emu #moulinette.forge.mtte .list > div > * {
-      flex: 0 0 auto; }
-    .-emu-layout body.-emu #moulinette.forge.mtte .list > div > span,
-    .-emu-layout body.-emu #moulinette.forge.mtte .list > div > a {
-      width: auto; }
-    .-emu-layout body.-emu #moulinette.forge.mtte .list > div > span {
-      flex: 1 1 auto; }
-    .-emu-layout body.-emu #moulinette.forge.mtte .list > div > img {
-      margin: 0; }
-    .-emu-layout body.-emu #moulinette.forge.mtte .list > div > input {
-      -webkit-margin-end: var(--emu-space-sm);
-              margin-inline-end: var(--emu-space-sm); }
+  padding: var(--emu-space-xs) var(--emu-space-base);
+}
+.-emu-layout body.-emu #moulinette.forge.mtte .list > div {
+  background-color: transparent;
+  min-height: 0;
+}
+.-emu-layout body.-emu #moulinette.forge.mtte .list > div:nth-of-type(even) {
+  background-color: rgba(var(--color-background-light), 0.1);
+}
+.-emu-layout body.-emu #moulinette.forge.mtte .list > div:hover {
+  background-color: rgba(var(--color-primary), 1);
+  color: rgba(var(--color-text-lightest), 1);
+}
+.-emu-layout body.-emu #moulinette.forge.mtte .list > div:hover > a {
+  color: rgba(var(--color-text-lightest), 1);
+}
+.-emu-layout body.-emu #moulinette.forge.mtte .list > div > * {
+  flex: 0 0 auto;
+}
+.-emu-layout body.-emu #moulinette.forge.mtte .list > div > span,
+.-emu-layout body.-emu #moulinette.forge.mtte .list > div > a {
+  width: auto;
+}
+.-emu-layout body.-emu #moulinette.forge.mtte .list > div > span {
+  flex: 1 1 auto;
+}
+.-emu-layout body.-emu #moulinette.forge.mtte .list > div > img {
+  margin: 0;
+}
+.-emu-layout body.-emu #moulinette.forge.mtte .list > div > input {
+  -webkit-margin-end: var(--emu-space-sm);
+  margin-inline-end: var(--emu-space-sm);
+}
 
 .-emu-layout body.-emu #moulinette.forge .filepicker {
-  max-width: 5.5rem; }
+  max-width: 5.5rem;
+}
 
 .-emu-layout body.-emu #moulinette.forge .filepicker .display-modes a {
   -webkit-margin-start: var(--emu-space-base);
-          margin-inline-start: var(--emu-space-base);
-  width: auto; }
-  .-emu-layout body.-emu #moulinette.forge .filepicker .display-modes a > i {
-    margin: 0; }
+  margin-inline-start: var(--emu-space-base);
+  width: auto;
+}
+.-emu-layout body.-emu #moulinette.forge .filepicker .display-modes a > i {
+  margin: 0;
+}
 
 body.-emu #mountup-settings-form hr {
-  display: none; }
+  display: none;
+}
 
 body.-emu .narrator-span {
-  text-shadow: none; }
+  text-shadow: none;
+}
 
 .-emu-layout body.-emu .narrator-sidebarBG {
-  width: var(--emu-space-sidebar); }
+  width: var(--emu-space-sidebar);
+}
 
-.-emu-layout body.-emu #sidebar .directory-footer button.npc-generator-btn, .-emu-layout
-body.-emu .sidebar-popout .directory-footer button.npc-generator-btn {
-  width: 100%; }
+.-emu-layout body.-emu #sidebar .directory-footer button.npc-generator-btn,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  .directory-footer
+  button.npc-generator-btn {
+  width: 100%;
+}
 
 .-emu-layout body.-emu #json-editor-menu.window-app .buttonDiv {
   display: flex;
   flex-wrap: wrap;
   -webkit-margin-after: var(--emu-space-sm);
-          margin-block-end: var(--emu-space-sm); }
+  margin-block-end: var(--emu-space-sm);
+}
 
-.-emu-layout body.-emu #json-editor-menu.window-app .buttonDiv .buttonSeperator {
+.-emu-layout
+  body.-emu
+  #json-editor-menu.window-app
+  .buttonDiv
+  .buttonSeperator {
   -webkit-margin-end: var(--emu-space-base);
-          margin-inline-end: var(--emu-space-base);
+  margin-inline-end: var(--emu-space-base);
   -webkit-margin-after: var(--emu-space-base);
-          margin-block-end: var(--emu-space-base); }
+  margin-block-end: var(--emu-space-base);
+}
 
 body.-emu #json-editor-menu.window-app .buttonDiv .buttonSeperator button {
-  box-shadow: none !important; }
+  box-shadow: none !important;
+}
 
 .-emu-layout body.-emu #json-editor-menu.window-app .bottomButtonDiv {
   -webkit-margin-before: var(--emu-space-sm);
-          margin-block-start: var(--emu-space-sm); }
+  margin-block-start: var(--emu-space-sm);
+}
 
 .-emu-layout body.-emu #json-editor-menu.window-app .json-code-editor {
   display: flex;
   flex-direction: column;
-  overflow: hidden; }
-  .-emu-layout body.-emu #json-editor-menu.window-app .json-code-editor > * {
-    flex: 0 0 auto; }
-  .-emu-layout body.-emu #json-editor-menu.window-app .json-code-editor .json-code-editor-border {
-    flex: 1 1 auto; }
+  overflow: hidden;
+}
+.-emu-layout body.-emu #json-editor-menu.window-app .json-code-editor > * {
+  flex: 0 0 auto;
+}
+.-emu-layout
+  body.-emu
+  #json-editor-menu.window-app
+  .json-code-editor
+  .json-code-editor-border {
+  flex: 1 1 auto;
+}
 
-.-emu-layout body.-emu #npcGen-image-location-settings.window-app .grid-container button.file-picker i {
-  margin: 0; }
+.-emu-layout
+  body.-emu
+  #npcGen-image-location-settings.window-app
+  .grid-container
+  button.file-picker
+  i {
+  margin: 0;
+}
 
-.-emu-layout body.-emu #npcGen-image-location-settings.window-app .button-container {
+.-emu-layout
+  body.-emu
+  #npcGen-image-location-settings.window-app
+  .button-container {
   -webkit-margin-before: var(--emu-space-sm);
-          margin-block-start: var(--emu-space-sm); }
+  margin-block-start: var(--emu-space-sm);
+}
 
 .-emu-layout body.-emu #npcgenerator-menu.window-app .npc-generator-form {
   display: flex;
   flex-direction: column;
-  overflow: hidden; }
-  .-emu-layout body.-emu #npcgenerator-menu.window-app .npc-generator-form > * {
-    flex: 0 0 auto; }
+  overflow: hidden;
+}
+.-emu-layout body.-emu #npcgenerator-menu.window-app .npc-generator-form > * {
+  flex: 0 0 auto;
+}
 
 .-emu-layout body.-emu #npcgenerator-menu.window-app .npc-generator {
   flex: 1 1 auto;
   height: 100%;
-  overflow: auto; }
-  .-emu-layout body.-emu #npcgenerator-menu.window-app .npc-generator + div {
-    display: flex;
-    height: auto !important;
-    -webkit-margin-before: var(--emu-space-sm);
-            margin-block-start: var(--emu-space-sm);
-    max-height: 100% !important;
-    width: auto !important; }
-    .-emu-layout body.-emu #npcgenerator-menu.window-app .npc-generator + div .npc-generator-bottom-button {
-      width: 100%; }
+  overflow: auto;
+}
+.-emu-layout body.-emu #npcgenerator-menu.window-app .npc-generator + div {
+  display: flex;
+  height: auto !important;
+  -webkit-margin-before: var(--emu-space-sm);
+  margin-block-start: var(--emu-space-sm);
+  max-height: 100% !important;
+  width: auto !important;
+}
+.-emu-layout
+  body.-emu
+  #npcgenerator-menu.window-app
+  .npc-generator
+  + div
+  .npc-generator-bottom-button {
+  width: 100%;
+}
 
-.-emu-layout body.-emu #npcgenerator-menu.window-app .npc-generator .npc-generator-nav {
+.-emu-layout
+  body.-emu
+  #npcgenerator-menu.window-app
+  .npc-generator
+  .npc-generator-nav {
   min-width: 20rem;
   -webkit-padding-end: var(--emu-space-sm);
-          padding-inline-end: var(--emu-space-sm); }
+  padding-inline-end: var(--emu-space-sm);
+}
 
-body.-emu #npcgenerator-menu.window-app .npc-generator .npc-generator-accordion {
+body.-emu
+  #npcgenerator-menu.window-app
+  .npc-generator
+  .npc-generator-accordion {
   border: rgba(var(--color-border), 1) 1px solid;
-  border-radius: 0; }
-  .-emu-layout body.-emu #npcgenerator-menu.window-app .npc-generator .npc-generator-accordion {
-    -webkit-margin-after: var(--emu-space-base);
-            margin-block-end: var(--emu-space-base); }
+  border-radius: 0;
+}
+.-emu-layout
+  body.-emu
+  #npcgenerator-menu.window-app
+  .npc-generator
+  .npc-generator-accordion {
+  -webkit-margin-after: var(--emu-space-base);
+  margin-block-end: var(--emu-space-base);
+}
 
 body.-emu #npcgenerator-menu.window-app .npc-generator .npc-generator-header {
   background: rgba(var(--color-background), 1);
-  color: rgba(var(--color-text-lightest), 1); }
-  .-emu-layout body.-emu #npcgenerator-menu.window-app .npc-generator .npc-generator-header {
-    cursor: pointer;
-    margin: 0;
-    padding: var(--emu-space-base); }
-    .-emu-layout body.-emu #npcgenerator-menu.window-app .npc-generator .npc-generator-header h3 {
-      margin: 0;
-      padding: 0; }
-      .-emu-layout body.-emu #npcgenerator-menu.window-app .npc-generator .npc-generator-header h3 .indicator {
-        display: none; }
+  color: rgba(var(--color-text-lightest), 1);
+}
+.-emu-layout
+  body.-emu
+  #npcgenerator-menu.window-app
+  .npc-generator
+  .npc-generator-header {
+  cursor: pointer;
+  margin: 0;
+  padding: var(--emu-space-base);
+}
+.-emu-layout
+  body.-emu
+  #npcgenerator-menu.window-app
+  .npc-generator
+  .npc-generator-header
+  h3 {
+  margin: 0;
+  padding: 0;
+}
+.-emu-layout
+  body.-emu
+  #npcgenerator-menu.window-app
+  .npc-generator
+  .npc-generator-header
+  h3
+  .indicator {
+  display: none;
+}
 
-.-emu-layout body.-emu #npcgenerator-menu.window-app .npc-generator .npc-generator-list {
-  padding: var(--emu-space-base); }
-  .-emu-layout body.-emu #npcgenerator-menu.window-app .npc-generator .npc-generator-list > div {
-    align-items: center;
-    -webkit-margin-after: var(--emu-space-base);
-            margin-block-end: var(--emu-space-base); }
-    .-emu-layout body.-emu #npcgenerator-menu.window-app .npc-generator .npc-generator-list > div:last-child {
-      -webkit-margin-after: 0;
-              margin-block-end: 0; }
-    .-emu-layout body.-emu #npcgenerator-menu.window-app .npc-generator .npc-generator-list > div input[type="number"] {
-      min-width: 0;
-      width: auto; }
-    .-emu-layout body.-emu #npcgenerator-menu.window-app .npc-generator .npc-generator-list > div > input[type="checkbox"] {
-      margin: 0 var(--emu-space-base); }
-    .-emu-layout body.-emu #npcgenerator-menu.window-app .npc-generator .npc-generator-list > div .nameForcedDiv {
-      display: flex;
-      min-width: initial; }
-      .-emu-layout body.-emu #npcgenerator-menu.window-app .npc-generator .npc-generator-list > div .nameForcedDiv input {
-        -webkit-margin-start: var(--emu-space-base);
-                margin-inline-start: var(--emu-space-base); }
+.-emu-layout
+  body.-emu
+  #npcgenerator-menu.window-app
+  .npc-generator
+  .npc-generator-list {
+  padding: var(--emu-space-base);
+}
+.-emu-layout
+  body.-emu
+  #npcgenerator-menu.window-app
+  .npc-generator
+  .npc-generator-list
+  > div {
+  align-items: center;
+  -webkit-margin-after: var(--emu-space-base);
+  margin-block-end: var(--emu-space-base);
+}
+.-emu-layout
+  body.-emu
+  #npcgenerator-menu.window-app
+  .npc-generator
+  .npc-generator-list
+  > div:last-child {
+  -webkit-margin-after: 0;
+  margin-block-end: 0;
+}
+.-emu-layout
+  body.-emu
+  #npcgenerator-menu.window-app
+  .npc-generator
+  .npc-generator-list
+  > div
+  input[type="number"] {
+  min-width: 0;
+  width: auto;
+}
+.-emu-layout
+  body.-emu
+  #npcgenerator-menu.window-app
+  .npc-generator
+  .npc-generator-list
+  > div
+  > input[type="checkbox"] {
+  margin: 0 var(--emu-space-base);
+}
+.-emu-layout
+  body.-emu
+  #npcgenerator-menu.window-app
+  .npc-generator
+  .npc-generator-list
+  > div
+  .nameForcedDiv {
+  display: flex;
+  min-width: initial;
+}
+.-emu-layout
+  body.-emu
+  #npcgenerator-menu.window-app
+  .npc-generator
+  .npc-generator-list
+  > div
+  .nameForcedDiv
+  input {
+  -webkit-margin-start: var(--emu-space-base);
+  margin-inline-start: var(--emu-space-base);
+}
 
-.-emu-layout body.-emu #npcgenerator-menu.window-app .npc-generator .npc-generator-character-item {
+.-emu-layout
+  body.-emu
+  #npcgenerator-menu.window-app
+  .npc-generator
+  .npc-generator-character-item {
   -webkit-padding-after: var(--emu-space-base);
-          padding-block-end: var(--emu-space-base);
+  padding-block-end: var(--emu-space-base);
   -webkit-padding-end: var(--emu-space-base);
-          padding-inline-end: var(--emu-space-base); }
+  padding-inline-end: var(--emu-space-base);
+}
 
-body.-emu #npcgenerator-menu.window-app .npc-generator .npc-generator-character-item table {
-  border: none; }
-  .-emu-layout body.-emu #npcgenerator-menu.window-app .npc-generator .npc-generator-character-item table {
-    -webkit-margin-after: var(--emu-space-sm);
-            margin-block-end: var(--emu-space-sm); }
-    .-emu-layout body.-emu #npcgenerator-menu.window-app .npc-generator .npc-generator-character-item table input {
-      width: auto; }
+body.-emu
+  #npcgenerator-menu.window-app
+  .npc-generator
+  .npc-generator-character-item
+  table {
+  border: none;
+}
+.-emu-layout
+  body.-emu
+  #npcgenerator-menu.window-app
+  .npc-generator
+  .npc-generator-character-item
+  table {
+  -webkit-margin-after: var(--emu-space-sm);
+  margin-block-end: var(--emu-space-sm);
+}
+.-emu-layout
+  body.-emu
+  #npcgenerator-menu.window-app
+  .npc-generator
+  .npc-generator-character-item
+  table
+  input {
+  width: auto;
+}
 
-.-emu-layout body.-emu #npcgenerator-menu.window-app .npc-generator .npc-generator-character-name {
+.-emu-layout
+  body.-emu
+  #npcgenerator-menu.window-app
+  .npc-generator
+  .npc-generator-character-name {
   display: flex;
   -webkit-padding-after: var(--emu-space-sm);
-          padding-block-end: var(--emu-space-sm);
-  text-align: initial; }
-  .-emu-layout body.-emu #npcgenerator-menu.window-app .npc-generator .npc-generator-character-name input {
-    font-size: var(--emu-font-size-lg); }
-    .-emu-layout body.-emu #npcgenerator-menu.window-app .npc-generator .npc-generator-character-name input:last-child {
-      -webkit-margin-start: var(--emu-space-base);
-              margin-inline-start: var(--emu-space-base); }
+  padding-block-end: var(--emu-space-sm);
+  text-align: initial;
+}
+.-emu-layout
+  body.-emu
+  #npcgenerator-menu.window-app
+  .npc-generator
+  .npc-generator-character-name
+  input {
+  font-size: var(--emu-font-size-lg);
+}
+.-emu-layout
+  body.-emu
+  #npcgenerator-menu.window-app
+  .npc-generator
+  .npc-generator-character-name
+  input:last-child {
+  -webkit-margin-start: var(--emu-space-base);
+  margin-inline-start: var(--emu-space-base);
+}
 
 .-emu-layout body.-emu #OneJournalShell.window-app.maximized {
-  width: calc(100% - var(--emu-space-sidebar)) !important; }
+  width: calc(100% - var(--emu-space-sidebar)) !important;
+}
 
 .-emu-layout body.-emu #OneJournalShell.window-app.maximized > .window-header {
-  position: relative; }
+  position: relative;
+}
 
 .-emu-layout body.-emu #OneJournalShell.window-app.maximized > .window-content {
-  padding: 0; }
+  padding: 0;
+}
 
 body.-emu #OneJournalShell.window-app .window-header .one-journal-header {
   background-color: transparent;
-  border: none; }
-  .-emu-layout body.-emu #OneJournalShell.window-app .window-header .one-journal-header {
-    margin: 0;
-    padding: 0 var(--emu-space-sm); }
-  .-emu-layout body.-emu #OneJournalShell.window-app .window-header .one-journal-header a {
-    position: relative; }
+  border: none;
+}
+.-emu-layout
+  body.-emu
+  #OneJournalShell.window-app
+  .window-header
+  .one-journal-header {
+  margin: 0;
+  padding: 0 var(--emu-space-sm);
+}
+.-emu-layout
+  body.-emu
+  #OneJournalShell.window-app
+  .window-header
+  .one-journal-header
+  a {
+  position: relative;
+}
 
 body.-emu #OneJournalShell.window-app .window-content {
   background-color: rgba(var(--color-background-lightest), 1);
-  background-image: var(--emu-image-background-lightest, none); }
+  background-image: var(--emu-image-background-lightest, none);
+}
 
-.-emu-layout body.-emu #OneJournalShell.window-app .one-journal-attached .window-header {
-  display: none; }
+.-emu-layout
+  body.-emu
+  #OneJournalShell.window-app
+  .one-journal-attached
+  .window-header {
+  display: none;
+}
 
-.-emu-layout body.-emu #OneJournalShell.window-app .one-journal-attached form > input {
-  flex: 0 0 calc(100% - 6.125rem); }
+.-emu-layout
+  body.-emu
+  #OneJournalShell.window-app
+  .one-journal-attached
+  form
+  > input {
+  flex: 0 0 calc(100% - 6.125rem);
+}
 
 body.-emu #OneJournalShell.window-app .shell-content {
-  border: none; }
-  .-emu-layout body.-emu #OneJournalShell.window-app .shell-content .window-resizable-handle {
-    display: none; }
-  .-emu-layout body.-emu #OneJournalShell.window-app .shell-content .editor-edit {
-    right: 4rem; }
+  border: none;
+}
+.-emu-layout
+  body.-emu
+  #OneJournalShell.window-app
+  .shell-content
+  .window-resizable-handle {
+  display: none;
+}
+.-emu-layout body.-emu #OneJournalShell.window-app .shell-content .editor-edit {
+  right: 4rem;
+}
 
 .-emu-layout body.-emu #OneJournalShell.window-app .history-navigation {
   right: var(--emu-space-sm);
-  top: var(--emu-space-sm); }
+  top: var(--emu-space-sm);
+}
 
 .-emu-layout body.-emu #OneJournalShell.window-app .history-navigation a {
-  opacity: 1; }
-  .-emu-layout body.-emu #OneJournalShell.window-app .history-navigation a > i {
-    margin: 0; }
+  opacity: 1;
+}
+.-emu-layout body.-emu #OneJournalShell.window-app .history-navigation a > i {
+  margin: 0;
+}
 
 body.-emu #OneJournalShell.window-app .sidebar-toggle {
   background-color: rgba(var(--color-background-button), 1);
   border: none;
   -webkit-border-after: rgba(var(--color-background-lightest), 1) 2px solid;
-          border-block-end: rgba(var(--color-background-lightest), 1) 2px solid;
+  border-block-end: rgba(var(--color-background-lightest), 1) 2px solid;
   -webkit-border-start: rgba(var(--color-background-lightest), 1) 2px solid;
-          border-inline-start: rgba(var(--color-background-lightest), 1) 2px solid;
+  border-inline-start: rgba(var(--color-background-lightest), 1) 2px solid;
   border-radius: 0 0 0 var(--emu-border-radius-default, 0);
   color: rgba(var(--color-text-lightest), 1);
-  transition: background 0.3s cubic-bezier(0.075, 0.82, 0.165, 1), box-shadow 0.3s cubic-bezier(0.075, 0.82, 0.165, 1), color 0.3s cubic-bezier(0.075, 0.82, 0.165, 1); }
-  .-emu-layout body.-emu #OneJournalShell.window-app .sidebar-toggle {
-    top: 0;
-    right: 0;
-    position: absolute;
-    width: 1.25rem;
-    height: 1.25rem;
-    align-items: center;
-    cursor: pointer;
-    display: inline-flex;
-    font-size: var(--emu-font-size-sm);
-    justify-content: center;
-    margin: 0;
-    padding: 0;
-    z-index: 10; }
+  transition: background 0.3s cubic-bezier(0.075, 0.82, 0.165, 1),
+    box-shadow 0.3s cubic-bezier(0.075, 0.82, 0.165, 1),
+    color 0.3s cubic-bezier(0.075, 0.82, 0.165, 1);
+}
+.-emu-layout body.-emu #OneJournalShell.window-app .sidebar-toggle {
+  top: 0;
+  right: 0;
+  position: absolute;
+  width: 1.25rem;
+  height: 1.25rem;
+  align-items: center;
+  cursor: pointer;
+  display: inline-flex;
+  font-size: var(--emu-font-size-sm);
+  justify-content: center;
+  margin: 0;
+  padding: 0;
+  z-index: 10;
+}
 
 body.-emu #OneJournalShell.window-app .one-journal-attached,
 body.-emu #OneJournalShell.window-app .shell-sidebar {
-  border: none; }
+  border: none;
+}
 
-.-emu-layout body.-emu #OneJournalDirectory #journal.sidebar-tab .directory-header {
+.-emu-layout
+  body.-emu
+  #OneJournalDirectory
+  #journal.sidebar-tab
+  .directory-header {
   margin: 0;
-  padding: var(--emu-space-sm); }
-  .-emu-layout body.-emu #OneJournalDirectory #journal.sidebar-tab .directory-header button {
-    height: auto; }
+  padding: var(--emu-space-sm);
+}
+.-emu-layout
+  body.-emu
+  #OneJournalDirectory
+  #journal.sidebar-tab
+  .directory-header
+  button {
+  height: auto;
+}
 
-body.-emu #OneJournalDirectory #journal.sidebar-tab .directory-header .header-actions {
-  border: none; }
-  .-emu-layout body.-emu #OneJournalDirectory #journal.sidebar-tab .directory-header .header-actions {
-    -webkit-margin-after: var(--emu-space-base);
-            margin-block-end: var(--emu-space-base); }
-    .-emu-layout body.-emu #OneJournalDirectory #journal.sidebar-tab .directory-header .header-actions #world-anvil {
-      display: none; }
+body.-emu
+  #OneJournalDirectory
+  #journal.sidebar-tab
+  .directory-header
+  .header-actions {
+  border: none;
+}
+.-emu-layout
+  body.-emu
+  #OneJournalDirectory
+  #journal.sidebar-tab
+  .directory-header
+  .header-actions {
+  -webkit-margin-after: var(--emu-space-base);
+  margin-block-end: var(--emu-space-base);
+}
+.-emu-layout
+  body.-emu
+  #OneJournalDirectory
+  #journal.sidebar-tab
+  .directory-header
+  .header-actions
+  #world-anvil {
+  display: none;
+}
 
 body.-emu #OneJournalDirectory #journal.sidebar-tab .subdirectory {
   -webkit-border-start: rgba(var(--color-primary), 1) 4px solid;
-          border-inline-start: rgba(var(--color-primary), 1) 4px solid;
+  border-inline-start: rgba(var(--color-primary), 1) 4px solid;
   -webkit-border-after: none;
-          border-block-end: none; }
-  body.-emu #OneJournalDirectory #journal.sidebar-tab .subdirectory .subdirectory {
-    -webkit-border-start: rgba(var(--color-orange-700), 1) 4px solid;
-            border-inline-start: rgba(var(--color-orange-700), 1) 4px solid; }
-    body.-emu #OneJournalDirectory #journal.sidebar-tab .subdirectory .subdirectory .subdirectory {
-      -webkit-border-start: rgba(var(--color-orange-900), 1) 4px solid;
-              border-inline-start: rgba(var(--color-orange-900), 1) 4px solid; }
+  border-block-end: none;
+}
+body.-emu
+  #OneJournalDirectory
+  #journal.sidebar-tab
+  .subdirectory
+  .subdirectory {
+  -webkit-border-start: rgba(var(--color-orange-700), 1) 4px solid;
+  border-inline-start: rgba(var(--color-orange-700), 1) 4px solid;
+}
+body.-emu
+  #OneJournalDirectory
+  #journal.sidebar-tab
+  .subdirectory
+  .subdirectory
+  .subdirectory {
+  -webkit-border-start: rgba(var(--color-orange-900), 1) 4px solid;
+  border-inline-start: rgba(var(--color-orange-900), 1) 4px solid;
+}
 
 body.-emu #OneJournalDirectory #journal.sidebar-tab .directory-item.selected {
-  background-color: rgba(var(--color-primary), 1); }
+  background-color: rgba(var(--color-primary), 1);
+}
 
-body.-emu #OneJournalDirectory #journal.sidebar-tab .directory-item .folder-header {
+body.-emu
+  #OneJournalDirectory
+  #journal.sidebar-tab
+  .directory-item
+  .folder-header {
   background-color: rgba(var(--color-folder-header), 1);
   -webkit-border-before: none;
-          border-block-start: none; }
+  border-block-start: none;
+}
 
 body.-emu #OneJournalDirectory #journal.sidebar-tab .directory-item h3 {
-  color: rgba(var(--color-text), 1); }
+  color: rgba(var(--color-text), 1);
+}
 
-body.-emu #OneJournalDirectory #journal.sidebar-tab .directory-item a.create-folder,
-body.-emu #OneJournalDirectory #journal.sidebar-tab .directory-item a.create-entity {
-  color: rgba(var(--color-text-lightest), 1); }
+body.-emu
+  #OneJournalDirectory
+  #journal.sidebar-tab
+  .directory-item
+  a.create-folder,
+body.-emu
+  #OneJournalDirectory
+  #journal.sidebar-tab
+  .directory-item
+  a.create-entity {
+  color: rgba(var(--color-text-lightest), 1);
+}
 
-.-emu-layout body.-emu #sidebar .sidebar-tab .directory-footer button + button + button.one-journal-open, .-emu-layout
-body.-emu .sidebar-popout .sidebar-tab .directory-footer button + button + button.one-journal-open {
+.-emu-layout
+  body.-emu
+  #sidebar
+  .sidebar-tab
+  .directory-footer
+  button
+  + button
+  + button.one-journal-open,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  .sidebar-tab
+  .directory-footer
+  button
+  + button
+  + button.one-journal-open {
   margin: 0;
   -webkit-margin-before: var(--emu-space-base);
-          margin-block-start: var(--emu-space-base); }
+  margin-block-start: var(--emu-space-base);
+}
 
-.-emu-layout body.-emu #sidebar .sidebar-tab .directory-footer button.one-journal-open, .-emu-layout
-body.-emu .sidebar-popout .sidebar-tab .directory-footer button.one-journal-open {
-  flex: 1 1 auto; }
+.-emu-layout
+  body.-emu
+  #sidebar
+  .sidebar-tab
+  .directory-footer
+  button.one-journal-open,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  .sidebar-tab
+  .directory-footer
+  button.one-journal-open {
+  flex: 1 1 auto;
+}
 
-body.-emu #fvtt-party-resources-dashboard.fvtt-party-resources.window-app .version {
-  color: rgba(var(--color-text), 0.5); }
-  .-emu-layout body.-emu #fvtt-party-resources-dashboard.fvtt-party-resources.window-app .version {
-    display: none; }
-    .-emu-layout body.-emu #fvtt-party-resources-dashboard.fvtt-party-resources.window-app .version + p {
-      margin: 0; }
+body.-emu
+  #fvtt-party-resources-dashboard.fvtt-party-resources.window-app
+  .version {
+  color: rgba(var(--color-text), 0.5);
+}
+.-emu-layout
+  body.-emu
+  #fvtt-party-resources-dashboard.fvtt-party-resources.window-app
+  .version {
+  display: none;
+}
+.-emu-layout
+  body.-emu
+  #fvtt-party-resources-dashboard.fvtt-party-resources.window-app
+  .version
+  + p {
+  margin: 0;
+}
 
-.-emu-layout body.-emu #edit-resource-form.fvtt-party-resources.window-app form .form-group label.checkbox, .-emu-layout
-body.-emu #add-resource-form.fvtt-party-resources.window-app form .form-group label.checkbox {
+.-emu-layout
+  body.-emu
+  #edit-resource-form.fvtt-party-resources.window-app
+  form
+  .form-group
+  label.checkbox,
+.-emu-layout
+  body.-emu
+  #add-resource-form.fvtt-party-resources.window-app
+  form
+  .form-group
+  label.checkbox {
   flex: 1 1 auto;
   font-size: var(--emu-font-size-md) !important;
-  margin: 0; }
-  .-emu-layout body.-emu #edit-resource-form.fvtt-party-resources.window-app form .form-group label.checkbox input[type="checkbox"], .-emu-layout
-  body.-emu #add-resource-form.fvtt-party-resources.window-app form .form-group label.checkbox input[type="checkbox"] {
-    margin: 0;
-    -webkit-margin-end: var(--emu-space-sm);
-            margin-inline-end: var(--emu-space-sm); }
-  .-emu-layout body.-emu #edit-resource-form.fvtt-party-resources.window-app form .form-group label.checkbox + .notes, .-emu-layout
-  body.-emu #add-resource-form.fvtt-party-resources.window-app form .form-group label.checkbox + .notes {
-    -webkit-margin-before: var(--emu-space-base);
-            margin-block-start: var(--emu-space-base); }
-
-body.-emu #edit-resource-form.fvtt-party-resources.window-app form .form-group #configure-permissions,
-body.-emu #add-resource-form.fvtt-party-resources.window-app form .form-group #configure-permissions {
+  margin: 0;
+}
+.-emu-layout
+  body.-emu
+  #edit-resource-form.fvtt-party-resources.window-app
+  form
+  .form-group
+  label.checkbox
+  input[type="checkbox"],
+.-emu-layout
+  body.-emu
+  #add-resource-form.fvtt-party-resources.window-app
+  form
+  .form-group
+  label.checkbox
+  input[type="checkbox"] {
+  margin: 0;
+  -webkit-margin-end: var(--emu-space-sm);
+  margin-inline-end: var(--emu-space-sm);
+}
+.-emu-layout
+  body.-emu
+  #edit-resource-form.fvtt-party-resources.window-app
+  form
+  .form-group
+  label.checkbox
+  + .notes,
+.-emu-layout
+  body.-emu
+  #add-resource-form.fvtt-party-resources.window-app
+  form
+  .form-group
+  label.checkbox
+  + .notes {
   -webkit-margin-before: var(--emu-space-base);
-          margin-block-start: var(--emu-space-base); }
+  margin-block-start: var(--emu-space-base);
+}
+
+body.-emu
+  #edit-resource-form.fvtt-party-resources.window-app
+  form
+  .form-group
+  #configure-permissions,
+body.-emu
+  #add-resource-form.fvtt-party-resources.window-app
+  form
+  .form-group
+  #configure-permissions {
+  -webkit-margin-before: var(--emu-space-base);
+  margin-block-start: var(--emu-space-base);
+}
 
 .-emu-layout body.-emu .app.window-app form.pdf-item-sheet .field-row {
   align-items: center;
   display: flex;
   -webkit-margin-after: var(--emu-space-base);
-          margin-block-end: var(--emu-space-base); }
-  .-emu-layout body.-emu .app.window-app form.pdf-item-sheet .field-row > label {
-    -webkit-margin-end: var(--emu-space-sm);
-            margin-inline-end: var(--emu-space-sm); }
+  margin-block-end: var(--emu-space-base);
+}
+.-emu-layout body.-emu .app.window-app form.pdf-item-sheet .field-row > label {
+  -webkit-margin-end: var(--emu-space-sm);
+  margin-inline-end: var(--emu-space-sm);
+}
 
 body.-emu .pdf-app.app.window-app section.window-content {
-  background-image: var(--emu-image-background-light, none) !important; }
+  background-image: var(--emu-image-background-light, none) !important;
+}
 
 .-emu-layout body.-emu .pdf-app.app.window-app div.flex {
   -webkit-margin-after: var(--emu-space-base);
-          margin-block-end: var(--emu-space-base); }
+  margin-block-end: var(--emu-space-base);
+}
 
 .-emu-layout body.-emu .pdf-app.app.window-app div.flex > * {
-  height: auto; }
+  height: auto;
+}
 
-.-emu-layout body.-emu #sidebar .sidebar-tab .directory-footer button.create-pdf, .-emu-layout
-body.-emu .sidebar-popout .sidebar-tab .directory-footer button.create-pdf {
-  flex: 1 1 auto; }
+.-emu-layout
+  body.-emu
+  #sidebar
+  .sidebar-tab
+  .directory-footer
+  button.create-pdf,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  .sidebar-tab
+  .directory-footer
+  button.create-pdf {
+  flex: 1 1 auto;
+}
 
 .-emu-layout body.-emu div.permission-viewer {
   flex: 0 0 auto;
   margin: 0;
   -webkit-margin-start: var(--emu-space-base);
-          margin-inline-start: var(--emu-space-base); }
+  margin-inline-start: var(--emu-space-base);
+}
 
 body.-emu div.permission-viewer a {
-  text-shadow: none; }
-  .-emu-layout body.-emu div.permission-viewer a {
-    padding: 0 var(--emu-space-base);
-    width: auto; }
+  text-shadow: none;
+}
+.-emu-layout body.-emu div.permission-viewer a {
+  padding: 0 var(--emu-space-base);
+  width: auto;
+}
 
 body.-emu .window-app .window-header a.pop__btn-open,
 body.-emu .window-app .window-header a.tit-menu__btn-open--sheet.px-2 {
   display: flex !important;
   flex: 0 0 auto;
   padding: 0 !important;
-  width: var(--emu-space-button-sm); }
-  body.-emu .window-app .window-header a.pop__btn-open > i,
-  body.-emu .window-app .window-header a.pop__btn-open > span.fas,
-  body.-emu .window-app .window-header a.tit-menu__btn-open--sheet.px-2 > i,
-  body.-emu .window-app .window-header a.tit-menu__btn-open--sheet.px-2 > span.fas {
-    -webkit-margin-end: 0;
-            margin-inline-end: 0; }
+  width: var(--emu-space-button-sm);
+}
+body.-emu .window-app .window-header a.pop__btn-open > i,
+body.-emu .window-app .window-header a.pop__btn-open > span.fas,
+body.-emu .window-app .window-header a.tit-menu__btn-open--sheet.px-2 > i,
+body.-emu
+  .window-app
+  .window-header
+  a.tit-menu__btn-open--sheet.px-2
+  > span.fas {
+  -webkit-margin-end: 0;
+  margin-inline-end: 0;
+}
 
-body.-emu #sidebar .flex-col.dir__wrp-header.w-100.no-shrink.min-w-100.dir__control-header,
-body.-emu .sidebar-popout .flex-col.dir__wrp-header.w-100.no-shrink.min-w-100.dir__control-header {
+body.-emu
+  #sidebar
+  .flex-col.dir__wrp-header.w-100.no-shrink.min-w-100.dir__control-header,
+body.-emu
+  .sidebar-popout
+  .flex-col.dir__wrp-header.w-100.no-shrink.min-w-100.dir__control-header {
   -webkit-margin-after: var(--emu-space-sm);
-          margin-block-end: var(--emu-space-sm);
-  padding: 0; }
-  body.-emu #sidebar .flex-col.dir__wrp-header.w-100.no-shrink.min-w-100.dir__control-header hr,
-  body.-emu .sidebar-popout .flex-col.dir__wrp-header.w-100.no-shrink.min-w-100.dir__control-header hr {
-    display: none; }
-  body.-emu #sidebar .flex-col.dir__wrp-header.w-100.no-shrink.min-w-100.dir__control-header .btn-group button:last-child,
-  body.-emu .sidebar-popout .flex-col.dir__wrp-header.w-100.no-shrink.min-w-100.dir__control-header .btn-group button:last-child {
-    -webkit-margin-start: var(--emu-space-xs) !important;
-            margin-inline-start: var(--emu-space-xs) !important; }
-  body.-emu #sidebar .flex-col.dir__wrp-header.w-100.no-shrink.min-w-100.dir__control-header button,
-  body.-emu .sidebar-popout .flex-col.dir__wrp-header.w-100.no-shrink.min-w-100.dir__control-header button {
-    flex: 0 0 auto; }
-    body.-emu #sidebar .flex-col.dir__wrp-header.w-100.no-shrink.min-w-100.dir__control-header button:first-child,
-    body.-emu .sidebar-popout .flex-col.dir__wrp-header.w-100.no-shrink.min-w-100.dir__control-header button:first-child {
-      flex: 1 1 auto; }
-      body.-emu #sidebar .flex-col.dir__wrp-header.w-100.no-shrink.min-w-100.dir__control-header button:first-child > span,
-      body.-emu .sidebar-popout .flex-col.dir__wrp-header.w-100.no-shrink.min-w-100.dir__control-header button:first-child > span {
-        -webkit-margin-end: var(--emu-space-base);
-                margin-inline-end: var(--emu-space-base); }
+  margin-block-end: var(--emu-space-sm);
+  padding: 0;
+}
+body.-emu
+  #sidebar
+  .flex-col.dir__wrp-header.w-100.no-shrink.min-w-100.dir__control-header
+  hr,
+body.-emu
+  .sidebar-popout
+  .flex-col.dir__wrp-header.w-100.no-shrink.min-w-100.dir__control-header
+  hr {
+  display: none;
+}
+body.-emu
+  #sidebar
+  .flex-col.dir__wrp-header.w-100.no-shrink.min-w-100.dir__control-header
+  .btn-group
+  button:last-child,
+body.-emu
+  .sidebar-popout
+  .flex-col.dir__wrp-header.w-100.no-shrink.min-w-100.dir__control-header
+  .btn-group
+  button:last-child {
+  -webkit-margin-start: var(--emu-space-xs) !important;
+  margin-inline-start: var(--emu-space-xs) !important;
+}
+body.-emu
+  #sidebar
+  .flex-col.dir__wrp-header.w-100.no-shrink.min-w-100.dir__control-header
+  button,
+body.-emu
+  .sidebar-popout
+  .flex-col.dir__wrp-header.w-100.no-shrink.min-w-100.dir__control-header
+  button {
+  flex: 0 0 auto;
+}
+body.-emu
+  #sidebar
+  .flex-col.dir__wrp-header.w-100.no-shrink.min-w-100.dir__control-header
+  button:first-child,
+body.-emu
+  .sidebar-popout
+  .flex-col.dir__wrp-header.w-100.no-shrink.min-w-100.dir__control-header
+  button:first-child {
+  flex: 1 1 auto;
+}
+body.-emu
+  #sidebar
+  .flex-col.dir__wrp-header.w-100.no-shrink.min-w-100.dir__control-header
+  button:first-child
+  > span,
+body.-emu
+  .sidebar-popout
+  .flex-col.dir__wrp-header.w-100.no-shrink.min-w-100.dir__control-header
+  button:first-child
+  > span {
+  -webkit-margin-end: var(--emu-space-base);
+  margin-inline-end: var(--emu-space-base);
+}
 
 body.-emu #polyglot {
   background-color: rgba(var(--color-background), 0.5);
-  background-image: var(--emu-image-background, none); }
-  .-emu-layout body.-emu #polyglot {
-    align-items: center;
-    display: flex;
-    flex: 0 0 auto;
-    flex-wrap: nowrap;
-    margin: 0;
-    padding: 0 var(--emu-space-sm);
-    -webkit-padding-after: var(--emu-space-base);
-            padding-block-end: var(--emu-space-base); }
-  body.-emu #polyglot label {
-    color: rgba(var(--color-text-lightest), 1); }
-    .-emu-layout body.-emu #polyglot label {
-      flex: 0 0 auto;
-      -webkit-margin-end: var(--emu-space-base);
-              margin-inline-end: var(--emu-space-base); }
-  body.-emu #polyglot select {
-    background-color: rgba(var(--color-background), 0.5);
-    color: rgba(var(--color-text-lightest), 1); }
-    .-emu-layout body.-emu #polyglot select {
-      flex: 1 1 auto;
-      width: 1px; }
+  background-image: var(--emu-image-background, none);
+}
+.-emu-layout body.-emu #polyglot {
+  align-items: center;
+  display: flex;
+  flex: 0 0 auto;
+  flex-wrap: nowrap;
+  margin: 0;
+  padding: 0 var(--emu-space-sm);
+  -webkit-padding-after: var(--emu-space-base);
+  padding-block-end: var(--emu-space-base);
+}
+body.-emu #polyglot label {
+  color: rgba(var(--color-text-lightest), 1);
+}
+.-emu-layout body.-emu #polyglot label {
+  flex: 0 0 auto;
+  -webkit-margin-end: var(--emu-space-base);
+  margin-inline-end: var(--emu-space-base);
+}
+body.-emu #polyglot select {
+  background-color: rgba(var(--color-background), 0.5);
+  color: rgba(var(--color-text-lightest), 1);
+}
+.-emu-layout body.-emu #polyglot select {
+  flex: 1 1 auto;
+  width: 1px;
+}
 
 body.-emu #client-settings.window-app form .polyglot-group-header {
   background-color: transparent;
   -webkit-border-after: rgba(var(--color-border), 1) 1px solid;
-          border-block-end: rgba(var(--color-border), 1) 1px solid; }
-  .-emu-layout body.-emu #client-settings.window-app form .polyglot-group-header {
-    -webkit-margin-before: var(--emu-space-base);
-            margin-block-start: var(--emu-space-base); }
+  border-block-end: rgba(var(--color-border), 1) 1px solid;
+}
+.-emu-layout body.-emu #client-settings.window-app form .polyglot-group-header {
+  -webkit-margin-before: var(--emu-space-base);
+  margin-block-start: var(--emu-space-base);
+}
 
 .-emu-layout body.-emu #polyglot-death-form.window-app .window-content form {
   display: flex;
   flex-direction: column;
   overflow: hidden;
-  padding: 0 !important; }
-  .-emu-layout body.-emu #polyglot-death-form.window-app .window-content form > div:not(.sheet-footer) {
-    flex: 1 1 auto;
-    overflow: auto;
-    -webkit-margin-after: var(--emu-space-base);
-            margin-block-end: var(--emu-space-base);
-    -webkit-padding-end: var(--emu-space-sm);
-            padding-inline-end: var(--emu-space-sm);
-    -webkit-padding-after: var(--emu-space-sm);
-            padding-block-end: var(--emu-space-sm); }
-    .-emu-layout body.-emu #polyglot-death-form.window-app .window-content form > div:not(.sheet-footer) ul {
-      padding: 0; }
-    .-emu-layout body.-emu #polyglot-death-form.window-app .window-content form > div:not(.sheet-footer) li {
-      -webkit-margin-after: var(--emu-space-base);
-              margin-block-end: var(--emu-space-base); }
-      .-emu-layout body.-emu #polyglot-death-form.window-app .window-content form > div:not(.sheet-footer) li:last-child {
-        -webkit-margin-after: 0;
-                margin-block-end: 0; }
-  .-emu-layout body.-emu #polyglot-death-form.window-app .window-content form .sheet-footer {
-    flex: 0 0 auto;
-    margin: 0;
-    -webkit-margin-before: var(--emu-space-sm) !important;
-            margin-block-start: var(--emu-space-sm) !important; }
+  padding: 0 !important;
+}
+.-emu-layout
+  body.-emu
+  #polyglot-death-form.window-app
+  .window-content
+  form
+  > div:not(.sheet-footer) {
+  flex: 1 1 auto;
+  overflow: auto;
+  -webkit-margin-after: var(--emu-space-base);
+  margin-block-end: var(--emu-space-base);
+  -webkit-padding-end: var(--emu-space-sm);
+  padding-inline-end: var(--emu-space-sm);
+  -webkit-padding-after: var(--emu-space-sm);
+  padding-block-end: var(--emu-space-sm);
+}
+.-emu-layout
+  body.-emu
+  #polyglot-death-form.window-app
+  .window-content
+  form
+  > div:not(.sheet-footer)
+  ul {
+  padding: 0;
+}
+.-emu-layout
+  body.-emu
+  #polyglot-death-form.window-app
+  .window-content
+  form
+  > div:not(.sheet-footer)
+  li {
+  -webkit-margin-after: var(--emu-space-base);
+  margin-block-end: var(--emu-space-base);
+}
+.-emu-layout
+  body.-emu
+  #polyglot-death-form.window-app
+  .window-content
+  form
+  > div:not(.sheet-footer)
+  li:last-child {
+  -webkit-margin-after: 0;
+  margin-block-end: 0;
+}
+.-emu-layout
+  body.-emu
+  #polyglot-death-form.window-app
+  .window-content
+  form
+  .sheet-footer {
+  flex: 0 0 auto;
+  margin: 0;
+  -webkit-margin-before: var(--emu-space-sm) !important;
+  margin-block-start: var(--emu-space-sm) !important;
+}
 
 body.-emu #sidebar #chat #chat-log .message .button.polyglot-message-language,
-body.-emu .sidebar-popout #chat #chat-log .message .button.polyglot-message-language {
-  color: rgba(var(--color-text), 1); }
-  .-emu-layout body.-emu #sidebar #chat #chat-log .message .button.polyglot-message-language, .-emu-layout
-  body.-emu .sidebar-popout #chat #chat-log .message .button.polyglot-message-language {
-    color: rgba(var(--color-text), 1); }
+body.-emu
+  .sidebar-popout
+  #chat
+  #chat-log
+  .message
+  .button.polyglot-message-language {
+  color: rgba(var(--color-text), 1);
+}
+.-emu-layout
+  body.-emu
+  #sidebar
+  #chat
+  #chat-log
+  .message
+  .button.polyglot-message-language,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  #chat
+  #chat-log
+  .message
+  .button.polyglot-message-language {
+  color: rgba(var(--color-text), 1);
+}
 
 body.-emu #search-anywhere-modal .modal-content {
   background-color: transparent;
   border: none;
-  border-radius: 0; }
+  border-radius: 0;
+}
 
 body.-emu #search-anywhere-modal #search-anywhere-autocomplete {
   background: rgba(var(--color-background-lightest), 1);
-  color: rgba(var(--color-text), 1); }
-  .-emu-layout body.-emu #search-anywhere-modal #search-anywhere-autocomplete {
-    font-size: var(--emu-font-size-xl);
-    height: auto;
-    padding: var(--emu-space-md); }
+  color: rgba(var(--color-text), 1);
+}
+.-emu-layout body.-emu #search-anywhere-modal #search-anywhere-autocomplete {
+  font-size: var(--emu-font-size-xl);
+  height: auto;
+  padding: var(--emu-space-md);
+}
 
 body.-emu ul.command-menu {
   background-color: rgba(var(--color-background-darkest), 0.8);
   background-image: var(--emu-image-background-darkest, none);
   border-radius: var(--emu-border-radius-default, 0);
-  box-shadow: 0 2px 4px rgba(var(--color-black), 1); }
-  .-emu-layout body.-emu ul.command-menu {
-    display: flex;
-    flex-direction: column;
-    padding: var(--emu-space-sm);
-    z-index: 1070; }
-  .-emu-layout body.-emu ul.command-menu li {
-    font-size: var(--emu-font-size-xl);
-    -webkit-margin-after: var(--emu-space-sm);
-            margin-block-end: var(--emu-space-sm); }
-  .-emu-layout body.-emu ul.command-menu li:last-child {
-    -webkit-margin-after: 0;
-            margin-block-end: 0; }
-  body.-emu ul.command-menu li h2 {
-    color: inherit; }
-    .-emu-layout body.-emu ul.command-menu li h2 {
-      flex: initial;
-      font-size: inherit;
-      line-height: 1;
-      padding: 0; }
+  box-shadow: 0 2px 4px rgba(var(--color-black), 1);
+}
+.-emu-layout body.-emu ul.command-menu {
+  display: flex;
+  flex-direction: column;
+  padding: var(--emu-space-sm);
+  z-index: 1070;
+}
+.-emu-layout body.-emu ul.command-menu li {
+  font-size: var(--emu-font-size-xl);
+  -webkit-margin-after: var(--emu-space-sm);
+  margin-block-end: var(--emu-space-sm);
+}
+.-emu-layout body.-emu ul.command-menu li:last-child {
+  -webkit-margin-after: 0;
+  margin-block-end: 0;
+}
+body.-emu ul.command-menu li h2 {
+  color: inherit;
+}
+.-emu-layout body.-emu ul.command-menu li h2 {
+  flex: initial;
+  font-size: inherit;
+  line-height: 1;
+  padding: 0;
+}
 
 body.-emu .window-app .window-draggable-handle {
   background-color: rgba(var(--color-background-button), 1);
   border: none;
   -webkit-border-before: rgba(var(--color-background-lightest), 1) 2px solid;
-          border-block-start: rgba(var(--color-background-lightest), 1) 2px solid;
+  border-block-start: rgba(var(--color-background-lightest), 1) 2px solid;
   -webkit-border-end: rgba(var(--color-background-lightest), 1) 2px solid;
-          border-inline-end: rgba(var(--color-background-lightest), 1) 2px solid;
+  border-inline-end: rgba(var(--color-background-lightest), 1) 2px solid;
   border-radius: 0 var(--emu-border-radius-default, 0) 0 0;
   color: rgba(var(--color-text-lightest), 1);
-  transition: background 0.3s cubic-bezier(0.075, 0.82, 0.165, 1), box-shadow 0.3s cubic-bezier(0.075, 0.82, 0.165, 1), color 0.3s cubic-bezier(0.075, 0.82, 0.165, 1); }
-  .-emu-layout body.-emu .window-app .window-draggable-handle {
-    bottom: 0;
-    left: 0;
-    position: absolute;
-    width: var(--emu-space-button-xs);
-    height: var(--emu-space-button-xs);
-    align-items: center;
-    cursor: pointer;
-    display: inline-flex;
-    font-size: var(--emu-font-size-md);
-    justify-content: center;
-    margin: 0;
-    padding: 0;
-    z-index: 10; }
-    .-emu-layout body.-emu .window-app .window-draggable-handle > i {
-      transform: rotate(45deg); }
+  transition: background 0.3s cubic-bezier(0.075, 0.82, 0.165, 1),
+    box-shadow 0.3s cubic-bezier(0.075, 0.82, 0.165, 1),
+    color 0.3s cubic-bezier(0.075, 0.82, 0.165, 1);
+}
+.-emu-layout body.-emu .window-app .window-draggable-handle {
+  bottom: 0;
+  left: 0;
+  position: absolute;
+  width: var(--emu-space-button-xs);
+  height: var(--emu-space-button-xs);
+  align-items: center;
+  cursor: pointer;
+  display: inline-flex;
+  font-size: var(--emu-font-size-md);
+  justify-content: center;
+  margin: 0;
+  padding: 0;
+  z-index: 10;
+}
+.-emu-layout body.-emu .window-app .window-draggable-handle > i {
+  transform: rotate(45deg);
+}
 
-.-emu-layout body.-emu .simple-calendar-configuration.window-app #simpleCalendarConfiguration .config-save {
+.-emu-layout
+  body.-emu
+  .simple-calendar-configuration.window-app
+  #simpleCalendarConfiguration
+  .config-save {
   position: -webkit-sticky;
-  position: sticky; }
+  position: sticky;
+}
 
 body.-emu .simple-dice-roller-popup {
   background-color: rgba(var(--color-background), 1);
@@ -7272,115 +18503,143 @@ body.-emu .simple-dice-roller-popup {
   border: rgba(var(--color-border), 1) 1px solid;
   border-radius: var(--emu-border-radius-default, 0);
   box-shadow: none;
-  color: rgba(var(--color-text-lightest), 1); }
-  .-emu-layout body.-emu .simple-dice-roller-popup {
-    line-height: initial;
-    margin: 0;
-    pointer-events: all; }
-  body.-emu .simple-dice-roller-popup ul {
-    -webkit-border-after: rgba(var(--color-border), 1) 1px solid;
-            border-block-end: rgba(var(--color-border), 1) 1px solid; }
-  body.-emu .simple-dice-roller-popup li {
-    border: none;
-    -webkit-border-end: rgba(var(--color-border), 1) 1px solid;
-            border-inline-end: rgba(var(--color-border), 1) 1px solid; }
-    .-emu-layout body.-emu .simple-dice-roller-popup li {
-      width: 3rem;
-      height: 3rem;
-      align-items: center;
-      display: inline-flex;
-      height: auto;
-      justify-content: center; }
-    .-emu-layout body.-emu .simple-dice-roller-popup li:first-child {
-      width: 7rem; }
-    body.-emu .simple-dice-roller-popup li:last-child {
-      -webkit-border-end: none;
-              border-inline-end: none; }
-    body.-emu .simple-dice-roller-popup li > i {
-      -webkit-margin-end: var(--emu-space-base);
-              margin-inline-end: var(--emu-space-base); }
+  color: rgba(var(--color-text-lightest), 1);
+}
+.-emu-layout body.-emu .simple-dice-roller-popup {
+  line-height: initial;
+  margin: 0;
+  pointer-events: all;
+}
+body.-emu .simple-dice-roller-popup ul {
+  -webkit-border-after: rgba(var(--color-border), 1) 1px solid;
+  border-block-end: rgba(var(--color-border), 1) 1px solid;
+}
+body.-emu .simple-dice-roller-popup li {
+  border: none;
+  -webkit-border-end: rgba(var(--color-border), 1) 1px solid;
+  border-inline-end: rgba(var(--color-border), 1) 1px solid;
+}
+.-emu-layout body.-emu .simple-dice-roller-popup li {
+  width: 3rem;
+  height: 3rem;
+  align-items: center;
+  display: inline-flex;
+  height: auto;
+  justify-content: center;
+}
+.-emu-layout body.-emu .simple-dice-roller-popup li:first-child {
+  width: 7rem;
+}
+body.-emu .simple-dice-roller-popup li:last-child {
+  -webkit-border-end: none;
+  border-inline-end: none;
+}
+body.-emu .simple-dice-roller-popup li > i {
+  -webkit-margin-end: var(--emu-space-base);
+  margin-inline-end: var(--emu-space-base);
+}
 
 body.-emu #smalltime-app {
-  box-shadow: none; }
-  .-emu-layout body.-emu #smalltime-app {
-    height: auto;
-    -webkit-margin-start: -0.375rem;
-            margin-inline-start: -0.375rem; }
-  .-emu-layout body.-emu #smalltime-app .window-header {
-    display: none; }
-  body.-emu #smalltime-app .window-content {
-    background-color: rgba(var(--color-background-darkest), 1);
-    background-image: var(--emu-image-background-darkest, none);
-    border-radius: 0; }
-    .-emu-layout body.-emu #smalltime-app .window-content {
-      height: 100%;
-      overflow: visible; }
-  .-emu-layout body.-emu #smalltime-app #slideContainer {
-    flex: 0 0 auto;
-    position: relative; }
-  body.-emu #smalltime-app #displayContainer {
-    align-items: center;
-    background-color: transparent;
-    -webkit-border-before: rgba(var(--color-border), 1) 1px solid;
-            border-block-start: rgba(var(--color-border), 1) 1px solid;
-    box-shadow: none; }
-    .-emu-layout body.-emu #smalltime-app #displayContainer {
-      height: auto;
-      padding: 0 var(--emu-space-base);
-      position: relative;
-      top: auto; }
-    .-emu-layout body.-emu #smalltime-app #displayContainer .arrow {
-      width: 1.25rem;
-      height: 1.25rem;
-      font-family: "Font Awesome 5 Free";
-      margin: var(--emu-space-xs) 0; }
-  body.-emu #smalltime-app #dateDisplay {
-    background-color: transparent;
-    box-shadow: none;
-    color: rgba(var(--color-text-lightest), 1); }
-    .-emu-layout body.-emu #smalltime-app #dateDisplay {
-      display: none;
-      font-size: var(--emu-font-size-md);
-      justify-content: center;
-      padding: var(--emu-space-base);
-      position: relative;
-      text-shadow: none;
-      transform: initial;
-      transition: none;
-      top: auto; }
-      .-emu-layout body.-emu #smalltime-app #dateDisplay.active {
-        display: flex; }
-  body.-emu #smalltime-app #timeDisplay {
-    color: rgba(var(--color-text-lightest), 1);
-    text-shadow: none; }
-    .-emu-layout body.-emu #smalltime-app #timeDisplay {
-      align-items: center;
-      display: inline-flex;
-      font-size: var(--emu-font-size-md);
-      justify-content: center;
-      padding: 0; }
-  .-emu-layout body.-emu #smalltime-app #timeSeparator {
-    margin: 0;
-    top: auto; }
-  body.-emu #smalltime-app #dragHandle {
-    background: transparent; }
-    .-emu-layout body.-emu #smalltime-app #dragHandle {
-      bottom: calc(-1 * var(--emu-space-md));
-      left: calc(-1 * var(--emu-space-md));
-      right: calc(-1 * var(--emu-space-md));
-      top: calc(-1 * var(--emu-space-md));
-      position: absolute;
-      z-index: -1; }
-  body.-emu #smalltime-app .window-draggable-handle {
-    display: none; }
+  box-shadow: none;
+}
+.-emu-layout body.-emu #smalltime-app {
+  height: auto;
+  -webkit-margin-start: -0.375rem;
+  margin-inline-start: -0.375rem;
+}
+.-emu-layout body.-emu #smalltime-app .window-header {
+  display: none;
+}
+body.-emu #smalltime-app .window-content {
+  background-color: rgba(var(--color-background-darkest), 1);
+  background-image: var(--emu-image-background-darkest, none);
+  border-radius: 0;
+}
+.-emu-layout body.-emu #smalltime-app .window-content {
+  height: 100%;
+  overflow: visible;
+}
+.-emu-layout body.-emu #smalltime-app #slideContainer {
+  flex: 0 0 auto;
+  position: relative;
+}
+body.-emu #smalltime-app #displayContainer {
+  align-items: center;
+  background-color: transparent;
+  -webkit-border-before: rgba(var(--color-border), 1) 1px solid;
+  border-block-start: rgba(var(--color-border), 1) 1px solid;
+  box-shadow: none;
+}
+.-emu-layout body.-emu #smalltime-app #displayContainer {
+  height: auto;
+  padding: 0 var(--emu-space-base);
+  position: relative;
+  top: auto;
+}
+.-emu-layout body.-emu #smalltime-app #displayContainer .arrow {
+  width: 1.25rem;
+  height: 1.25rem;
+  font-family: "Font Awesome 5 Free";
+  margin: var(--emu-space-xs) 0;
+}
+body.-emu #smalltime-app #dateDisplay {
+  background-color: transparent;
+  box-shadow: none;
+  color: rgba(var(--color-text-lightest), 1);
+}
+.-emu-layout body.-emu #smalltime-app #dateDisplay {
+  display: none;
+  font-size: var(--emu-font-size-md);
+  justify-content: center;
+  padding: var(--emu-space-base);
+  position: relative;
+  text-shadow: none;
+  transform: initial;
+  transition: none;
+  top: auto;
+}
+.-emu-layout body.-emu #smalltime-app #dateDisplay.active {
+  display: flex;
+}
+body.-emu #smalltime-app #timeDisplay {
+  color: rgba(var(--color-text-lightest), 1);
+  text-shadow: none;
+}
+.-emu-layout body.-emu #smalltime-app #timeDisplay {
+  align-items: center;
+  display: inline-flex;
+  font-size: var(--emu-font-size-md);
+  justify-content: center;
+  padding: 0;
+}
+.-emu-layout body.-emu #smalltime-app #timeSeparator {
+  margin: 0;
+  top: auto;
+}
+body.-emu #smalltime-app #dragHandle {
+  background: transparent;
+}
+.-emu-layout body.-emu #smalltime-app #dragHandle {
+  bottom: calc(-1 * var(--emu-space-md));
+  left: calc(-1 * var(--emu-space-md));
+  right: calc(-1 * var(--emu-space-md));
+  top: calc(-1 * var(--emu-space-md));
+  position: absolute;
+  z-index: -1;
+}
+body.-emu #smalltime-app .window-draggable-handle {
+  display: none;
+}
 
 body.-emu #sidebar #chat .tabbedchatlog,
 body.-emu .sidebar-popout #chat .tabbedchatlog {
   border-radius: none;
-  box-shadow: none; }
-  body.-emu #sidebar #chat .tabbedchatlog a,
-  body.-emu .sidebar-popout #chat .tabbedchatlog a {
-    color: rgba(var(--color-text-lightest), 1); }
+  box-shadow: none;
+}
+body.-emu #sidebar #chat .tabbedchatlog a,
+body.-emu .sidebar-popout #chat .tabbedchatlog a {
+  color: rgba(var(--color-text-lightest), 1);
+}
 
 body.-emu #sidebar #chat #icNotification,
 body.-emu #sidebar #chat #rollsNotification,
@@ -7389,25 +18648,28 @@ body.-emu .sidebar-popout #chat #icNotification,
 body.-emu .sidebar-popout #chat #rollsNotification,
 body.-emu .sidebar-popout #chat #oocNotification {
   color: rgba(var(--color-text-lightest), 1);
-  text-shadow: none; }
-  .-emu-layout body.-emu #sidebar #chat #icNotification, .-emu-layout
-  body.-emu #sidebar #chat #rollsNotification, .-emu-layout
-  body.-emu #sidebar #chat #oocNotification, .-emu-layout
-  body.-emu .sidebar-popout #chat #icNotification, .-emu-layout
-  body.-emu .sidebar-popout #chat #rollsNotification, .-emu-layout
-  body.-emu .sidebar-popout #chat #oocNotification {
-    -webkit-margin-before: var(--emu-space-xs);
-            margin-block-start: var(--emu-space-xs);
-    -webkit-margin-end: var(--emu-space-xs);
-            margin-inline-end: var(--emu-space-xs);
-    padding: var(--emu-space-xs);
-    right: 0;
-    top: 0; }
+  text-shadow: none;
+}
+.-emu-layout body.-emu #sidebar #chat #icNotification,
+.-emu-layout body.-emu #sidebar #chat #rollsNotification,
+.-emu-layout body.-emu #sidebar #chat #oocNotification,
+.-emu-layout body.-emu .sidebar-popout #chat #icNotification,
+.-emu-layout body.-emu .sidebar-popout #chat #rollsNotification,
+.-emu-layout body.-emu .sidebar-popout #chat #oocNotification {
+  -webkit-margin-before: var(--emu-space-xs);
+  margin-block-start: var(--emu-space-xs);
+  -webkit-margin-end: var(--emu-space-xs);
+  margin-inline-end: var(--emu-space-xs);
+  padding: var(--emu-space-xs);
+  right: 0;
+  top: 0;
+}
 
 .-emu-layout body.-emu [data-tool="thandulTogglables"] i {
   width: 70%;
   height: 70%;
-  filter: initial; }
+  filter: initial;
+}
 
 body.-emu .thandulTogglables {
   background-color: rgba(var(--color-background), 1);
@@ -7415,459 +18677,813 @@ body.-emu .thandulTogglables {
   border: rgba(var(--color-border), 1) 1px solid;
   border-radius: 2px;
   box-shadow: none;
-  color: rgba(var(--color-text-lightest), 1); }
-  .-emu-layout body.-emu .thandulTogglables {
-    left: 3rem;
-    position: absolute;
-    display: none;
-    padding: var(--emu-space-base);
-    top: 0 !important; }
-  .-emu-layout body.-emu .thandulTogglables ul {
-    width: 100%;
-    height: 100%;
-    display: flex;
-    min-width: 25rem;
-    padding: 0; }
-  .-emu-layout body.-emu .thandulTogglables li {
-    width: 25%;
-    height: 100%;
-    border: none;
-    display: flex;
-    justify-content: center;
-    padding: var(--emu-space-sm); }
-  body.-emu .thandulTogglables li:hover {
-    background-color: rgba(var(--color-primary), 1);
-    box-shadow: none; }
-  body.-emu .thandulTogglables li img {
-    border: rgba(var(--color-border), 1) 1px solid;
-    border-radius: 0; }
-    .-emu-layout body.-emu .thandulTogglables li img {
-      margin: 0;
-      max-width: 3.5rem; }
-  .-emu-layout body.-emu .thandulTogglables li p {
-    margin: 0;
-    -webkit-margin-before: var(--emu-space-sm);
-            margin-block-start: var(--emu-space-sm); }
+  color: rgba(var(--color-text-lightest), 1);
+}
+.-emu-layout body.-emu .thandulTogglables {
+  left: 3rem;
+  position: absolute;
+  display: none;
+  padding: var(--emu-space-base);
+  top: 0 !important;
+}
+.-emu-layout body.-emu .thandulTogglables ul {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  min-width: 25rem;
+  padding: 0;
+}
+.-emu-layout body.-emu .thandulTogglables li {
+  width: 25%;
+  height: 100%;
+  border: none;
+  display: flex;
+  justify-content: center;
+  padding: var(--emu-space-sm);
+}
+body.-emu .thandulTogglables li:hover {
+  background-color: rgba(var(--color-primary), 1);
+  box-shadow: none;
+}
+body.-emu .thandulTogglables li img {
+  border: rgba(var(--color-border), 1) 1px solid;
+  border-radius: 0;
+}
+.-emu-layout body.-emu .thandulTogglables li img {
+  margin: 0;
+  max-width: 3.5rem;
+}
+.-emu-layout body.-emu .thandulTogglables li p {
+  margin: 0;
+  -webkit-margin-before: var(--emu-space-sm);
+  margin-block-start: var(--emu-space-sm);
+}
 
-.-emu-layout body.-emu #controls li.active[data-tool="thandulTogglables"] div.thandulTogglables {
-  display: grid; }
+.-emu-layout
+  body.-emu
+  #controls
+  li.active[data-tool="thandulTogglables"]
+  div.thandulTogglables {
+  display: grid;
+}
 
 body.-emu #sidebar #playlists li.sound.sound-is-playing,
 body.-emu .sidebar-popout #playlists li.sound.sound-is-playing {
-  background: transparent; }
+  background: transparent;
+}
 
-.-emu-layout body.-emu form .furnace-macro-run-as-gm.form-group label.form-group {
+.-emu-layout
+  body.-emu
+  form
+  .furnace-macro-run-as-gm.form-group
+  label.form-group {
   flex: 1 1 auto;
   margin: 0;
-  padding: 0; }
+  padding: 0;
+}
 
 body.-emu form .furnace-macro-run-as-gm.form-group .tooltip {
   background-color: rgba(var(--color-background-darkest), 0.8);
   background-image: var(--emu-image-background-darkest, none);
   border-radius: var(--emu-border-radius-default, 0);
   border: none;
-  color: rgba(var(--color-text-lightest), 1); }
-  .-emu-layout body.-emu form .furnace-macro-run-as-gm.form-group .tooltip {
-    bottom: 100% !important;
-    height: auto;
-    left: auto;
-    max-width: 100%;
-    padding: var(--emu-space-base);
-    pointer-events: none;
-    right: 0 !important;
-    top: auto;
-    white-space: initial;
-    word-break: break-word; }
+  color: rgba(var(--color-text-lightest), 1);
+}
+.-emu-layout body.-emu form .furnace-macro-run-as-gm.form-group .tooltip {
+  bottom: 100% !important;
+  height: auto;
+  left: auto;
+  max-width: 100%;
+  padding: var(--emu-space-base);
+  pointer-events: none;
+  right: 0 !important;
+  top: auto;
+  white-space: initial;
+  word-break: break-word;
+}
 
-body.-emu form .furnace-macro-run-as-gm.form-group + .form-group.stacked.command {
-  padding: var(--emu-space-sm); }
+body.-emu
+  form
+  .furnace-macro-run-as-gm.form-group
+  + .form-group.stacked.command {
+  padding: var(--emu-space-sm);
+}
 
-body.-emu .sheet.macro-sheet[id*="macro-config-"] form .form-group.furnace-macro-command {
+body.-emu
+  .sheet.macro-sheet[id*="macro-config-"]
+  form
+  .form-group.furnace-macro-command {
   border: rgba(var(--color-border), 1) 1px solid;
   border-radius: 0;
-  color: rgba(var(--color-text), 1); }
-  .-emu-layout body.-emu .sheet.macro-sheet[id*="macro-config-"] form .form-group.furnace-macro-command {
-    padding: 0; }
-  .-emu-layout body.-emu .sheet.macro-sheet[id*="macro-config-"] form .form-group.furnace-macro-command.fullscreen {
-    width: 80vw;
-    height: 80vh;
-    background: transparent;
-    -webkit-margin-before: 10vh;
-            margin-block-start: 10vh;
-    -webkit-margin-start: 10vh;
-            margin-inline-start: 10vh;
-    z-index: 10000; }
-  .-emu-layout body.-emu .sheet.macro-sheet[id*="macro-config-"] form .form-group.furnace-macro-command.fullscreen::before {
-    top: -10vh;
-    left: -10vw;
-    position: fixed;
-    width: 110vw;
-    height: 110vh;
-    background-color: rgba(var(--color-background-darkest), 0.8);
-    content: "";
-    z-index: 1; }
-  .-emu-layout body.-emu .sheet.macro-sheet[id*="macro-config-"] form .form-group.furnace-macro-command.fullscreen textarea {
-    height: 100%;
-    z-index: 10; }
-  body.-emu .sheet.macro-sheet[id*="macro-config-"] form .form-group.furnace-macro-command.fullscreen pre {
-    background-color: rgba(var(--color-background-lightest), 1);
-    background-image: var(--emu-image-background-lightest, none); }
-  .-emu-layout body.-emu .sheet.macro-sheet[id*="macro-config-"] form .form-group.furnace-macro-command.fullscreen .furnace-macro-expand {
-    z-index: 11; }
-  body.-emu .sheet.macro-sheet[id*="macro-config-"] form .form-group.furnace-macro-command textarea {
-    border: none;
-    text-shadow: none; }
-    .-emu-layout body.-emu .sheet.macro-sheet[id*="macro-config-"] form .form-group.furnace-macro-command textarea {
-      font-size: 0.875rem;
-      font-family: Consolas,Liberation Mono,Courier,monospace;
-      height: 100%;
-      padding: 0.3125rem; }
-    body.-emu .sheet.macro-sheet[id*="macro-config-"] form .form-group.furnace-macro-command textarea::-moz-selection {
-      background-color: rgba(var(--color-primary), 0.2); }
-    body.-emu .sheet.macro-sheet[id*="macro-config-"] form .form-group.furnace-macro-command textarea::selection {
-      background-color: rgba(var(--color-primary), 0.2); }
+  color: rgba(var(--color-text), 1);
+}
+.-emu-layout
+  body.-emu
+  .sheet.macro-sheet[id*="macro-config-"]
+  form
+  .form-group.furnace-macro-command {
+  padding: 0;
+}
+.-emu-layout
+  body.-emu
+  .sheet.macro-sheet[id*="macro-config-"]
+  form
+  .form-group.furnace-macro-command.fullscreen {
+  width: 80vw;
+  height: 80vh;
+  background: transparent;
+  -webkit-margin-before: 10vh;
+  margin-block-start: 10vh;
+  -webkit-margin-start: 10vh;
+  margin-inline-start: 10vh;
+  z-index: 10000;
+}
+.-emu-layout
+  body.-emu
+  .sheet.macro-sheet[id*="macro-config-"]
+  form
+  .form-group.furnace-macro-command.fullscreen::before {
+  top: -10vh;
+  left: -10vw;
+  position: fixed;
+  width: 110vw;
+  height: 110vh;
+  background-color: rgba(var(--color-background-darkest), 0.8);
+  content: "";
+  z-index: 1;
+}
+.-emu-layout
+  body.-emu
+  .sheet.macro-sheet[id*="macro-config-"]
+  form
+  .form-group.furnace-macro-command.fullscreen
+  textarea {
+  height: 100%;
+  z-index: 10;
+}
+body.-emu
+  .sheet.macro-sheet[id*="macro-config-"]
+  form
+  .form-group.furnace-macro-command.fullscreen
+  pre {
+  background-color: rgba(var(--color-background-lightest), 1);
+  background-image: var(--emu-image-background-lightest, none);
+}
+.-emu-layout
+  body.-emu
+  .sheet.macro-sheet[id*="macro-config-"]
+  form
+  .form-group.furnace-macro-command.fullscreen
+  .furnace-macro-expand {
+  z-index: 11;
+}
+body.-emu
+  .sheet.macro-sheet[id*="macro-config-"]
+  form
+  .form-group.furnace-macro-command
+  textarea {
+  border: none;
+  text-shadow: none;
+}
+.-emu-layout
+  body.-emu
+  .sheet.macro-sheet[id*="macro-config-"]
+  form
+  .form-group.furnace-macro-command
+  textarea {
+  font-size: 0.875rem;
+  font-family: Consolas, Liberation Mono, Courier, monospace;
+  height: 100%;
+  padding: 0.3125rem;
+}
+body.-emu
+  .sheet.macro-sheet[id*="macro-config-"]
+  form
+  .form-group.furnace-macro-command
+  textarea::-moz-selection {
+  background-color: rgba(var(--color-primary), 0.2);
+}
+body.-emu
+  .sheet.macro-sheet[id*="macro-config-"]
+  form
+  .form-group.furnace-macro-command
+  textarea::selection {
+  background-color: rgba(var(--color-primary), 0.2);
+}
 
-.-emu-layout body.-emu .sheet.macro-sheet[id*="macro-config-"] .furnace-macro-expand {
-  position: absolute; }
+.-emu-layout
+  body.-emu
+  .sheet.macro-sheet[id*="macro-config-"]
+  .furnace-macro-expand {
+  position: absolute;
+}
 
-.-emu-layout body.-emu .sheet.macro-sheet[id*="macro-config-"] .sheet-footer, .-emu-layout
-body.-emu .sheet.macro-sheet[id*="macro-config-"] .window-resizable-handle {
-  z-index: 11; }
+.-emu-layout body.-emu .sheet.macro-sheet[id*="macro-config-"] .sheet-footer,
+.-emu-layout
+  body.-emu
+  .sheet.macro-sheet[id*="macro-config-"]
+  .window-resizable-handle {
+  z-index: 11;
+}
 
 body.-emu .theatre-emote-menu {
   background-color: rgba(var(--color-background), 1);
-  color: rgba(var(--color-text), 1); }
+  color: rgba(var(--color-text), 1);
+}
 
 body.-emu .tidy5e.settings.window-app {
   background-color: rgba(var(--color-background-lightest), 1);
   background-image: var(--emu-image-background-light, none);
   border: rgba(var(--color-border), 1) 1px solid;
   border-radius: var(--emu-border-radius-default, 0);
-  box-shadow: 0 2px 4px rgba(var(--color-black), 1); }
-  .-emu-layout body.-emu .tidy5e.settings.window-app .window-content {
-    padding: var(--emu-space-sm); }
-  .-emu-layout body.-emu .tidy5e.settings.window-app .sheet-tabs {
-    padding: 0; }
-  .-emu-layout body.-emu .tidy5e.settings.window-app section.tab {
-    -webkit-margin-before: var(--emu-space-base);
-            margin-block-start: var(--emu-space-base); }
-  body.-emu .tidy5e.settings.window-app .setting {
-    background-color: transparent;
-    border-radius: 0; }
-    .-emu-layout body.-emu .tidy5e.settings.window-app .setting {
-      margin: 0;
-      padding: var(--emu-space-sm); }
-    body.-emu .tidy5e.settings.window-app .setting:nth-of-type(even) {
-      background-color: rgba(var(--color-background-light), 0.1); }
-    .-emu-layout body.-emu .tidy5e.settings.window-app .setting + h3 {
-      -webkit-margin-before: var(--emu-space-sm);
-              margin-block-start: var(--emu-space-sm); }
-    .-emu-layout body.-emu .tidy5e.settings.window-app .setting .description {
-      -webkit-margin-start: var(--emu-space-sm);
-              margin-inline-start: var(--emu-space-sm); }
+  box-shadow: 0 2px 4px rgba(var(--color-black), 1);
+}
+.-emu-layout body.-emu .tidy5e.settings.window-app .window-content {
+  padding: var(--emu-space-sm);
+}
+.-emu-layout body.-emu .tidy5e.settings.window-app .sheet-tabs {
+  padding: 0;
+}
+.-emu-layout body.-emu .tidy5e.settings.window-app section.tab {
+  -webkit-margin-before: var(--emu-space-base);
+  margin-block-start: var(--emu-space-base);
+}
+body.-emu .tidy5e.settings.window-app .setting {
+  background-color: transparent;
+  border-radius: 0;
+}
+.-emu-layout body.-emu .tidy5e.settings.window-app .setting {
+  margin: 0;
+  padding: var(--emu-space-sm);
+}
+body.-emu .tidy5e.settings.window-app .setting:nth-of-type(even) {
+  background-color: rgba(var(--color-background-light), 0.1);
+}
+.-emu-layout body.-emu .tidy5e.settings.window-app .setting + h3 {
+  -webkit-margin-before: var(--emu-space-sm);
+  margin-block-start: var(--emu-space-sm);
+}
+.-emu-layout body.-emu .tidy5e.settings.window-app .setting .description {
+  -webkit-margin-start: var(--emu-space-sm);
+  margin-inline-start: var(--emu-space-sm);
+}
 
 body.-emu .tidy5e.sheet.actor.npc .spellcasting-ability {
   background-color: rgba(var(--color-background-lightest), 1);
-  background-image: var(--emu-image-background-lightest, none); }
+  background-image: var(--emu-image-background-lightest, none);
+}
 
 .-emu-layout body.-emu .tidy5e.sheet.actor .window-content {
   padding: 0;
-  position: initial; }
+  position: initial;
+}
 
 body.-emu .tidy5e.sheet.actor #item-info-container {
-  background-color: rgba(var(--color-background-lightest), var(--emu-background-opacity-window-content, 1));
+  background-color: rgba(
+    var(--color-background-lightest),
+    var(--emu-background-opacity-window-content, 1)
+  );
   background-image: var(--emu-image-background-lightest, none);
-  border-radius: var(--emu-border-radius-default, 0) 0 0 var(--emu-border-radius-default, 0);
+  border-radius: var(--emu-border-radius-default, 0) 0 0
+    var(--emu-border-radius-default, 0);
   border: rgba(var(--color-border), 1) 1px solid;
   -webkit-border-end: 0;
-          border-inline-end: 0;
+  border-inline-end: 0;
   box-shadow: 0 2px 4px rgba(var(--color-black), 1);
-  color: rgba(var(--color-text), 1); }
-  .-emu-layout body.-emu .tidy5e.sheet.actor #item-info-container {
-    transition: width 0.3s cubic-bezier(0.77, 0, 0.175, 1);
-    transition-delay: 0s; }
-  body.-emu .tidy5e.sheet.actor #item-info-container .info-wrap {
-    -webkit-border-end: rgba(var(--color-border-lighter), 1) 1px solid;
-            border-inline-end: rgba(var(--color-border-lighter), 1) 1px solid; }
-  body.-emu .tidy5e.sheet.actor #item-info-container .info-card {
-    border-radius: 0; }
-    .-emu-layout body.-emu .tidy5e.sheet.actor #item-info-container .info-card {
-      padding: var(--emu-space-sm); }
+  color: rgba(var(--color-text), 1);
+}
+.-emu-layout body.-emu .tidy5e.sheet.actor #item-info-container {
+  transition: width 0.3s cubic-bezier(0.77, 0, 0.175, 1);
+  transition-delay: 0s;
+}
+body.-emu .tidy5e.sheet.actor #item-info-container .info-wrap {
+  -webkit-border-end: rgba(var(--color-border-lighter), 1) 1px solid;
+  border-inline-end: rgba(var(--color-border-lighter), 1) 1px solid;
+}
+body.-emu .tidy5e.sheet.actor #item-info-container .info-card {
+  border-radius: 0;
+}
+.-emu-layout body.-emu .tidy5e.sheet.actor #item-info-container .info-card {
+  padding: var(--emu-space-sm);
+}
 
-body.-emu #client-settings.window-app.form .window-content #config-tabs .module-settings-wrapper div.form-group {
-  color: rgba(var(--color-text), 1); }
-  .-emu-layout body.-emu #client-settings.window-app.form .window-content #config-tabs .module-settings-wrapper div.form-group {
-    align-items: center !important;
-    display: flex;
-    flex-direction: row;
-    flex-wrap: wrap;
-    font-size: var(--emu-font-size-lg);
-    justify-content: space-between !important;
-    margin: 0;
-    padding: var(--emu-space-sm);
-    transition: none; }
-    .-emu-layout body.-emu #client-settings.window-app.form .window-content #config-tabs .module-settings-wrapper div.form-group:nth-of-type(even) {
-      background-color: rgba(var(--color-background-light), 0.1); }
-  .-emu-layout body.-emu #client-settings.window-app.form .window-content #config-tabs .module-settings-wrapper div.form-group.submenu > .notes {
-    -webkit-margin-before: var(--emu-space-sm);
-            margin-block-start: var(--emu-space-sm); }
-  .-emu-layout body.-emu #client-settings.window-app.form .window-content #config-tabs .module-settings-wrapper div.form-group.submenu > button[type="button"] {
-    margin: 0; }
-  .-emu-layout body.-emu #client-settings.window-app.form .window-content #config-tabs .module-settings-wrapper div.form-group .form-fields {
-    justify-content: flex-end;
-    margin: 0; }
-    .-emu-layout body.-emu #client-settings.window-app.form .window-content #config-tabs .module-settings-wrapper div.form-group .form-fields + .notes {
-      -webkit-margin-before: var(--emu-space-sm);
-              margin-block-start: var(--emu-space-sm); }
-    .-emu-layout body.-emu #client-settings.window-app.form .window-content #config-tabs .module-settings-wrapper div.form-group .form-fields select {
-      flex: 1 1 auto; }
-  .-emu-layout body.-emu #client-settings.window-app.form .window-content #config-tabs .module-settings-wrapper div.form-group input[type="checkbox"] {
-    -webkit-appearance: auto;
-       -moz-appearance: auto;
-            appearance: auto;
-    left: auto; }
-    .-emu-layout body.-emu #client-settings.window-app.form .window-content #config-tabs .module-settings-wrapper div.form-group input[type="checkbox"]::after {
-      display: none; }
-  .-emu-layout body.-emu #client-settings.window-app.form .window-content #config-tabs .module-settings-wrapper div.form-group label {
-    align-items: center;
-    display: inline-flex;
-    font-size: var(--emu-font-size-md);
-    line-height: initial;
-    margin: 0;
-    order: initial;
-    -webkit-padding-end: var(--emu-space-base);
-            padding-inline-end: var(--emu-space-base); }
-  .-emu-layout body.-emu #client-settings.window-app.form .window-content #config-tabs .module-settings-wrapper div.form-group > label {
-    flex: 0 0 40% !important; }
-  .-emu-layout body.-emu #client-settings.window-app.form .window-content #config-tabs .module-settings-wrapper div.form-group > button {
-    flex: 1 1 auto !important;
-    margin: 0;
-    width: auto; }
-    .-emu-layout body.-emu #client-settings.window-app.form .window-content #config-tabs .module-settings-wrapper div.form-group > button > label {
-      justify-content: center;
-      padding: 0; }
+body.-emu
+  #client-settings.window-app.form
+  .window-content
+  #config-tabs
+  .module-settings-wrapper
+  div.form-group {
+  color: rgba(var(--color-text), 1);
+}
+.-emu-layout
+  body.-emu
+  #client-settings.window-app.form
+  .window-content
+  #config-tabs
+  .module-settings-wrapper
+  div.form-group {
+  align-items: center !important;
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  font-size: var(--emu-font-size-lg);
+  justify-content: space-between !important;
+  margin: 0;
+  padding: var(--emu-space-sm);
+  transition: none;
+}
+.-emu-layout
+  body.-emu
+  #client-settings.window-app.form
+  .window-content
+  #config-tabs
+  .module-settings-wrapper
+  div.form-group:nth-of-type(even) {
+  background-color: rgba(var(--color-background-light), 0.1);
+}
+.-emu-layout
+  body.-emu
+  #client-settings.window-app.form
+  .window-content
+  #config-tabs
+  .module-settings-wrapper
+  div.form-group.submenu
+  > .notes {
+  -webkit-margin-before: var(--emu-space-sm);
+  margin-block-start: var(--emu-space-sm);
+}
+.-emu-layout
+  body.-emu
+  #client-settings.window-app.form
+  .window-content
+  #config-tabs
+  .module-settings-wrapper
+  div.form-group.submenu
+  > button[type="button"] {
+  margin: 0;
+}
+.-emu-layout
+  body.-emu
+  #client-settings.window-app.form
+  .window-content
+  #config-tabs
+  .module-settings-wrapper
+  div.form-group
+  .form-fields {
+  justify-content: flex-end;
+  margin: 0;
+}
+.-emu-layout
+  body.-emu
+  #client-settings.window-app.form
+  .window-content
+  #config-tabs
+  .module-settings-wrapper
+  div.form-group
+  .form-fields
+  + .notes {
+  -webkit-margin-before: var(--emu-space-sm);
+  margin-block-start: var(--emu-space-sm);
+}
+.-emu-layout
+  body.-emu
+  #client-settings.window-app.form
+  .window-content
+  #config-tabs
+  .module-settings-wrapper
+  div.form-group
+  .form-fields
+  select {
+  flex: 1 1 auto;
+}
+.-emu-layout
+  body.-emu
+  #client-settings.window-app.form
+  .window-content
+  #config-tabs
+  .module-settings-wrapper
+  div.form-group
+  input[type="checkbox"] {
+  -webkit-appearance: auto;
+  -moz-appearance: auto;
+  appearance: auto;
+  left: auto;
+}
+.-emu-layout
+  body.-emu
+  #client-settings.window-app.form
+  .window-content
+  #config-tabs
+  .module-settings-wrapper
+  div.form-group
+  input[type="checkbox"]::after {
+  display: none;
+}
+.-emu-layout
+  body.-emu
+  #client-settings.window-app.form
+  .window-content
+  #config-tabs
+  .module-settings-wrapper
+  div.form-group
+  label {
+  align-items: center;
+  display: inline-flex;
+  font-size: var(--emu-font-size-md);
+  line-height: initial;
+  margin: 0;
+  order: initial;
+  -webkit-padding-end: var(--emu-space-base);
+  padding-inline-end: var(--emu-space-base);
+}
+.-emu-layout
+  body.-emu
+  #client-settings.window-app.form
+  .window-content
+  #config-tabs
+  .module-settings-wrapper
+  div.form-group
+  > label {
+  flex: 0 0 40% !important;
+}
+.-emu-layout
+  body.-emu
+  #client-settings.window-app.form
+  .window-content
+  #config-tabs
+  .module-settings-wrapper
+  div.form-group
+  > button {
+  flex: 1 1 auto !important;
+  margin: 0;
+  width: auto;
+}
+.-emu-layout
+  body.-emu
+  #client-settings.window-app.form
+  .window-content
+  #config-tabs
+  .module-settings-wrapper
+  div.form-group
+  > button
+  > label {
+  justify-content: center;
+  padding: 0;
+}
 
-.-emu-layout body.-emu #client-settings.window-app.form .window-content #config-tabs .module-settings-wrapper .notes {
-  margin: 0; }
+.-emu-layout
+  body.-emu
+  #client-settings.window-app.form
+  .window-content
+  #config-tabs
+  .module-settings-wrapper
+  .notes {
+  margin: 0;
+}
 
-body.-emu #client-settings.window-app.form .window-content #config-tabs div.tab[data-tab="modules"] #searchField {
+body.-emu
+  #client-settings.window-app.form
+  .window-content
+  #config-tabs
+  div.tab[data-tab="modules"]
+  #searchField {
   border: none;
-  border-radius: 0; }
-  .-emu-layout body.-emu #client-settings.window-app.form .window-content #config-tabs div.tab[data-tab="modules"] #searchField {
-    flex: 0 0 auto;
-    height: auto;
-    margin: var(--emu-space-sm); }
+  border-radius: 0;
+}
+.-emu-layout
+  body.-emu
+  #client-settings.window-app.form
+  .window-content
+  #config-tabs
+  div.tab[data-tab="modules"]
+  #searchField {
+  flex: 0 0 auto;
+  height: auto;
+  margin: var(--emu-space-sm);
+}
 
-body.-emu #client-settings.window-app.form .window-content #config-tabs div.tab[data-tab="modules"] .module-wrapper h2.module-header {
+body.-emu
+  #client-settings.window-app.form
+  .window-content
+  #config-tabs
+  div.tab[data-tab="modules"]
+  .module-wrapper
+  h2.module-header {
   -webkit-border-after: rgba(var(--color-border), 1) 1px solid;
-          border-block-end: rgba(var(--color-border), 1) 1px solid; }
-  .-emu-layout body.-emu #client-settings.window-app.form .window-content #config-tabs div.tab[data-tab="modules"] .module-wrapper h2.module-header {
-    align-items: center;
-    display: flex;
-    font-size: var(--emu-font-size-lg);
-    font-weight: normal;
-    margin: 0;
-    padding: var(--emu-space-sm); }
-  body.-emu #client-settings.window-app.form .window-content #config-tabs div.tab[data-tab="modules"] .module-wrapper h2.module-header:hover {
-    background-color: rgba(var(--color-primary), 1);
-    color: rgba(var(--color-text-lightest), 1); }
-  body.-emu #client-settings.window-app.form .window-content #config-tabs div.tab[data-tab="modules"] .module-wrapper h2.module-header > span {
-    color: inherit; }
-    .-emu-layout body.-emu #client-settings.window-app.form .window-content #config-tabs div.tab[data-tab="modules"] .module-wrapper h2.module-header > span {
-      -webkit-margin-end: var(--emu-space-sm);
-              margin-inline-end: var(--emu-space-sm); }
+  border-block-end: rgba(var(--color-border), 1) 1px solid;
+}
+.-emu-layout
+  body.-emu
+  #client-settings.window-app.form
+  .window-content
+  #config-tabs
+  div.tab[data-tab="modules"]
+  .module-wrapper
+  h2.module-header {
+  align-items: center;
+  display: flex;
+  font-size: var(--emu-font-size-lg);
+  font-weight: normal;
+  margin: 0;
+  padding: var(--emu-space-sm);
+}
+body.-emu
+  #client-settings.window-app.form
+  .window-content
+  #config-tabs
+  div.tab[data-tab="modules"]
+  .module-wrapper
+  h2.module-header:hover {
+  background-color: rgba(var(--color-primary), 1);
+  color: rgba(var(--color-text-lightest), 1);
+}
+body.-emu
+  #client-settings.window-app.form
+  .window-content
+  #config-tabs
+  div.tab[data-tab="modules"]
+  .module-wrapper
+  h2.module-header
+  > span {
+  color: inherit;
+}
+.-emu-layout
+  body.-emu
+  #client-settings.window-app.form
+  .window-content
+  #config-tabs
+  div.tab[data-tab="modules"]
+  .module-wrapper
+  h2.module-header
+  > span {
+  -webkit-margin-end: var(--emu-space-sm);
+  margin-inline-end: var(--emu-space-sm);
+}
 
 .-emu-layout body.-emu #module-management .enhanced-module-management {
   justify-content: center;
   -webkit-margin-after: var(--emu-space-sm);
-          margin-block-end: var(--emu-space-sm); }
+  margin-block-end: var(--emu-space-sm);
+}
 
 .-emu-layout body.-emu #module-management .enhanced-module-management button {
   -webkit-margin-end: 0;
-          margin-inline-end: 0; }
-  .-emu-layout body.-emu #module-management .enhanced-module-management button > i {
-    margin: 0; }
+  margin-inline-end: 0;
+}
+.-emu-layout
+  body.-emu
+  #module-management
+  .enhanced-module-management
+  button
+  > i {
+  margin: 0;
+}
 
-body.-emu #module-management .enhanced-module-management button.disable-all-modules {
+body.-emu
+  #module-management
+  .enhanced-module-management
+  button.disable-all-modules {
   background-color: rgba(var(--color-negative), 1);
-  color: rgba(var(--color-white), 1); }
+  color: rgba(var(--color-white), 1);
+}
 
-body.-emu #module-management .enhanced-module-management button.enable-all-modules {
+body.-emu
+  #module-management
+  .enhanced-module-management
+  button.enable-all-modules {
   background-color: rgba(var(--color-positive), 1);
-  color: rgba(var(--color-white), 1); }
+  color: rgba(var(--color-white), 1);
+}
 
-.-emu-layout body.-emu #module-management .package-title input[type="checkbox"] {
+.-emu-layout
+  body.-emu
+  #module-management
+  .package-title
+  input[type="checkbox"] {
   -webkit-appearance: auto;
-     -moz-appearance: auto;
-          appearance: auto;
+  -moz-appearance: auto;
+  appearance: auto;
   -webkit-margin-end: var(--emu-space-sm);
-          margin-inline-end: var(--emu-space-sm); }
-  .-emu-layout body.-emu #module-management .package-title input[type="checkbox"]::after {
-    display: none; }
+  margin-inline-end: var(--emu-space-sm);
+}
+.-emu-layout
+  body.-emu
+  #module-management
+  .package-title
+  input[type="checkbox"]::after {
+  display: none;
+}
 
 .-emu-layout body.-emu #token-action-hud {
-  margin: 0; }
+  margin: 0;
+}
 
-.-emu-layout body.-emu #token-action-hud:hover #tah-reposition, .-emu-layout
-body.-emu #token-action-hud:hover #tah-categories {
-  visibility: visible; }
+.-emu-layout body.-emu #token-action-hud:hover #tah-reposition,
+.-emu-layout body.-emu #token-action-hud:hover #tah-categories {
+  visibility: visible;
+}
 
 body.-emu #token-action-hud #tah-hudTitle {
   color: rgba(var(--color-text-lightest), 1);
-  text-shadow: 2px 2px 2px rgba(var(--color-black), 1); }
-  .-emu-layout body.-emu #token-action-hud #tah-hudTitle {
-    font-size: var(--emu-font-size-sm);
-    margin: 0;
-    -webkit-margin-start: 1.75rem;
-            margin-inline-start: 1.75rem;
-    padding: 0; }
+  text-shadow: 2px 2px 2px rgba(var(--color-black), 1);
+}
+.-emu-layout body.-emu #token-action-hud #tah-hudTitle {
+  font-size: var(--emu-font-size-sm);
+  margin: 0;
+  -webkit-margin-start: 1.75rem;
+  margin-inline-start: 1.75rem;
+  padding: 0;
+}
 
-.-emu-layout body.-emu #token-action-hud #tah-reposition, .-emu-layout
-body.-emu #token-action-hud #tah-categories {
+.-emu-layout body.-emu #token-action-hud #tah-reposition,
+.-emu-layout body.-emu #token-action-hud #tah-categories {
   left: initial;
   margin: 0;
-  visibility: hidden; }
+  visibility: hidden;
+}
 
 body.-emu #token-action-hud #tah-reposition i,
 body.-emu #token-action-hud #tah-categories i {
   color: inherit;
-  text-shadow: 2px 2px 2px rgba(var(--color-black), 1); }
-  .-emu-layout body.-emu #token-action-hud #tah-reposition i, .-emu-layout
-  body.-emu #token-action-hud #tah-categories i {
-    font-size: var(--emu-font-size-sm);
-    padding: initial;
-    margin: initial;
-    text-align: initial; }
+  text-shadow: 2px 2px 2px rgba(var(--color-black), 1);
+}
+.-emu-layout body.-emu #token-action-hud #tah-reposition i,
+.-emu-layout body.-emu #token-action-hud #tah-categories i {
+  font-size: var(--emu-font-size-sm);
+  padding: initial;
+  margin: initial;
+  text-align: initial;
+}
 
 .-emu-layout body.-emu #token-action-hud #tah-categories {
   -webkit-margin-start: var(--emu-space-base);
-          margin-inline-start: var(--emu-space-base); }
+  margin-inline-start: var(--emu-space-base);
+}
 
-.-emu-layout body.-emu #token-action-hud button.tah-title-button, .-emu-layout
-body.-emu #token-action-hud .tah-action button {
+.-emu-layout body.-emu #token-action-hud button.tah-title-button,
+.-emu-layout body.-emu #token-action-hud .tah-action button {
   -webkit-margin-start: var(--emu-space-base);
-          margin-inline-start: var(--emu-space-base); }
-  .-emu-layout body.-emu #token-action-hud button.tah-title-button > .fa, .-emu-layout
-  body.-emu #token-action-hud .tah-action button > .fa {
-    display: none; }
+  margin-inline-start: var(--emu-space-base);
+}
+.-emu-layout body.-emu #token-action-hud button.tah-title-button > .fa,
+.-emu-layout body.-emu #token-action-hud .tah-action button > .fa {
+  display: none;
+}
 
 body.-emu #token-action-hud .tah-subtitle {
   color: rgba(var(--color-text-lightest), 1);
-  text-shadow: 2px 2px 2px rgba(var(--color-black), 1); }
-  .-emu-layout body.-emu #token-action-hud .tah-subtitle {
-    font-size: var(--emu-font-size-sm);
-    line-height: initial;
-    padding: 0;
-    -webkit-padding-before: var(--emu-space-sm);
-            padding-block-start: var(--emu-space-sm); }
+  text-shadow: 2px 2px 2px rgba(var(--color-black), 1);
+}
+.-emu-layout body.-emu #token-action-hud .tah-subtitle {
+  font-size: var(--emu-font-size-sm);
+  line-height: initial;
+  padding: 0;
+  -webkit-padding-before: var(--emu-space-sm);
+  padding-block-start: var(--emu-space-sm);
+}
 
 .-emu-layout body.-emu #token-action-hud .tah-action {
   margin: 0;
   -webkit-margin-after: var(--emu-space-base);
-          margin-block-end: var(--emu-space-base);
+  margin-block-end: var(--emu-space-base);
   -webkit-margin-start: var(--emu-space-base);
-          margin-inline-start: var(--emu-space-base);
-  padding: 0; }
+  margin-inline-start: var(--emu-space-base);
+  padding: 0;
+}
 
 body.-emu #token-action-hud .tah-action button {
   background-color: rgba(var(--color-background), 1);
-  background-image: var(--emu-image-background-controls, none); }
-  body.-emu #token-action-hud .tah-action button > div {
-    text-shadow: none; }
-    .-emu-layout body.-emu #token-action-hud .tah-action button > div {
-      -webkit-margin-start: var(--emu-space-base);
-              margin-inline-start: var(--emu-space-base); }
-  body.-emu #token-action-hud .tah-action button > .tah-img {
-    border: none; }
-    .-emu-layout body.-emu #token-action-hud .tah-action button > .tah-img {
-      width: 1rem;
-      height: 1rem;
-      border-radius: 0;
-      display: inline-block;
-      margin: 0;
-      -webkit-margin-end: var(--emu-space-sm);
-              margin-inline-end: var(--emu-space-sm);
-      padding: 0; }
+  background-image: var(--emu-image-background-controls, none);
+}
+body.-emu #token-action-hud .tah-action button > div {
+  text-shadow: none;
+}
+.-emu-layout body.-emu #token-action-hud .tah-action button > div {
+  -webkit-margin-start: var(--emu-space-base);
+  margin-inline-start: var(--emu-space-base);
+}
+body.-emu #token-action-hud .tah-action button > .tah-img {
+  border: none;
+}
+.-emu-layout body.-emu #token-action-hud .tah-action button > .tah-img {
+  width: 1rem;
+  height: 1rem;
+  border-radius: 0;
+  display: inline-block;
+  margin: 0;
+  -webkit-margin-end: var(--emu-space-sm);
+  margin-inline-end: var(--emu-space-sm);
+  padding: 0;
+}
 
 .-emu-layout body.-emu #token-action-hud .tah-content {
   left: -9.625rem;
-  padding: var(--emu-space-sm) 0; }
+  padding: var(--emu-space-sm) 0;
+}
 
 .-emu-layout body.-emu .token-action-hud-taginput {
-  margin: var(--emu-space-sm) 0; }
+  margin: var(--emu-space-sm) 0;
+}
 
 .-emu-layout body.-emu #token-action-hud-index {
   -webkit-margin-end: var(--emu-space-base);
-          margin-inline-end: var(--emu-space-base); }
+  margin-inline-end: var(--emu-space-base);
+}
 
-.-emu-layout body.-emu .token-attacher-gm-menu.window-app.settings .window-content form button {
+.-emu-layout
+  body.-emu
+  .token-attacher-gm-menu.window-app.settings
+  .window-content
+  form
+  button {
   margin: 0;
   -webkit-margin-after: var(--emu-space-base);
-          margin-block-end: var(--emu-space-base); }
-  .-emu-layout body.-emu .token-attacher-gm-menu.window-app.settings .window-content form button:last-child {
-    -webkit-margin-after: 0;
-            margin-block-end: 0; }
+  margin-block-end: var(--emu-space-base);
+}
+.-emu-layout
+  body.-emu
+  .token-attacher-gm-menu.window-app.settings
+  .window-content
+  form
+  button:last-child {
+  -webkit-margin-after: 0;
+  margin-block-end: 0;
+}
 
 body.-emu #tokenAttacherQuickEdit {
-  background: transparent; }
-  body.-emu #tokenAttacherQuickEdit h3 {
-    color: rgba(var(--color-primary), 1);
-    text-shadow: 1px 1px 4px rgba(var(--color-black), 1); }
-    .-emu-layout body.-emu #tokenAttacherQuickEdit h3 {
-      font-size: var(--emu-font-size-xl);
-      line-height: initial; }
+  background: transparent;
+}
+body.-emu #tokenAttacherQuickEdit h3 {
+  color: rgba(var(--color-primary), 1);
+  text-shadow: 1px 1px 4px rgba(var(--color-black), 1);
+}
+.-emu-layout body.-emu #tokenAttacherQuickEdit h3 {
+  font-size: var(--emu-font-size-xl);
+  line-height: initial;
+}
 
 .-emu-layout body.-emu #tokenAttacher {
   left: 6rem;
-  top: 3.25rem; }
+  top: 3.25rem;
+}
 
 .-emu-layout.-emu-compact body.-emu #tokenAttacher {
   left: 4.5rem;
-  top: 2.375rem; }
+  top: 2.375rem;
+}
 
 body.-emu #tokenAttacher .image {
   background-color: rgba(var(--color-background-darkest), 0.8);
   background-image: var(--emu-image-background-darkest, none);
-  border-radius: var(--emu-border-radius-images, 0) var(--emu-border-radius-images, 0) 0 0;
-  border: rgba(var(--color-primary), 1) 1px solid; }
-  .-emu-layout body.-emu #tokenAttacher .image {
-    width: 6.5rem;
-    height: 6.5rem;
-    flex: 0 0 auto;
-    margin: 0;
-    min-width: 0; }
-  body.-emu #tokenAttacher .image .token-name {
-    background-color: rgba(var(--color-background-darkest), 1);
-    background-image: var(--emu-image-background-darkest, none);
-    border: rgba(var(--color-primary), 1) 1px solid;
-    border-radius: 0 0 var(--emu-border-radius-images, 0) var(--emu-border-radius-images, 0);
-    color: rgba(var(--color-text-lightest), 1); }
-    .-emu-layout body.-emu #tokenAttacher .image .token-name {
-      align-items: center;
-      bottom: auto;
-      box-sizing: border-box;
-      display: flex;
-      font-size: var(--emu-font-size-lg);
-      justify-content: center;
-      overflow: hidden;
-      padding: var(--emu-space-base);
-      margin: 0;
-      max-width: 100%;
-      top: 100%; }
-      .-emu-layout body.-emu #tokenAttacher .image .token-name span {
-        height: auto;
-        margin: 0;
-        width: auto; }
+  border-radius: var(--emu-border-radius-images, 0)
+    var(--emu-border-radius-images, 0) 0 0;
+  border: rgba(var(--color-primary), 1) 1px solid;
+}
+.-emu-layout body.-emu #tokenAttacher .image {
+  width: 6.5rem;
+  height: 6.5rem;
+  flex: 0 0 auto;
+  margin: 0;
+  min-width: 0;
+}
+body.-emu #tokenAttacher .image .token-name {
+  background-color: rgba(var(--color-background-darkest), 1);
+  background-image: var(--emu-image-background-darkest, none);
+  border: rgba(var(--color-primary), 1) 1px solid;
+  border-radius: 0 0 var(--emu-border-radius-images, 0)
+    var(--emu-border-radius-images, 0);
+  color: rgba(var(--color-text-lightest), 1);
+}
+.-emu-layout body.-emu #tokenAttacher .image .token-name {
+  align-items: center;
+  bottom: auto;
+  box-sizing: border-box;
+  display: flex;
+  font-size: var(--emu-font-size-lg);
+  justify-content: center;
+  overflow: hidden;
+  padding: var(--emu-space-base);
+  margin: 0;
+  max-width: 100%;
+  top: 100%;
+}
+.-emu-layout body.-emu #tokenAttacher .image .token-name span {
+  height: auto;
+  margin: 0;
+  width: auto;
+}
 
 .-emu-layout body.-emu #tokenAttacher .control-tools {
   box-sizing: border-box;
   flex: 0 0 auto;
   flex-direction: column;
   -webkit-margin-start: var(--emu-space-base);
-          margin-inline-start: var(--emu-space-base);
+  margin-inline-start: var(--emu-space-base);
   pointer-events: none;
   opacity: 1;
-  transition: opacity 0.3s cubic-bezier(0.075, 0.82, 0.165, 1), left 0.3s cubic-bezier(0.075, 0.82, 0.165, 1); }
+  transition: opacity 0.3s cubic-bezier(0.075, 0.82, 0.165, 1),
+    left 0.3s cubic-bezier(0.075, 0.82, 0.165, 1);
+}
 
 body.-emu #tokenAttacher .control-tool {
   background-color: rgba(var(--color-background), 0.8);
@@ -7877,85 +19493,165 @@ body.-emu #tokenAttacher .control-tool {
   box-shadow: none;
   color: rgba(var(--color-text-lightest), 1);
   font-size: var(--emu-font-size-lg);
-  transition: background 0.3s cubic-bezier(0.075, 0.82, 0.165, 1), box-shadow 0.3s cubic-bezier(0.075, 0.82, 0.165, 1), color 0.3s cubic-bezier(0.075, 0.82, 0.165, 1), opacity 0.3s cubic-bezier(0.075, 0.82, 0.165, 1); }
-  .-emu-layout body.-emu #tokenAttacher .control-tool {
-    width: var(--emu-space-button-lg);
-    height: var(--emu-space-button-lg);
-    align-items: center;
-    box-sizing: border-box;
-    cursor: pointer;
-    display: flex;
-    flex: 0 0 auto;
-    justify-content: center;
-    line-height: initial;
-    -webkit-margin-after: var(--emu-space-base);
-            margin-block-end: var(--emu-space-base);
-    pointer-events: all;
-    position: relative; }
-    .-emu-layout body.-emu #tokenAttacher .control-tool:last-of-type {
-      -webkit-margin-after: 0;
-              margin-block-end: 0; }
-    .-emu-layout body.-emu #tokenAttacher .control-tool > i {
-      font-size: inherit;
-      height: auto;
-      line-height: 1;
-      margin: 0;
-      position: relative;
-      width: auto; }
-  body.-emu #tokenAttacher .control-tool:hover {
-    background-image: none; }
-  body.-emu #tokenAttacher .control-tool:focus {
-    background-image: none; }
-  body.-emu #tokenAttacher .control-tool.close {
-    top: var(--emu-space-pf);
-    left: var(--emu-space-pf);
-    position: absolute;
-    margin: 0; }
+  transition: background 0.3s cubic-bezier(0.075, 0.82, 0.165, 1),
+    box-shadow 0.3s cubic-bezier(0.075, 0.82, 0.165, 1),
+    color 0.3s cubic-bezier(0.075, 0.82, 0.165, 1),
+    opacity 0.3s cubic-bezier(0.075, 0.82, 0.165, 1);
+}
+.-emu-layout body.-emu #tokenAttacher .control-tool {
+  width: var(--emu-space-button-lg);
+  height: var(--emu-space-button-lg);
+  align-items: center;
+  box-sizing: border-box;
+  cursor: pointer;
+  display: flex;
+  flex: 0 0 auto;
+  justify-content: center;
+  line-height: initial;
+  -webkit-margin-after: var(--emu-space-base);
+  margin-block-end: var(--emu-space-base);
+  pointer-events: all;
+  position: relative;
+}
+.-emu-layout body.-emu #tokenAttacher .control-tool:last-of-type {
+  -webkit-margin-after: 0;
+  margin-block-end: 0;
+}
+.-emu-layout body.-emu #tokenAttacher .control-tool > i {
+  font-size: inherit;
+  height: auto;
+  line-height: 1;
+  margin: 0;
+  position: relative;
+  width: auto;
+}
+body.-emu #tokenAttacher .control-tool:hover {
+  background-image: none;
+}
+body.-emu #tokenAttacher .control-tool:focus {
+  background-image: none;
+}
+body.-emu #tokenAttacher .control-tool.close {
+  top: var(--emu-space-pf);
+  left: var(--emu-space-pf);
+  position: absolute;
+  margin: 0;
+}
 
 body.-emu .token-sheet.sheet[id*="token-config-"] .window-content form .auras {
-  border: rgba(var(--color-border), 1) 1px solid; }
-  .-emu-layout body.-emu .token-sheet.sheet[id*="token-config-"] .window-content form .auras {
-    -webkit-margin-before: var(--emu-space-sm);
-            margin-block-start: var(--emu-space-sm);
-    padding: 0 var(--emu-space-base); }
-    .-emu-layout body.-emu .token-sheet.sheet[id*="token-config-"] .window-content form .auras .aura-row {
-      flex: 0 0 100%; }
-      .-emu-layout body.-emu .token-sheet.sheet[id*="token-config-"] .window-content form .auras .aura-row input {
-        flex: 1 1 auto; }
-        .-emu-layout body.-emu .token-sheet.sheet[id*="token-config-"] .window-content form .auras .aura-row input + span {
-          flex: 0 0 auto;
-          -webkit-margin-start: var(--emu-space-base);
-                  margin-inline-start: var(--emu-space-base); }
-      .-emu-layout body.-emu .token-sheet.sheet[id*="token-config-"] .window-content form .auras .aura-row span {
-        font-size: var(--emu-font-size-md); }
-        .-emu-layout body.-emu .token-sheet.sheet[id*="token-config-"] .window-content form .auras .aura-row span + input {
-          -webkit-margin-start: var(--emu-space-sm);
-                  margin-inline-start: var(--emu-space-sm); }
-      .-emu-layout body.-emu .token-sheet.sheet[id*="token-config-"] .window-content form .auras .aura-row label {
-        flex: 0 0 auto;
-        -webkit-margin-start: var(--emu-space-sm);
-                margin-inline-start: var(--emu-space-sm); }
-        .-emu-layout body.-emu .token-sheet.sheet[id*="token-config-"] .window-content form .auras .aura-row label input {
-          -webkit-margin-end: var(--emu-space-base);
-                  margin-inline-end: var(--emu-space-base); }
+  border: rgba(var(--color-border), 1) 1px solid;
+}
+.-emu-layout
+  body.-emu
+  .token-sheet.sheet[id*="token-config-"]
+  .window-content
+  form
+  .auras {
+  -webkit-margin-before: var(--emu-space-sm);
+  margin-block-start: var(--emu-space-sm);
+  padding: 0 var(--emu-space-base);
+}
+.-emu-layout
+  body.-emu
+  .token-sheet.sheet[id*="token-config-"]
+  .window-content
+  form
+  .auras
+  .aura-row {
+  flex: 0 0 100%;
+}
+.-emu-layout
+  body.-emu
+  .token-sheet.sheet[id*="token-config-"]
+  .window-content
+  form
+  .auras
+  .aura-row
+  input {
+  flex: 1 1 auto;
+}
+.-emu-layout
+  body.-emu
+  .token-sheet.sheet[id*="token-config-"]
+  .window-content
+  form
+  .auras
+  .aura-row
+  input
+  + span {
+  flex: 0 0 auto;
+  -webkit-margin-start: var(--emu-space-base);
+  margin-inline-start: var(--emu-space-base);
+}
+.-emu-layout
+  body.-emu
+  .token-sheet.sheet[id*="token-config-"]
+  .window-content
+  form
+  .auras
+  .aura-row
+  span {
+  font-size: var(--emu-font-size-md);
+}
+.-emu-layout
+  body.-emu
+  .token-sheet.sheet[id*="token-config-"]
+  .window-content
+  form
+  .auras
+  .aura-row
+  span
+  + input {
+  -webkit-margin-start: var(--emu-space-sm);
+  margin-inline-start: var(--emu-space-sm);
+}
+.-emu-layout
+  body.-emu
+  .token-sheet.sheet[id*="token-config-"]
+  .window-content
+  form
+  .auras
+  .aura-row
+  label {
+  flex: 0 0 auto;
+  -webkit-margin-start: var(--emu-space-sm);
+  margin-inline-start: var(--emu-space-sm);
+}
+.-emu-layout
+  body.-emu
+  .token-sheet.sheet[id*="token-config-"]
+  .window-content
+  form
+  .auras
+  .aura-row
+  label
+  input {
+  -webkit-margin-end: var(--emu-space-base);
+  margin-inline-end: var(--emu-space-base);
+}
 
 .-emu-layout body.-emu #hud #token-hud .thwildcard-button-select {
   display: inline-flex;
-  height: auto; }
+  height: auto;
+}
 
 .-emu-layout body.-emu #hud .token-info-container {
-  margin: 0; }
+  margin: 0;
+}
 
 body.-emu #hud .token-info-container .token-info-column-left {
-  left: -7.5rem; }
+  left: -7.5rem;
+}
 
 body.-emu #hud .token-info-container .token-info-column-right {
-  right: -7.5rem; }
+  right: -7.5rem;
+}
 
-.-emu-layout body.-emu #hud .token-info-container .token-info-column-left, .-emu-layout
-body.-emu #hud .token-info-container .token-info-column-right {
+.-emu-layout body.-emu #hud .token-info-container .token-info-column-left,
+.-emu-layout body.-emu #hud .token-info-container .token-info-column-right {
   padding: 0;
-  width: auto; }
+  width: auto;
+}
 
 .-emu-layout body.-emu #hud .token-info-container .token-info-icon {
   flex-wrap: wrap;
@@ -7963,202 +19659,377 @@ body.-emu #hud .token-info-container .token-info-column-right {
   margin: 0 0 var(--emu-space-base) 0 !important;
   min-height: var(--emu-space-button-lg);
   min-width: 0;
-  padding: 0 var(--emu-space-sm); }
-  .-emu-layout body.-emu #hud .token-info-container .token-info-icon .token-info-speed {
-    font-size: 0.75rem;
-    margin: var(--emu-space-xs) 0;
-    width: 100%; }
-    .-emu-layout body.-emu #hud .token-info-container .token-info-icon .token-info-speed:first-child {
-      -webkit-margin-before: var(--emu-space-base);
-              margin-block-start: var(--emu-space-base); }
-    .-emu-layout body.-emu #hud .token-info-container .token-info-icon .token-info-speed:last-child {
-      -webkit-margin-after: var(--emu-space-base);
-              margin-block-end: var(--emu-space-base); }
-    .-emu-layout body.-emu #hud .token-info-container .token-info-icon .token-info-speed > i {
-      font-size: 0.625rem; }
-    .-emu-layout body.-emu #hud .token-info-container .token-info-icon .token-info-speed > span {
-      font-size: inherit !important; }
-  .-emu-layout body.-emu #hud .token-info-container .token-info-icon i,
-  .-emu-layout body.-emu #hud .token-info-container .token-info-icon > i {
-    -webkit-margin-end: var(--emu-space-base);
-            margin-inline-end: var(--emu-space-base); }
+  padding: 0 var(--emu-space-sm);
+}
+.-emu-layout
+  body.-emu
+  #hud
+  .token-info-container
+  .token-info-icon
+  .token-info-speed {
+  font-size: 0.75rem;
+  margin: var(--emu-space-xs) 0;
+  width: 100%;
+}
+.-emu-layout
+  body.-emu
+  #hud
+  .token-info-container
+  .token-info-icon
+  .token-info-speed:first-child {
+  -webkit-margin-before: var(--emu-space-base);
+  margin-block-start: var(--emu-space-base);
+}
+.-emu-layout
+  body.-emu
+  #hud
+  .token-info-container
+  .token-info-icon
+  .token-info-speed:last-child {
+  -webkit-margin-after: var(--emu-space-base);
+  margin-block-end: var(--emu-space-base);
+}
+.-emu-layout
+  body.-emu
+  #hud
+  .token-info-container
+  .token-info-icon
+  .token-info-speed
+  > i {
+  font-size: 0.625rem;
+}
+.-emu-layout
+  body.-emu
+  #hud
+  .token-info-container
+  .token-info-icon
+  .token-info-speed
+  > span {
+  font-size: inherit !important;
+}
+.-emu-layout body.-emu #hud .token-info-container .token-info-icon i,
+.-emu-layout body.-emu #hud .token-info-container .token-info-icon > i {
+  -webkit-margin-end: var(--emu-space-base);
+  margin-inline-end: var(--emu-space-base);
+}
 
 body.-emu .tokenmagic.window-app.settings section.content {
-  border: none; }
-  .-emu-layout body.-emu .tokenmagic.window-app.settings section.content {
-    overflow-y: auto; }
-  body.-emu .tokenmagic.window-app.settings section.content div.override-entry {
-    -webkit-border-before: rgba(var(--color-border), 1) 1px solid;
-            border-block-start: rgba(var(--color-border), 1) 1px solid; }
-    .-emu-layout body.-emu .tokenmagic.window-app.settings section.content div.override-entry {
-      padding: var(--emu-space-sm) 0; }
-      .-emu-layout body.-emu .tokenmagic.window-app.settings section.content div.override-entry .remove-override-wrapper {
-        -webkit-margin-start: var(--emu-space-base);
-                margin-inline-start: var(--emu-space-base); }
-        .-emu-layout body.-emu .tokenmagic.window-app.settings section.content div.override-entry .remove-override-wrapper i {
-          margin: 0; }
-  .-emu-layout body.-emu .tokenmagic.window-app.settings section.content .settings-list {
-    max-height: 100%;
-    overflow: hidden;
-    padding: 0; }
-    .-emu-layout body.-emu .tokenmagic.window-app.settings section.content .settings-list h2 {
-      -webkit-margin-before: var(--emu-space-sm);
-              margin-block-start: var(--emu-space-sm); }
+  border: none;
+}
+.-emu-layout body.-emu .tokenmagic.window-app.settings section.content {
+  overflow-y: auto;
+}
+body.-emu .tokenmagic.window-app.settings section.content div.override-entry {
+  -webkit-border-before: rgba(var(--color-border), 1) 1px solid;
+  border-block-start: rgba(var(--color-border), 1) 1px solid;
+}
+.-emu-layout
+  body.-emu
+  .tokenmagic.window-app.settings
+  section.content
+  div.override-entry {
+  padding: var(--emu-space-sm) 0;
+}
+.-emu-layout
+  body.-emu
+  .tokenmagic.window-app.settings
+  section.content
+  div.override-entry
+  .remove-override-wrapper {
+  -webkit-margin-start: var(--emu-space-base);
+  margin-inline-start: var(--emu-space-base);
+}
+.-emu-layout
+  body.-emu
+  .tokenmagic.window-app.settings
+  section.content
+  div.override-entry
+  .remove-override-wrapper
+  i {
+  margin: 0;
+}
+.-emu-layout
+  body.-emu
+  .tokenmagic.window-app.settings
+  section.content
+  .settings-list {
+  max-height: 100%;
+  overflow: hidden;
+  padding: 0;
+}
+.-emu-layout
+  body.-emu
+  .tokenmagic.window-app.settings
+  section.content
+  .settings-list
+  h2 {
+  -webkit-margin-before: var(--emu-space-sm);
+  margin-block-start: var(--emu-space-sm);
+}
 
 .-emu-layout body.-emu .tokenmagic.window-app.settings .sheet-footer {
   flex: 0 0 auto;
   -webkit-padding-before: var(--emu-space-sm);
-          padding-block-start: var(--emu-space-sm); }
+  padding-block-start: var(--emu-space-sm);
+}
 
 body.-emu #sidebar .token-mold,
 body.-emu .sidebar-popout .token-mold {
   -webkit-border-after: rgba(var(--color-border), 1) 1px solid;
-          border-block-end: rgba(var(--color-border), 1) 1px solid; }
-  .-emu-layout body.-emu #sidebar .token-mold, .-emu-layout
-  body.-emu .sidebar-popout .token-mold {
-    flex-wrap: wrap; }
-  .-emu-layout body.-emu #sidebar .token-mold h3, .-emu-layout
-  body.-emu .sidebar-popout .token-mold h3 {
-    font-size: var(--emu-font-size-lg);
-    font-weight: normal;
-    margin: 0;
-    -webkit-margin-after: var(--emu-space-base);
-            margin-block-end: var(--emu-space-base);
-    width: 100%; }
-  .-emu-layout body.-emu #sidebar .token-mold > label, .-emu-layout
-  body.-emu .sidebar-popout .token-mold > label {
-    flex: 1 1 auto;
-    padding: var(--emu-space-xs); }
-  .-emu-layout body.-emu #sidebar .token-mold > label > span, .-emu-layout
-  body.-emu .sidebar-popout .token-mold > label > span {
-    width: 100%;
-    height: var(--emu-space-button-sm);
-    font-size: var(--emu-font-size-sm);
-    padding: var(--emu-space-base); }
-    .-emu-layout body.-emu #sidebar .token-mold > label > span > span, .-emu-layout
-    body.-emu .sidebar-popout .token-mold > label > span > span {
-      -webkit-margin-end: var(--emu-space-base);
-              margin-inline-end: var(--emu-space-base); }
-  .-emu-layout body.-emu #sidebar .token-mold > label:first-of-type, .-emu-layout
-  body.-emu .sidebar-popout .token-mold > label:first-of-type {
-    -webkit-padding-start: 0;
-            padding-inline-start: 0; }
+  border-block-end: rgba(var(--color-border), 1) 1px solid;
+}
+.-emu-layout body.-emu #sidebar .token-mold,
+.-emu-layout body.-emu .sidebar-popout .token-mold {
+  flex-wrap: wrap;
+}
+.-emu-layout body.-emu #sidebar .token-mold h3,
+.-emu-layout body.-emu .sidebar-popout .token-mold h3 {
+  font-size: var(--emu-font-size-lg);
+  font-weight: normal;
+  margin: 0;
+  -webkit-margin-after: var(--emu-space-base);
+  margin-block-end: var(--emu-space-base);
+  width: 100%;
+}
+.-emu-layout body.-emu #sidebar .token-mold > label,
+.-emu-layout body.-emu .sidebar-popout .token-mold > label {
+  flex: 1 1 auto;
+  padding: var(--emu-space-xs);
+}
+.-emu-layout body.-emu #sidebar .token-mold > label > span,
+.-emu-layout body.-emu .sidebar-popout .token-mold > label > span {
+  width: 100%;
+  height: var(--emu-space-button-sm);
+  font-size: var(--emu-font-size-sm);
+  padding: var(--emu-space-base);
+}
+.-emu-layout body.-emu #sidebar .token-mold > label > span > span,
+.-emu-layout body.-emu .sidebar-popout .token-mold > label > span > span {
+  -webkit-margin-end: var(--emu-space-base);
+  margin-inline-end: var(--emu-space-base);
+}
+.-emu-layout body.-emu #sidebar .token-mold > label:first-of-type,
+.-emu-layout body.-emu .sidebar-popout .token-mold > label:first-of-type {
+  -webkit-padding-start: 0;
+  padding-inline-start: 0;
+}
 
 .-emu-layout body.-emu .window-app.token-mold .window-content {
-  overflow: hidden; }
+  overflow: hidden;
+}
 
 body.-emu .window-app.token-mold .window-content nav {
-  background-color: transparent; }
-  .-emu-layout body.-emu .window-app.token-mold .window-content nav {
-    padding: 0; }
+  background-color: transparent;
+}
+.-emu-layout body.-emu .window-app.token-mold .window-content nav {
+  padding: 0;
+}
 
 .-emu-layout body.-emu .window-app.token-mold .window-content form {
   display: flex;
-  flex-direction: column; }
+  flex-direction: column;
+}
 
-.-emu-layout body.-emu .window-app.token-mold .window-content form section + section {
+.-emu-layout
+  body.-emu
+  .window-app.token-mold
+  .window-content
+  form
+  section
+  + section {
   -webkit-margin-before: var(--emu-space-base);
-          margin-block-start: var(--emu-space-base); }
+  margin-block-start: var(--emu-space-base);
+}
 
-.-emu-layout body.-emu .window-app.token-mold .window-content form .add-attribute {
+.-emu-layout
+  body.-emu
+  .window-app.token-mold
+  .window-content
+  form
+  .add-attribute {
   display: flex;
   -webkit-margin-before: var(--emu-space-sm);
-          margin-block-start: var(--emu-space-sm); }
+  margin-block-start: var(--emu-space-sm);
+}
 
 body.-emu .window-app.token-mold .window-content form .flexcol {
-  border: none; }
-  .-emu-layout body.-emu .window-app.token-mold .window-content form .flexcol {
-    padding: 0;
-    width: 1px; }
-    .-emu-layout body.-emu .window-app.token-mold .window-content form .flexcol > select {
-      -webkit-margin-before: var(--emu-space-base);
-              margin-block-start: var(--emu-space-base);
-      width: auto; }
+  border: none;
+}
+.-emu-layout body.-emu .window-app.token-mold .window-content form .flexcol {
+  padding: 0;
+  width: 1px;
+}
+.-emu-layout
+  body.-emu
+  .window-app.token-mold
+  .window-content
+  form
+  .flexcol
+  > select {
+  -webkit-margin-before: var(--emu-space-base);
+  margin-block-start: var(--emu-space-base);
+  width: auto;
+}
 
-.-emu-layout body.-emu .window-app.token-mold .window-content .form-group input[type="checkbox"] + label {
+.-emu-layout
+  body.-emu
+  .window-app.token-mold
+  .window-content
+  .form-group
+  input[type="checkbox"]
+  + label {
   flex: 1 1 40%;
   -webkit-padding-start: var(--emu-space-sm);
-          padding-inline-start: var(--emu-space-sm); }
+  padding-inline-start: var(--emu-space-sm);
+}
 
 body.-emu .window-app.token-mold .window-content .form-group.unlinked {
-  border: none; }
+  border: none;
+}
 
 body.-emu .window-app.token-mold .window-content .info {
-  height: auto; }
+  height: auto;
+}
 
 .-emu-layout body.-emu #turnmarker-settings-form form > p:last-of-type {
   -webkit-margin-after: 1.5rem;
-          margin-block-end: 1.5rem; }
+  margin-block-end: 1.5rem;
+}
 
-.-emu-layout body.-emu #sidebar .import-dd, .-emu-layout
-body.-emu .sidebar-popout .import-dd {
-  display: flex  !important;
+.-emu-layout body.-emu #sidebar .import-dd,
+.-emu-layout body.-emu .sidebar-popout .import-dd {
+  display: flex !important;
   flex: 1 1 100% !important;
   margin: 0 !important;
   -webkit-margin-before: var(--emu-space-base) !important;
-          margin-block-start: var(--emu-space-base) !important; }
-  .-emu-layout body.-emu #sidebar .import-dd:only-child, .-emu-layout
-  body.-emu .sidebar-popout .import-dd:only-child {
-    -webkit-margin-before: 0 !important;
-            margin-block-start: 0 !important; }
+  margin-block-start: var(--emu-space-base) !important;
+}
+.-emu-layout body.-emu #sidebar .import-dd:only-child,
+.-emu-layout body.-emu .sidebar-popout .import-dd:only-child {
+  -webkit-margin-before: 0 !important;
+  margin-block-start: 0 !important;
+}
 
 .-emu-layout body.-emu #dd-importer .window-content {
-  overflow: auto; }
+  overflow: auto;
+}
 
 .-emu-layout body.-emu #dd-importer .form-group {
   align-items: center;
   display: flex;
   margin: 0;
-  padding: var(--emu-space-sm); }
-  .-emu-layout body.-emu #dd-importer .form-group#dd-upload-files {
-    align-items: flex-start;
-    flex-direction: column; }
-    .-emu-layout body.-emu #dd-importer .form-group#dd-upload-files .file-input {
-      -webkit-margin-before: var(--emu-space-sm);
-              margin-block-start: var(--emu-space-sm); }
-  .-emu-layout body.-emu #dd-importer .form-group > label {
-    flex: 0 0 auto;
-    -webkit-padding-end: var(--emu-space-base);
-            padding-inline-end: var(--emu-space-base); }
+  padding: var(--emu-space-sm);
+}
+.-emu-layout body.-emu #dd-importer .form-group#dd-upload-files {
+  align-items: flex-start;
+  flex-direction: column;
+}
+.-emu-layout body.-emu #dd-importer .form-group#dd-upload-files .file-input {
+  -webkit-margin-before: var(--emu-space-sm);
+  margin-block-start: var(--emu-space-sm);
+}
+.-emu-layout body.-emu #dd-importer .form-group > label {
+  flex: 0 0 auto;
+  -webkit-padding-end: var(--emu-space-base);
+  padding-inline-end: var(--emu-space-base);
+}
 
-.-emu-layout body.-emu #sidebar .sidebar-tab .directory-header .header-actions #world-anvil, .-emu-layout
-body.-emu .sidebar-popout .sidebar-tab .directory-header .header-actions #world-anvil {
-  flex: 0 0 auto; }
+.-emu-layout
+  body.-emu
+  #sidebar
+  .sidebar-tab
+  .directory-header
+  .header-actions
+  #world-anvil,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  .sidebar-tab
+  .directory-header
+  .header-actions
+  #world-anvil {
+  flex: 0 0 auto;
+}
 
-.-emu-layout body.-emu #sidebar .sidebar-tab .directory-header .header-actions #world-anvil img, .-emu-layout
-body.-emu .sidebar-popout .sidebar-tab .directory-header .header-actions #world-anvil img {
+.-emu-layout
+  body.-emu
+  #sidebar
+  .sidebar-tab
+  .directory-header
+  .header-actions
+  #world-anvil
+  img,
+.-emu-layout
+  body.-emu
+  .sidebar-popout
+  .sidebar-tab
+  .directory-header
+  .header-actions
+  #world-anvil
+  img {
   max-height: var(--emu-font-size-lg);
-  top: auto; }
+  top: auto;
+}
 
-.-emu-layout body.-emu #world-anvil-config.window-app.world-anvil .world-articles {
+.-emu-layout
+  body.-emu
+  #world-anvil-config.window-app.world-anvil
+  .world-articles {
   -webkit-margin-before: 1.5rem;
-          margin-block-start: 1.5rem; }
-  .-emu-layout body.-emu #world-anvil-config.window-app.world-anvil .world-articles:first-child {
-    -webkit-margin-before: 0;
-            margin-block-start: 0; }
+  margin-block-start: 1.5rem;
+}
+.-emu-layout
+  body.-emu
+  #world-anvil-config.window-app.world-anvil
+  .world-articles:first-child {
+  -webkit-margin-before: 0;
+  margin-block-start: 0;
+}
 
 .-emu-layout body.-emu #world-anvil-config.window-app.world-anvil article {
   -webkit-margin-after: var(--emu-space-base);
-          margin-block-end: var(--emu-space-base); }
+  margin-block-end: var(--emu-space-base);
+}
 
 .-emu-layout body.-emu #world-anvil-config.window-app.world-anvil hr {
-  display: none; }
+  display: none;
+}
 
 body.-emu #world-anvil-config.window-app.world-anvil h2 {
-  border: none; }
+  border: none;
+}
 
 .-emu-layout body.-emu #world-anvil-config.window-app.world-anvil h3 {
-  margin: 0; }
+  margin: 0;
+}
 
 body.-emu #world-anvil-config.window-app.world-anvil header.section {
   -webkit-border-after: rgba(var(--color-border), 1) 1px solid;
-          border-block-end: rgba(var(--color-border), 1) 1px solid; }
-  .-emu-layout body.-emu #world-anvil-config.window-app.world-anvil header.section {
-    -webkit-margin-after: var(--emu-space-base);
-            margin-block-end: var(--emu-space-base);
-    padding: var(--emu-space-base) 0; }
+  border-block-end: rgba(var(--color-border), 1) 1px solid;
+}
+.-emu-layout
+  body.-emu
+  #world-anvil-config.window-app.world-anvil
+  header.section {
+  -webkit-margin-after: var(--emu-space-base);
+  margin-block-end: var(--emu-space-base);
+  padding: var(--emu-space-base) 0;
+}
 
-.-emu-layout body.-emu #world-anvil-config.window-app.world-anvil button.world-anvil-control[data-action="sync-folder"] i, .-emu-layout
-body.-emu #world-anvil-config.window-app.world-anvil button.world-anvil-control[data-action="link-entry"] i, .-emu-layout
-body.-emu #world-anvil-config.window-app.world-anvil button.world-anvil-control[data-action="link-folder"] i {
-  margin: 0; }
+.-emu-layout
+  body.-emu
+  #world-anvil-config.window-app.world-anvil
+  button.world-anvil-control[data-action="sync-folder"]
+  i,
+.-emu-layout
+  body.-emu
+  #world-anvil-config.window-app.world-anvil
+  button.world-anvil-control[data-action="link-entry"]
+  i,
+.-emu-layout
+  body.-emu
+  #world-anvil-config.window-app.world-anvil
+  button.world-anvil-control[data-action="link-folder"]
+  i {
+  margin: 0;
+}


### PR DESCRIPTION
Foundry v9 broke the left side ui bar, and the bottom hotbar. Now works as intended (on a clean install). Also fixed for subtle and compact mode.

I felt like in some instances I had to brute force with !important, which is not ideal. 

This works perfectly on my clean install, but this is my first fork->pull, so feel free to check it. 

I've also 'prettified' the css in a different branch that I can fork->pull, It is about 3k lines longer, but I found this format a little difficult to read. Thought I'd ask!